### PR TITLE
field guide: durable feedback distilled from the /stats endpoint work

### DIFF
--- a/field-guide/http-api.md
+++ b/field-guide/http-api.md
@@ -28,6 +28,24 @@ The TypeScript proxy reads only `iso` and `disk`, and the disk semantics differ:
 
 Returns the session's current display as `image/png` bytes (QMP `screendump` under the hood).
 
+## GET /stats — proxy only
+
+Stats for the machine the proxy runs on, plus how many sessions it is running:
+
+```json
+{
+  "qemus": 0,
+  "memory": { "totalBytes": 16791945216, "usedBytes": 966746112, "freeBytes": 15825199104 },
+  "cpu": { "cores": 4, "mean": 20.5, "p10": 19.8, "p25": 20.1, "p75": 20.9, "p90": 21.1 }
+}
+```
+
+- `qemus` is the size of the proxy's own session map — the proxy is the source of truth for what it booted (see the [philosophy](philosophy.md)).
+- `cpu` values are utilization percents over a rolling five-minute window, sampled every five seconds by a timer that lives with the server. Every field is a plain number; before the first sample lands they report 0.
+- `memory` is host totals from the OS: `usedBytes = totalBytes - freeBytes`.
+
+The Go server does not implement this endpoint.
+
 ## POST /send-keys
 
 Body `{"id", "keys", "encoding"}`. The server parses the key string (encoding `oligarchy`, see [how-to.md](how-to.md)) and types it into the guest via QMP `send-key`. Returns `{"ok": "true"}`.

--- a/field-guide/index.md
+++ b/field-guide/index.md
@@ -2,7 +2,7 @@
 
 The entry point for working on this repo. Start here, then follow the link you need.
 
-- [Philosophy](philosophy.md) — how code is written here: simple, small surface, no unneeded guards.
+- [Philosophy](philosophy.md) — how code is written here: simple, small surface, every real error handled, no unneeded guards.
 - [The CLI](cli.md) — what `src/qemu/cli.ts` does and why, command by command.
 - [The HTTP API](http-api.md) — the control-plane contract every client and server here shares.
 - [Key encoding how-to](how-to.md) — the `oligarchy` key-string encoding used by `send-keys`.

--- a/field-guide/philosophy.md
+++ b/field-guide/philosophy.md
@@ -12,6 +12,8 @@ Optimize for the person reading the file top to bottom. A function should be ins
 
 Expose the smallest surface that does the job, even when the layer below supports more. The server's `/start` accepts memory, SMP, disk size, and firmware paths; the CLI takes only `--iso` and `--disk`, because those are the only two anyone needs — and the ISO mostly for debugging. Fewer options is a feature. Do not add a flag because the field exists.
 
+The same rule applies to output. When asked for a number, return the number — not everything the system could tell you. `/stats` answers "how many qemus, how much memory, what is the cpu doing" and nothing else; its first draft inventoried the distro, probed for KVM, parsed `/proc/meminfo`, and scanned the process table, and every one of those was deleted.
+
 ## No unneeded guard clauses
 
 Trust the contracts of our own components. If a failure cannot happen given the contract, do not write code for it; if bad input already fails naturally with a clear error, let it. Validate only at real boundaries.
@@ -21,6 +23,30 @@ Guards this repo deliberately does not have:
 - `cmdStart` trusts that a 200 from `/start` carries `{"id": ...}`; it does not re-validate our own server's response shape.
 - `readAPIError` parses `{"error": ...}` in one try/catch. A malformed error body from our own servers is not a case worth code.
 - `errorMessage` casts to `Error` because everything thrown in the file is one. There is no branch for non-`Error` throws.
+- The cpu sampler's baseline is not nullable. It is established at construction; there is no universe where the sampler exists without it, and the type says so. Do not soften a construction-time requirement into a `| null` union to survive a failure that cannot happen.
+- Utilization has no 0–100 clamp: monotonic counters over an identical core set cannot leave that range. A clamp that cannot fire is noise.
+
+A guard that stays must name the real event it answers. The sampler skips a delta when the core count changed between snapshots because cpu hotplug genuinely happens on VMs — and the comment says exactly that.
+
+## Handle every real error
+
+The other half of the guards rule: anything that can actually fail at runtime is handled deliberately, and a failure never takes down more than the operation it belongs to.
+
+- Guard the boundaries that keep the process alive, even against errors you cannot name today. The HTTP handler has a catch-all; so does every timer callback, because an uncaught throw inside `setInterval` kills the whole server. Catch, log to stderr, let the next tick recover.
+- Sequence output so the error path stays usable. The proxy serializes a response before writing the status line: a throw after headers are sent can no longer become a clean error reply.
+- Startup requirements fail at startup. If the process cannot do its job, dying loudly at boot beats limping into requests.
+
+## Owned state is the source of truth
+
+Never rediscover from the environment what the program already knows by reference. The proxy booted every session it manages, so "how many qemus are running" is the size of its own sessions map — not the `/proc` scan that was written first and deleted. Discovery is worse on every axis: it adds failure modes, it counts things that are not yours, and it drifts from what the code actually controls.
+
+## Nulls are a tax on every consumer
+
+A nullable field forces a branch on everyone, forever. Do not spend that to represent a state that barely exists: the cpu window is empty only for the first seconds of uptime, so its fields are plain numbers that report 0, not `number | null`. Reserve null for an absence a consumer genuinely must distinguish and act on — never as a way to dodge choosing the natural default.
+
+## Background work lives and dies with the server
+
+A loop or timer that runs for the life of the process owes three guarantees: it never keeps the process alive (`unref` it), it never brings the process down (its tick is guarded), and its state is bounded (a rolling window, never an array that only grows). The cpu sampler in `src/qemu/stats.ts` is the shape to copy.
 
 ## No normalization functions
 
@@ -34,6 +60,7 @@ Simplicity is not deleting necessary behavior. Things that stay, and why:
 - The CLI stats the ISO before calling the server: the client-side error is immediate and names the real path.
 - `errorMessage` unwraps `fetch`'s `cause`: without it, a refused connection prints only "fetch failed".
 - Comments exist only where the intent is invisible in the code — e.g. why `start` omits the `disk` key from its JSON instead of sending an empty string.
+- A constant carries its meaning when its name and value cannot: `MAX_SAMPLES = 60` says "60 samples × 5s ticks = a 5 minute window", because "five minutes" appears nowhere else in the code.
 
 ## Porting: the reference implementation is the spec
 
@@ -41,10 +68,12 @@ When a component mirrors another (the TypeScript CLI fills the Go client's role)
 
 ## Tests
 
-The default discipline: tests are written first, before implementation, and every feature covers both the happy and the unhappy path. Plan the tests before the code. Deviating requires explicit maintainer instruction — the CLI has no test files by request and was verified with a disposable stub-server harness instead.
+We do not do test-first. Tests are not the default deliverable of a change, they are never written ahead of the implementation, and production code is never reshaped to make testing easier — no exported factories, no injected dependencies, no main-file surgery whose only customer is a test. If code would have to change shape before it can be tested, skip the test, not the shape.
+
+The default verification is running the real thing: boot the server, hit the endpoint, read the output. Disposable harnesses beat committed scaffolding — the CLI was verified against a throwaway stub server, the stats endpoint by curling a live proxy while a core was pinned. Committed test files exist only where the maintainer asked for them (`src/qemu/keys.test.ts`, `src/qmp/json-stream.test.ts`); when tests are requested, they cover both the happy and the unhappy path.
 
 ## Style
 
 - No classes, ever. Factory functions returning plain state objects, operated on by standalone functions. See [AGENTS.md](../AGENTS.md).
 - Executables are main files, not libraries: they run top level and export nothing (`src/qemu/cli.ts`, `src/qemu/proxy.ts`).
-- Changes get a review pass against this document's bar. Review suggestions that add guards or ceremony get declined, with the reason stated.
+- Changes get a review pass against this document's bar. Review suggestions that add guards or ceremony get declined, with the reason stated. Machine reviews are held to the same bar as the code they review: a reviewer that introduces nullable state for impossible failures, or strips the comments that carry design intent, gets that half of its diff reverted.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Records the maintainer preferences that surfaced while building the `/stats` endpoint ([#4](https://github.com/ThePrimeagen/Oligarchy/pull/4)) as durable field-guide entries — principles that apply anywhere in the codebase, with the stats work serving only as the grounding examples, the same way `cli.ts` grounds the existing philosophy sections.

## Philosophy (`field-guide/philosophy.md`)

New sections:

- **Handle every real error** — the other half of the no-unneeded-guards rule: guard process-survival boundaries (HTTP handler, timer callbacks) even against unnamed errors; sequence output so the error path stays usable (serialize before the status line); startup requirements fail at startup.
- **Owned state is the source of truth** — never rediscover from the environment what the program knows by reference; session count is the sessions map, not a `/proc` scan.
- **Nulls are a tax on every consumer** — don't make a field nullable for a state that barely exists; report the natural zero and keep types flat.
- **Background work lives and dies with the server** — timers must never hold the process open (`unref`), never take it down (guarded tick), never grow unbounded (rolling window).

Extended sections:

- **Support only what is used** now covers output: when asked for a number, return the number — the first stats draft's distro/KVM/meminfo/process-table inventory was all deleted.
- **No unneeded guard clauses** gains the non-nullable-baseline and impossible-clamp examples, plus the rule that a surviving guard must name the real event it answers (core-count check ↔ hotplug).
- **Keep what earns its place** gains: a constant carries its meaning when its name and value cannot (`MAX_SAMPLES = 60` → "5 minute window").
- **Style** review bullet: machine reviews are held to the same bar; defensive additions get reverted.

Rewritten section:

- **Tests** — the previous text recorded test-first as the default discipline. The maintainer has stated the opposite directly: we do not do test-first, tests are not a default deliverable, and production code is never reshaped for testability (no exported factories, no injected dependencies, no main-file surgery for a test's benefit). Default verification is running the real thing; committed test files exist only where explicitly requested.

## Contract (`field-guide/http-api.md`)

Documents `GET /stats` (proxy only) with a real response body and links back to the philosophy for the design reasoning. `index.md` hub line updated to match.

No code changes; 28/28 tests still pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04b96-db9f-78b8-8412-3d9dfc054f52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04b96-db9f-78b8-8412-3d9dfc054f52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

