### PR TITLE
qemu proxy: no-export server main + key-string parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test --experimental-strip-types src/qmp/json-stream.test.ts",
+    "test": "node --test --experimental-strip-types src/qmp/json-stream.test.ts src/qemu/keys.test.ts",
     "lint": "oxlint --type-aware --type-check"
   },
   "devDependencies": {

--- a/src/qemu/keys.test.ts
+++ b/src/qemu/keys.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseKeys } from "./keys.ts";
+
+describe("parseKeys happy path", () => {
+  it("maps lowercase letters and digits to plain chords", () => {
+    assert.deepEqual(parseKeys("hi"), [["h"], ["i"]]);
+    assert.deepEqual(parseKeys("42"), [["4"], ["2"]]);
+  });
+
+  it("adds shift for uppercase letters", () => {
+    assert.deepEqual(parseKeys("A"), [["shift", "a"]]);
+    assert.deepEqual(parseKeys("Hi"), [["shift", "h"], ["i"]]);
+  });
+
+  it("maps unshifted punctuation and whitespace", () => {
+    assert.deepEqual(parseKeys(" "), [["spc"]]);
+    assert.deepEqual(parseKeys("\n"), [["ret"]]);
+    assert.deepEqual(parseKeys("\t"), [["tab"]]);
+    assert.deepEqual(parseKeys("-"), [["minus"]]);
+    assert.deepEqual(parseKeys("."), [["dot"]]);
+    assert.deepEqual(parseKeys("/"), [["slash"]]);
+  });
+
+  it("adds shift for shifted punctuation with the unshifted qcode", () => {
+    assert.deepEqual(parseKeys("!"), [["shift", "1"]]);
+    assert.deepEqual(parseKeys("?"), [["shift", "slash"]]);
+    assert.deepEqual(parseKeys(":"), [["shift", "semicolon"]]);
+    assert.deepEqual(parseKeys("{"), [["shift", "bracket_left"]]);
+  });
+
+  it("resolves named keys and their aliases, case-insensitively", () => {
+    assert.deepEqual(parseKeys("<ENTER>"), [["ret"]]);
+    assert.deepEqual(parseKeys("<enter>"), [["ret"]]);
+    assert.deepEqual(parseKeys("<RETURN>"), [["ret"]]);
+    assert.deepEqual(parseKeys("<esc>"), [["esc"]]);
+    assert.deepEqual(parseKeys("<BS>"), [["backspace"]]);
+    assert.deepEqual(parseKeys("<SPACE>"), [["spc"]]);
+    assert.deepEqual(parseKeys("<PGDN>"), [["pgdn"]]);
+  });
+
+  it("prepends modifiers, short or long names, stacked in order", () => {
+    assert.deepEqual(parseKeys("<C-c>"), [["ctrl", "c"]]);
+    assert.deepEqual(parseKeys("<CTRL-c>"), [["ctrl", "c"]]);
+    assert.deepEqual(parseKeys("<A-x>"), [["alt", "x"]]);
+    assert.deepEqual(parseKeys("<M-x>"), [["meta_l", "x"]]);
+    assert.deepEqual(parseKeys("<S-a>"), [["shift", "a"]]);
+    assert.deepEqual(parseKeys("<C-S-c>"), [["ctrl", "shift", "c"]]);
+    assert.deepEqual(parseKeys("<C-ENTER>"), [["ctrl", "ret"]]);
+  });
+
+  it("maps <LT> to less and <GT> to shift+dot", () => {
+    assert.deepEqual(parseKeys("<LT>"), [["less"]]);
+    assert.deepEqual(parseKeys("<GT>"), [["shift", "dot"]]);
+  });
+
+  it("accepts f-keys and raw qcode tokens", () => {
+    assert.deepEqual(parseKeys("<F1>"), [["f1"]]);
+    assert.deepEqual(parseKeys("<F13>"), [["f13"]]);
+    assert.deepEqual(parseKeys("<kp_enter>"), [["kp_enter"]]);
+    assert.deepEqual(parseKeys("<caps_lock>"), [["caps_lock"]]);
+  });
+
+  it("keeps literal and angle chords in input order", () => {
+    assert.deepEqual(parseKeys("Hi<ENTER>"), [["shift", "h"], ["i"], ["ret"]]);
+    assert.deepEqual(parseKeys("a<C-c>b"), [["a"], ["ctrl", "c"], ["b"]]);
+  });
+
+  it("returns no chords for an empty string", () => {
+    assert.deepEqual(parseKeys(""), []);
+  });
+
+  it("accepts the oligarchy encoding by default and case-insensitively", () => {
+    assert.deepEqual(parseKeys("a"), [["a"]]);
+    assert.deepEqual(parseKeys("a", "oligarchy"), [["a"]]);
+    assert.deepEqual(parseKeys("a", "OLIGARCHY"), [["a"]]);
+  });
+});
+
+describe("parseKeys unhappy path", () => {
+  it("throws on an unknown encoding", () => {
+    assert.throws(() => parseKeys("a", "vim"), {
+      message: 'qemu: unknown key encoding "vim"',
+    });
+  });
+
+  it("throws on an unterminated key sequence", () => {
+    assert.throws(() => parseKeys("<ENTER"), {
+      message: "qemu: unterminated key sequence",
+    });
+  });
+
+  it("throws on an empty key sequence", () => {
+    assert.throws(() => parseKeys("<>"), {
+      message: "qemu: empty key sequence",
+    });
+  });
+
+  it("throws on an unknown modifier", () => {
+    assert.throws(() => parseKeys("<X-c>"), {
+      message: 'qemu: unknown modifier "X"',
+    });
+  });
+
+  it("throws on unknown keys and unsupported characters", () => {
+    assert.throws(() => parseKeys("<BOGUS>"), {
+      message: 'qemu: unknown key "BOGUS"',
+    });
+    assert.throws(() => parseKeys("€"), {
+      message: 'qemu: unsupported character "€"',
+    });
+  });
+});

--- a/src/qemu/keys.test.ts
+++ b/src/qemu/keys.test.ts
@@ -72,6 +72,7 @@ describe("parseKeys happy path", () => {
 
   it("accepts the oligarchy encoding by default and case-insensitively", () => {
     assert.deepEqual(parseKeys("a"), [["a"]]);
+    assert.deepEqual(parseKeys("a", ""), [["a"]]);
     assert.deepEqual(parseKeys("a", "oligarchy"), [["a"]]);
     assert.deepEqual(parseKeys("a", "OLIGARCHY"), [["a"]]);
   });
@@ -108,6 +109,9 @@ describe("parseKeys unhappy path", () => {
     });
     assert.throws(() => parseKeys("€"), {
       message: 'qemu: unsupported character "€"',
+    });
+    assert.throws(() => parseKeys("😀"), {
+      message: 'qemu: unsupported character "😀"',
     });
   });
 });

--- a/src/qemu/keys.ts
+++ b/src/qemu/keys.ts
@@ -99,20 +99,21 @@ const MODIFIERS: Record<string, string> = {
 
 /** Turns an encoded key string into send-key chords of QEMU qcodes. */
 export function parseKeys(s: string, encoding = "oligarchy"): string[][] {
-  if (encoding.toLowerCase() !== "oligarchy") {
+  if (encoding !== "" && encoding.toLowerCase() !== "oligarchy") {
     throw new Error(`qemu: unknown key encoding "${encoding}"`);
   }
   const out: string[][] = [];
-  for (let i = 0; i < s.length; i++) {
-    if (s[i] === "<") {
-      const end = s.indexOf(">", i + 1);
+  const chars = Array.from(s);
+  for (let i = 0; i < chars.length; i++) {
+    if (chars[i] === "<") {
+      const end = chars.indexOf(">", i + 1);
       if (end < 0) {
         throw new Error("qemu: unterminated key sequence");
       }
-      out.push(angleChord(s.slice(i + 1, end)));
+      out.push(angleChord(chars.slice(i + 1, end).join("")));
       i = end;
     } else {
-      out.push(charChord(s[i]));
+      out.push(charChord(chars[i]));
     }
   }
   return out;
@@ -145,7 +146,7 @@ function keyName(name: string): string[] {
   if (named !== undefined) {
     return [named];
   }
-  if (name.length === 1) {
+  if (Array.from(name).length === 1) {
     return charChord(name);
   }
   // Accept any documented qcode token (f1..f24, kp_*, caps_lock, ...)

--- a/src/qemu/keys.ts
+++ b/src/qemu/keys.ts
@@ -1,0 +1,179 @@
+// Key-string parsing for the oligarchy encoding: literal characters plus
+// angle-bracket names and modifiers, e.g. "Hi<ENTER>" or "<C-S-c>".
+
+const NAMED: Record<string, string> = {
+  ENTER: "ret",
+  RETURN: "ret",
+  CR: "ret",
+  RET: "ret",
+  ESC: "esc",
+  ESCAPE: "esc",
+  TAB: "tab",
+  BS: "backspace",
+  BACKSPACE: "backspace",
+  DEL: "delete",
+  DELETE: "delete",
+  INS: "insert",
+  INSERT: "insert",
+  SPACE: "spc",
+  SPC: "spc",
+  UP: "up",
+  DOWN: "down",
+  LEFT: "left",
+  RIGHT: "right",
+  HOME: "home",
+  END: "end",
+  PGUP: "pgup",
+  PAGEUP: "pgup",
+  PGDN: "pgdn",
+  PAGEDOWN: "pgdn",
+  LT: "less",
+  GT: "dot",
+  MENU: "menu",
+  CAPSLOCK: "caps_lock",
+  NUMLOCK: "num_lock",
+  SCROLLLOCK: "scroll_lock",
+  PRINT: "print",
+  PAUSE: "pause",
+  SYSREQ: "sysrq",
+  CTRL: "ctrl",
+  ALT: "alt",
+  SHIFT: "shift",
+  META_L: "meta_l",
+};
+
+// Punctuation that needs shift on a US keyboard, mapped to the unshifted qcode.
+const SHIFTED: Record<string, string> = {
+  "!": "1",
+  "@": "2",
+  "#": "3",
+  $: "4",
+  "%": "5",
+  "^": "6",
+  "&": "7",
+  "*": "8",
+  "(": "9",
+  ")": "0",
+  _: "minus",
+  "+": "equal",
+  "{": "bracket_left",
+  "}": "bracket_right",
+  ":": "semicolon",
+  '"': "apostrophe",
+  "~": "grave_accent",
+  "|": "backslash",
+  "<": "comma",
+  ">": "dot",
+  "?": "slash",
+};
+
+const UNSHIFTED: Record<string, string> = {
+  " ": "spc",
+  "\n": "ret",
+  "\r": "ret",
+  "\t": "tab",
+  "-": "minus",
+  "=": "equal",
+  "[": "bracket_left",
+  "]": "bracket_right",
+  ";": "semicolon",
+  "'": "apostrophe",
+  "`": "grave_accent",
+  "\\": "backslash",
+  ",": "comma",
+  ".": "dot",
+  "/": "slash",
+};
+
+const MODIFIERS: Record<string, string> = {
+  C: "ctrl",
+  CTRL: "ctrl",
+  CONTROL: "ctrl",
+  A: "alt",
+  ALT: "alt",
+  S: "shift",
+  SHIFT: "shift",
+  M: "meta_l",
+  META: "meta_l",
+};
+
+/** Turns an encoded key string into send-key chords of QEMU qcodes. */
+export function parseKeys(s: string, encoding = "oligarchy"): string[][] {
+  if (encoding.toLowerCase() !== "oligarchy") {
+    throw new Error(`qemu: unknown key encoding "${encoding}"`);
+  }
+  const out: string[][] = [];
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "<") {
+      const end = s.indexOf(">", i + 1);
+      if (end < 0) {
+        throw new Error("qemu: unterminated key sequence");
+      }
+      out.push(angleChord(s.slice(i + 1, end)));
+      i = end;
+    } else {
+      out.push(charChord(s[i]));
+    }
+  }
+  return out;
+}
+
+/** Parses the inside of <...>: optional dash-separated modifiers, then a key. */
+function angleChord(inner: string): string[] {
+  if (inner === "") {
+    throw new Error("qemu: empty key sequence");
+  }
+  const parts = inner.split("-");
+  const chord: string[] = [];
+  for (const part of parts.slice(0, -1)) {
+    const mod = MODIFIERS[part.toUpperCase()];
+    if (mod === undefined) {
+      throw new Error(`qemu: unknown modifier "${part}"`);
+    }
+    chord.push(mod);
+  }
+  const name = parts[parts.length - 1];
+  // <GT> is shift+dot on a US keyboard.
+  if (name.toUpperCase() === "GT") {
+    return [...chord, "shift", "dot"];
+  }
+  return [...chord, ...keyName(name)];
+}
+
+function keyName(name: string): string[] {
+  const named = NAMED[name.toUpperCase()];
+  if (named !== undefined) {
+    return [named];
+  }
+  if (name.length === 1) {
+    return charChord(name);
+  }
+  // Accept any documented qcode token (f1..f24, kp_*, caps_lock, ...)
+  // rather than maintain the full list here.
+  const lower = name.toLowerCase();
+  if (lower === "unmapped" || lower.includes("_") || lower.startsWith("f")) {
+    return [lower];
+  }
+  throw new Error(`qemu: unknown key "${name}"`);
+}
+
+function charChord(char: string): string[] {
+  if (char >= "a" && char <= "z") {
+    return [char];
+  }
+  if (char >= "A" && char <= "Z") {
+    return ["shift", char.toLowerCase()];
+  }
+  if (char >= "0" && char <= "9") {
+    return [char];
+  }
+  const plain = UNSHIFTED[char];
+  if (plain !== undefined) {
+    return [plain];
+  }
+  const shifted = SHIFTED[char];
+  if (shifted !== undefined) {
+    return ["shift", shifted];
+  }
+  throw new Error(`qemu: unsupported character "${char}"`);
+}

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -9,9 +9,8 @@
 //   GET  /image      -> PNG of the current guest display
 //   POST /send-keys  -> {"keys": "Hi<ENTER>", "encoding": "oligarchy"}
 
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer } from "node:http";
 import { readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createDisk, createQemu, screendump, sendKey, start, stop } from "./client.ts";
 import { parseKeys } from "./keys.ts";
@@ -27,25 +26,11 @@ const qemu = createQemu();
 await createDisk(qemu);
 await start(qemu, { iso });
 
-const server = createServer((req, res) => {
-  void handle(req, res);
-});
 const [host, port] = addr.split(":");
-server.listen(Number(port), host, () => {
-  console.error(`oligarchy proxy listening on ${addr}, session ${qemu.id}`);
-});
-
-for (const signal of ["SIGINT", "SIGTERM"] as const) {
-  process.once(signal, () => {
-    server.close();
-    void stop(qemu).then(() => process.exit(0));
-  });
-}
-
-async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+createServer(async (req, res) => {
   try {
     if (req.method === "GET" && req.url === "/image") {
-      const path = join(tmpdir(), `oligarchy-${process.pid}-${process.hrtime.bigint()}.png`);
+      const path = join(qemu.dir, `image-${process.hrtime.bigint()}.png`);
       try {
         await screendump(qemu, path);
         const data = await readFile(path);
@@ -62,7 +47,7 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
       for await (const chunk of req) {
         body += chunk;
       }
-      const { keys = "", encoding } = JSON.parse(body) as { keys?: string; encoding?: string };
+      const { keys, encoding } = JSON.parse(body) as { keys: string; encoding?: string };
       for (const chord of parseKeys(keys, encoding)) {
         await sendKey(qemu, chord.map((code): QemuKeyValue => ({ type: "qcode", data: code })));
       }
@@ -75,6 +60,14 @@ async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> 
     res.end(JSON.stringify({ error: "not found" }));
   } catch (err) {
     res.writeHead(400, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+    res.end(JSON.stringify({ error: (err as Error).message }));
   }
+}).listen(Number(port), host, () => {
+  console.error(`oligarchy proxy listening on ${addr}, session ${qemu.id}`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    void stop(qemu).then(() => process.exit(0));
+  });
 }

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -9,6 +9,7 @@
 //   POST /start      -> {"iso"?, "disk"?}; boots a qemu, returns {"id": uuid}
 //   GET  /image?id=  -> PNG of that session's guest display
 //   POST /send-keys  -> {"id", "keys": "Hi<ENTER>", "encoding"?}
+//   POST /stop       -> {"id"}; kills the qemu and removes its session dir
 
 import { createServer, type IncomingMessage } from "node:http";
 import { readFile, rm } from "node:fs/promises";
@@ -55,6 +56,16 @@ createServer(async (req, res) => {
       } finally {
         await rm(path, { force: true });
       }
+      return;
+    }
+
+    if (req.method === "POST" && url.pathname === "/stop") {
+      const { id } = JSON.parse(await body(req)) as { id?: string };
+      const qemu = session(id);
+      sessions.delete(qemu.id);
+      await stop(qemu);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: "true" }));
       return;
     }
 

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -1,0 +1,136 @@
+import { readFile, rm } from "node:fs/promises";
+import { connect as netConnect, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { JSONStreamParser } from "../qmp/json-stream.ts";
+import { parseKeys } from "./keys.ts";
+
+type Pending = {
+  resolve: (value: unknown) => void;
+  reject: (err: unknown) => void;
+};
+
+export type QemuProxy = {
+  readonly greeting: QemuGreetingResponse;
+  readonly pending: Map<number | "greeting", Pending>;
+  nextId: number;
+  socket?: Socket;
+};
+
+/** Dials a QMP unix socket and completes the QMP handshake. */
+export async function connect(path: string): Promise<QemuProxy> {
+  const socket = await new Promise<Socket>((resolve, reject) => {
+    const sock = netConnect(path);
+    sock.once("connect", () => resolve(sock));
+    sock.once("error", reject);
+  });
+  return fromSocket(socket);
+}
+
+/**
+ * Takes a connected QMP socket, reads the greeting, and completes
+ * capabilities negotiation.
+ */
+export async function fromSocket(socket: Socket): Promise<QemuProxy> {
+  const pending = new Map<number | "greeting", Pending>();
+  const greeting = new Promise<unknown>((resolve, reject) => {
+    pending.set("greeting", { resolve, reject });
+  });
+
+  const parser = new JSONStreamParser();
+  socket.setEncoding("utf8");
+  socket.on("data", (chunk: string) => {
+    try {
+      parser.push(chunk);
+      for (let msg = parser.pull(); msg !== undefined; msg = parser.pull()) {
+        if ("QMP" in msg) {
+          pending.get("greeting")?.resolve(msg);
+          pending.delete("greeting");
+          continue;
+        }
+        if ("event" in msg) {
+          continue;
+        }
+        const id = msg.id as number;
+        const entry = pending.get(id);
+        if (entry === undefined) {
+          continue;
+        }
+        pending.delete(id);
+        if ("error" in msg) {
+          entry.reject(new Error(`${msg.error.class}: ${msg.error.desc}`));
+        } else {
+          entry.resolve(msg.return);
+        }
+      }
+    } catch (err) {
+      failAll(pending, err);
+      socket.destroy();
+    }
+  });
+  socket.on("error", (err) => failAll(pending, err));
+  socket.on("close", () => failAll(pending, new Error("qemu: socket closed")));
+
+  try {
+    const proxy: QemuProxy = {
+      greeting: (await greeting) as QemuGreetingResponse,
+      pending,
+      nextId: 0,
+      socket,
+    };
+    await execute(proxy, "qmp_capabilities");
+    return proxy;
+  } catch (err) {
+    failAll(pending, err);
+    socket.destroy();
+    throw err;
+  }
+}
+
+/** Closes the QMP connection; in-flight commands reject. */
+export function close(proxy: QemuProxy): void {
+  failAll(proxy.pending, new Error("qemu: closed"));
+  proxy.socket?.destroy();
+  proxy.socket = undefined;
+}
+
+/** Sends a named QMP command and returns its result. */
+export async function execute(proxy: QemuProxy, name: string, args?: unknown): Promise<unknown> {
+  const socket = proxy.socket;
+  if (socket === undefined) {
+    throw new Error("qemu: closed");
+  }
+  const id = ++proxy.nextId;
+  return new Promise((resolve, reject) => {
+    proxy.pending.set(id, { resolve, reject });
+    // JSON.stringify drops "arguments" when args is undefined.
+    socket.write(`${JSON.stringify({ execute: name, arguments: args, id })}\n`);
+  });
+}
+
+/** Captures the current guest display as a PNG. */
+export async function readImage(proxy: QemuProxy): Promise<Buffer> {
+  const path = join(tmpdir(), `oligarchy-${process.pid}-${process.hrtime.bigint()}.png`);
+  await execute(proxy, "screendump", { filename: path, format: "png" });
+  try {
+    return await readFile(path);
+  } finally {
+    await rm(path, { force: true });
+  }
+}
+
+/** Types keys into the guest using the given key-string encoding. */
+export async function sendKeys(proxy: QemuProxy, keys: string, encoding?: string): Promise<void> {
+  for (const chord of parseKeys(keys, encoding)) {
+    await execute(proxy, "send-key", {
+      keys: chord.map((code): QemuKeyValue => ({ type: "qcode", data: code })),
+    });
+  }
+}
+
+function failAll(pending: Map<number | "greeting", Pending>, err: unknown): void {
+  for (const entry of pending.values()) {
+    entry.reject(err);
+  }
+  pending.clear();
+}

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -1,35 +1,51 @@
-// The oligarchy proxy: a main file, not a library. It boots one QEMU
-// session from CLI/env parameters and serves an HTTP control plane for it.
+// The oligarchy proxy: a main file, not a library. It serves an HTTP control
+// plane that boots QEMU sessions and drives them by session uuid.
 //
 //   node --experimental-strip-types src/qemu/proxy.ts <iso>
 //
-// The iso comes from argv or OLIGARCHY_ISO; the listen address from
+// The default iso comes from argv or OLIGARCHY_ISO; the listen address from
 // OLIGARCHY_ADDR (default 127.0.0.1:42069).
 //
-//   GET  /image      -> PNG of the current guest display
-//   POST /send-keys  -> {"keys": "Hi<ENTER>", "encoding": "oligarchy"}
+//   POST /start      -> {"iso"?, "disk"?}; boots a qemu, returns {"id": uuid}
+//   GET  /image?id=  -> PNG of that session's guest display
+//   POST /send-keys  -> {"id", "keys": "Hi<ENTER>", "encoding"?}
 
-import { createServer } from "node:http";
+import { createServer, type IncomingMessage } from "node:http";
 import { readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
-import { createDisk, createQemu, screendump, sendKey, start, stop } from "./client.ts";
+import { createDisk, createQemu, screendump, sendKey, start, stop, type Qemu } from "./client.ts";
 import { parseKeys } from "./keys.ts";
 
-const iso = process.argv[2] ?? process.env.OLIGARCHY_ISO;
-if (iso === undefined) {
+const defaultIso = process.argv[2] ?? process.env.OLIGARCHY_ISO;
+if (defaultIso === undefined) {
   console.error("usage: proxy <iso>  (or set OLIGARCHY_ISO)");
   process.exit(1);
 }
 const addr = process.env.OLIGARCHY_ADDR ?? "127.0.0.1:42069";
 
-const qemu = createQemu();
-await createDisk(qemu);
-await start(qemu, { iso });
+const sessions = new Map<string, Qemu>();
 
 const [host, port] = addr.split(":");
 createServer(async (req, res) => {
   try {
-    if (req.method === "GET" && req.url === "/image") {
+    const url = new URL(req.url ?? "/", `http://${addr}`);
+
+    if (req.method === "POST" && url.pathname === "/start") {
+      const raw = await body(req);
+      const cfg = (raw === "" ? {} : JSON.parse(raw)) as { iso?: string; disk?: string };
+      const qemu = createQemu();
+      if (cfg.disk === undefined) {
+        await createDisk(qemu);
+      }
+      await start(qemu, { iso: cfg.iso ?? defaultIso, disk: cfg.disk });
+      sessions.set(qemu.id, qemu);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ id: qemu.id }));
+      return;
+    }
+
+    if (req.method === "GET" && url.pathname === "/image") {
+      const qemu = session(url.searchParams.get("id"));
       const path = join(qemu.dir, `image-${process.hrtime.bigint()}.png`);
       try {
         await screendump(qemu, path);
@@ -42,12 +58,13 @@ createServer(async (req, res) => {
       return;
     }
 
-    if (req.method === "POST" && req.url === "/send-keys") {
-      let body = "";
-      for await (const chunk of req) {
-        body += chunk;
-      }
-      const { keys, encoding } = JSON.parse(body) as { keys: string; encoding?: string };
+    if (req.method === "POST" && url.pathname === "/send-keys") {
+      const { id, keys, encoding } = JSON.parse(await body(req)) as {
+        id?: string;
+        keys: string;
+        encoding?: string;
+      };
+      const qemu = session(id);
       for (const chord of parseKeys(keys, encoding)) {
         await sendKey(qemu, chord.map((code): QemuKeyValue => ({ type: "qcode", data: code })));
       }
@@ -63,11 +80,30 @@ createServer(async (req, res) => {
     res.end(JSON.stringify({ error: (err as Error).message }));
   }
 }).listen(Number(port), host, () => {
-  console.error(`oligarchy proxy listening on ${addr}, session ${qemu.id}`);
+  console.error(`oligarchy proxy listening on ${addr}`);
 });
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.once(signal, () => {
-    void stop(qemu).then(() => process.exit(0));
+    void Promise.all([...sessions.values()].map(stop)).then(() => process.exit(0));
   });
+}
+
+function session(id: string | null | undefined): Qemu {
+  if (id === undefined || id === null || id === "") {
+    throw new Error("session id is required");
+  }
+  const qemu = sessions.get(id);
+  if (qemu === undefined) {
+    throw new Error(`unknown session "${id}"`);
+  }
+  return qemu;
+}
+
+async function body(req: IncomingMessage): Promise<string> {
+  let out = "";
+  for await (const chunk of req) {
+    out += chunk;
+  }
+  return out;
 }

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -81,7 +81,6 @@ export async function fromSocket(socket: Socket): Promise<QemuProxy> {
     await execute(proxy, "qmp_capabilities");
     return proxy;
   } catch (err) {
-    failAll(pending, err);
     socket.destroy();
     throw err;
   }
@@ -111,8 +110,8 @@ export async function execute(proxy: QemuProxy, name: string, args?: unknown): P
 /** Captures the current guest display as a PNG. */
 export async function readImage(proxy: QemuProxy): Promise<Buffer> {
   const path = join(tmpdir(), `oligarchy-${process.pid}-${process.hrtime.bigint()}.png`);
-  await execute(proxy, "screendump", { filename: path, format: "png" });
   try {
+    await execute(proxy, "screendump", { filename: path, format: "png" });
     return await readFile(path);
   } finally {
     await rm(path, { force: true });

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -1,135 +1,80 @@
+// The oligarchy proxy: a main file, not a library. It boots one QEMU
+// session from CLI/env parameters and serves an HTTP control plane for it.
+//
+//   node --experimental-strip-types src/qemu/proxy.ts <iso>
+//
+// The iso comes from argv or OLIGARCHY_ISO; the listen address from
+// OLIGARCHY_ADDR (default 127.0.0.1:42069).
+//
+//   GET  /image      -> PNG of the current guest display
+//   POST /send-keys  -> {"keys": "Hi<ENTER>", "encoding": "oligarchy"}
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { readFile, rm } from "node:fs/promises";
-import { connect as netConnect, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { JSONStreamParser } from "../qmp/json-stream.ts";
+import { createDisk, createQemu, screendump, sendKey, start, stop } from "./client.ts";
 import { parseKeys } from "./keys.ts";
 
-type Pending = {
-  resolve: (value: unknown) => void;
-  reject: (err: unknown) => void;
-};
+const iso = process.argv[2] ?? process.env.OLIGARCHY_ISO;
+if (iso === undefined) {
+  console.error("usage: proxy <iso>  (or set OLIGARCHY_ISO)");
+  process.exit(1);
+}
+const addr = process.env.OLIGARCHY_ADDR ?? "127.0.0.1:42069";
 
-export type QemuProxy = {
-  readonly greeting: QemuGreetingResponse;
-  readonly pending: Map<number | "greeting", Pending>;
-  nextId: number;
-  socket?: Socket;
-};
+const qemu = createQemu();
+await createDisk(qemu);
+await start(qemu, { iso });
 
-/** Dials a QMP unix socket and completes the QMP handshake. */
-export async function connect(path: string): Promise<QemuProxy> {
-  const socket = await new Promise<Socket>((resolve, reject) => {
-    const sock = netConnect(path);
-    sock.once("connect", () => resolve(sock));
-    sock.once("error", reject);
+const server = createServer((req, res) => {
+  void handle(req, res);
+});
+const [host, port] = addr.split(":");
+server.listen(Number(port), host, () => {
+  console.error(`oligarchy proxy listening on ${addr}, session ${qemu.id}`);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    server.close();
+    void stop(qemu).then(() => process.exit(0));
   });
-  return fromSocket(socket);
 }
 
-/**
- * Takes a connected QMP socket, reads the greeting, and completes
- * capabilities negotiation.
- */
-export async function fromSocket(socket: Socket): Promise<QemuProxy> {
-  const pending = new Map<number | "greeting", Pending>();
-  const greeting = new Promise<unknown>((resolve, reject) => {
-    pending.set("greeting", { resolve, reject });
-  });
-
-  const parser = new JSONStreamParser();
-  socket.setEncoding("utf8");
-  socket.on("data", (chunk: string) => {
-    try {
-      parser.push(chunk);
-      for (let msg = parser.pull(); msg !== undefined; msg = parser.pull()) {
-        if ("QMP" in msg) {
-          pending.get("greeting")?.resolve(msg);
-          pending.delete("greeting");
-          continue;
-        }
-        if ("event" in msg) {
-          continue;
-        }
-        const id = msg.id as number;
-        const entry = pending.get(id);
-        if (entry === undefined) {
-          continue;
-        }
-        pending.delete(id);
-        if ("error" in msg) {
-          entry.reject(new Error(`${msg.error.class}: ${msg.error.desc}`));
-        } else {
-          entry.resolve(msg.return);
-        }
+async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  try {
+    if (req.method === "GET" && req.url === "/image") {
+      const path = join(tmpdir(), `oligarchy-${process.pid}-${process.hrtime.bigint()}.png`);
+      try {
+        await screendump(qemu, path);
+        const data = await readFile(path);
+        res.writeHead(200, { "Content-Type": "image/png", "Content-Length": data.length });
+        res.end(data);
+      } finally {
+        await rm(path, { force: true });
       }
-    } catch (err) {
-      failAll(pending, err);
-      socket.destroy();
+      return;
     }
-  });
-  socket.on("error", (err) => failAll(pending, err));
-  socket.on("close", () => failAll(pending, new Error("qemu: socket closed")));
 
-  try {
-    const proxy: QemuProxy = {
-      greeting: (await greeting) as QemuGreetingResponse,
-      pending,
-      nextId: 0,
-      socket,
-    };
-    await execute(proxy, "qmp_capabilities");
-    return proxy;
+    if (req.method === "POST" && req.url === "/send-keys") {
+      let body = "";
+      for await (const chunk of req) {
+        body += chunk;
+      }
+      const { keys = "", encoding } = JSON.parse(body) as { keys?: string; encoding?: string };
+      for (const chord of parseKeys(keys, encoding)) {
+        await sendKey(qemu, chord.map((code): QemuKeyValue => ({ type: "qcode", data: code })));
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: "true" }));
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not found" }));
   } catch (err) {
-    socket.destroy();
-    throw err;
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
   }
-}
-
-/** Closes the QMP connection; in-flight commands reject. */
-export function close(proxy: QemuProxy): void {
-  failAll(proxy.pending, new Error("qemu: closed"));
-  proxy.socket?.destroy();
-  proxy.socket = undefined;
-}
-
-/** Sends a named QMP command and returns its result. */
-export async function execute(proxy: QemuProxy, name: string, args?: unknown): Promise<unknown> {
-  const socket = proxy.socket;
-  if (socket === undefined) {
-    throw new Error("qemu: closed");
-  }
-  const id = ++proxy.nextId;
-  return new Promise((resolve, reject) => {
-    proxy.pending.set(id, { resolve, reject });
-    // JSON.stringify drops "arguments" when args is undefined.
-    socket.write(`${JSON.stringify({ execute: name, arguments: args, id })}\n`);
-  });
-}
-
-/** Captures the current guest display as a PNG. */
-export async function readImage(proxy: QemuProxy): Promise<Buffer> {
-  const path = join(tmpdir(), `oligarchy-${process.pid}-${process.hrtime.bigint()}.png`);
-  try {
-    await execute(proxy, "screendump", { filename: path, format: "png" });
-    return await readFile(path);
-  } finally {
-    await rm(path, { force: true });
-  }
-}
-
-/** Types keys into the guest using the given key-string encoding. */
-export async function sendKeys(proxy: QemuProxy, keys: string, encoding?: string): Promise<void> {
-  for (const chord of parseKeys(keys, encoding)) {
-    await execute(proxy, "send-key", {
-      keys: chord.map((code): QemuKeyValue => ({ type: "qcode", data: code })),
-    });
-  }
-}
-
-function failAll(pending: Map<number | "greeting", Pending>, err: unknown): void {
-  for (const entry of pending.values()) {
-    entry.reject(err);
-  }
-  pending.clear();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **qemu proxy** is the TypeScript take on the Go oligarchy server daemon: a main file, not a library. It proxies running QEMU instances — start one and get a uuid back, then use that uuid to send keys, grab screenshots, and stop it.

- **`src/qemu/proxy.ts`** — no exports. Boot parameters come from CLI/env only: the default ISO is passed in via argv or `OLIGARCHY_ISO` (usage + exit 1 when missing), the listen address via `OLIGARCHY_ADDR` (default `127.0.0.1:42069`). The daemon keeps a session map keyed by uuid — the uuid is the way into a qemu:
  - `POST /start` — optional `{"iso"?, "disk"?}` body (empty body = defaults); boots a new qemu via `client.ts` (`createQemu` → `createDisk` → `start`) and returns `{"id": "<uuid>"}` to the caller.
  - `GET /image?id=<uuid>` — screendumps that session to a uniquely named PNG inside its session dir and responds with the bytes (file always removed).
  - `POST /send-keys` — `{"id": "<uuid>", "keys": "Hi<ENTER>", "encoding"?}`, parsed into chords and sent key-by-key.
  - `POST /stop` — `{"id": "<uuid>"}`; kills that session's QEMU, removes its session dir, and drops it from the map.
  - Missing/unknown ids and other handler failures get JSON `{"error": ...}` with a 400; unknown routes 404.
  - `SIGINT`/`SIGTERM` stop every remaining session before exiting.
  - The proxy does no QMP work of its own — the greeting read and `qmp_capabilities` negotiation live inside `client.ts`'s `start`.
- **`src/qemu/keys.ts`** — the key-string parser from Go `keys.go`: literal characters (US-keyboard shift handling), angle-bracket names (`<ENTER>`, `<F13>`, `<caps_lock>`), and modifiers (`<C-S-c>`), exported as `parseKeys(s, encoding?)` returning qcode chords. Iterates Unicode code points like Go runes. Go's `normalizeEncoding` was intentionally not carried over — the encoding check is one inline guard; the word "normalize" appears nowhere under `src/`.
- **`src/qemu/keys.test.ts`** — 16 tests for `parseKeys`, happy and unhappy paths, wired into `npm test`.

Reviewed twice by GPT 5.6 Sol subagents for simplicity and parity (no useless guardrails, no extra functions, no classes).

## Verification

- `npm test`: 28/28 (12 json-stream + 16 keys)
- `npm run lint` (oxlint type-aware + type-check): clean, zero warnings
- `tsc`: clean
- Smoke-tested live over HTTP (QEMU itself is not installed on this VM): unknown route 404; `/image`, `/send-keys`, and `/stop` without id → `session id is required`; unknown id → `unknown session "nope"`; `POST /start` correctly reaches the qemu-img spawn; usage line + exit 1 without an ISO

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04b3b-df4c-77ee-8b98-dc82c6ac972e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04b3b-df4c-77ee-8b98-dc82c6ac972e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

