### PR TITLE
prompts: self-contained bases for driving a guest, plus the CI boot-to-desktop prompt (reland)

### DIFF
--- a/field-guide/index.md
+++ b/field-guide/index.md
@@ -7,4 +7,5 @@ The entry point for working on this repo. Start here, then follow the link you n
 - [The HTTP API](http-api.md) — the control-plane contract between the CLI and the proxy.
 - [The database](database.md) — the PlanetScale Postgres record of every session, and the `src/db/ops.ts` interface to it.
 - [Key encoding how-to](how-to.md) — the `oligarchy` key-string encoding used by `send-keys`.
+- [Prompts](../prompts/README.md) — ready-to-send prompt bases for agents driving a guest through the CLI, plus the CI boot-to-desktop prompt.
 - [Agent rules](../AGENTS.md) — vocabulary and hard TypeScript rules.

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,14 @@
+# Prompts
+
+Ready-to-send prompts for agents that drive a QEMU guest through the oligarchy CLI (`src/qemu/cli.ts`). Each file is self-contained on purpose: the commands, the key encoding, and the working loop are inlined so the agent never has to explore this repo to operate the guest. When the CLI's interface changes, change these files with it.
+
+The bases are templates: pick the one matching where the server runs, replace every `{{...}}`, and put the work in `{{TASK}}`. The CI prompt is not a base — fill in the ISO path and send it as-is.
+
+- [base-local.md](base-local.md) — the server is on the agent's machine at the default `127.0.0.1:42069`, and the ISO is a local path. Fill `{{ISO}}` and `{{TASK}}`.
+- [base-remote.md](base-remote.md) — the server is elsewhere; the agent exports `OLIGARCHY_ADDR` (host:port, no scheme — the CLI speaks plain HTTP). The ISO must be an http(s) URL for the server to download and cache, and `--disk` is never passed. Fill `{{ADDR}}`, `{{ISO_URL}}`, and `{{TASK}}`.
+- [ci-boot-to-desktop.md](ci-boot-to-desktop.md) — the CI smoke test. A proxy is already running locally and an ISO is already on disk; the agent boots a session, drives the installer, creates a user, signs in, and must end its reply with `PASS <session-id>` or `FAIL: <reason>`, leaving `desktop.png` and the numbered `step-NN.png` screenshots behind. Fill `{{ISO}}`.
+
+Two checks before sending:
+
+- `grep '{{' <file>` — a leftover placeholder means it is not ready.
+- The agent's shell must be on the machine the prompt assumes. The CI prompt means `127.0.0.1` literally: run it with an agent on the CI runner itself (e.g. the `cursor-agent` CLI). A cloud agent started through `src/cursor-agent/client.ts` runs on its own VM and cannot see the runner's localhost.

--- a/prompts/base-local.md
+++ b/prompts/base-local.md
@@ -13,7 +13,7 @@ The CLI is the only way you touch the guest. Do not call the HTTP API directly, 
 Boot a session — prints the session id every other command needs:
 
 ```bash
-node --experimental-strip-types src/qemu/cli.ts start --iso {{ISO}}
+node --experimental-strip-types src/qemu/cli.ts start --iso '{{ISO}}'
 ```
 
 Leave `--disk` out and the server creates a fresh 40G disk for the session. Pass `--disk <path>` only when the task below hands you an existing qcow2.

--- a/prompts/base-local.md
+++ b/prompts/base-local.md
@@ -1,0 +1,53 @@
+# Drive a QEMU guest — local server
+
+You are operating a QEMU guest through the oligarchy CLI in this repository. Run every command from the repository root. Everything you need to operate the guest is in this prompt; do not explore this repo's docs or source to learn the control plane.
+
+## The server
+
+The oligarchy proxy is already running on this machine at `127.0.0.1:42069`, the CLI's default address. Do not start, stop, or restart it, and leave `OLIGARCHY_ADDR` unset.
+
+## The commands
+
+The CLI is the only way you touch the guest. Do not call the HTTP API directly, and do not run `qemu-*` commands yourself.
+
+Boot a session — prints the session id every other command needs:
+
+```bash
+node --experimental-strip-types src/qemu/cli.ts start --iso {{ISO}}
+```
+
+Leave `--disk` out and the server creates a fresh 40G disk for the session. Pass `--disk <path>` only when the task below hands you an existing qcow2.
+
+Capture the guest display as a PNG:
+
+```bash
+node --experimental-strip-types src/qemu/cli.ts get-image <id> -o step-01.png
+```
+
+Type into the guest:
+
+```bash
+node --experimental-strip-types src/qemu/cli.ts send-keys <id> 'hello<ENTER>'
+```
+
+## Key encoding
+
+- Literal characters are typed as written. `A` already sends shift+a; never add your own shift.
+- Special keys go in angle brackets: `<ENTER>`, `<ESC>`, `<TAB>`, `<BS>`, `<DEL>`, `<SPACE>`, `<UP>`, `<DOWN>`, `<LEFT>`, `<RIGHT>`, `<HOME>`, `<END>`, `<PGUP>`, `<PGDN>`, `<F1>`–`<F24>`.
+- Modifiers: `<C-c>` control, `<A-x>` alt, `<S-x>` shift, `<M-x>` meta. They combine: `<C-S-c>`.
+- Literal `<` and `>` are `<LT>` and `<GT>`.
+- Single-quote the key string so the shell keeps `<`, `>`, and spaces.
+
+## How to work
+
+Look, act, look again:
+
+1. Take a screenshot and read it.
+2. Send the keys that screen calls for.
+3. Take another screenshot to confirm the effect before deciding the next step.
+
+Never type blind. When the guest is busy — boot messages, spinners, progress bars — `sleep 20` and re-screenshot instead of pressing keys. Number the screenshots (`step-01.png`, `step-02.png`, ...) so the run leaves a trail.
+
+## Your task
+
+{{TASK}}

--- a/prompts/base-remote.md
+++ b/prompts/base-remote.md
@@ -19,10 +19,10 @@ The CLI is the only way you touch the guest. Do not call the HTTP API directly, 
 Boot a session — prints the session id every other command needs:
 
 ```bash
-node --experimental-strip-types src/qemu/cli.ts start --iso {{ISO_URL}}
+node --experimental-strip-types src/qemu/cli.ts start --iso '{{ISO_URL}}'
 ```
 
-The ISO must be an http(s) URL. A file path cannot work here: the CLI would check it on this machine, and the server would try to open it on its own disk. The server downloads the URL into its cache on the first start and reuses it afterwards, so a first boot of a new URL takes as long as the download. Never pass `--disk` — a disk path would also have to exist on the server's machine; leaving it out makes the server create a fresh 40G disk.
+The ISO must be an http(s) URL: a path on this machine's disk is not on the server's, so the server could not open it. The server downloads the URL into its cache on the first start and reuses it afterwards, so a first boot of a new URL takes as long as the download. Never pass `--disk` — a disk path would also have to exist on the server's machine; leaving it out makes the server create a fresh 40G disk.
 
 Capture the guest display as a PNG — the file is written on your machine, nothing to copy from the server:
 

--- a/prompts/base-remote.md
+++ b/prompts/base-remote.md
@@ -1,0 +1,59 @@
+# Drive a QEMU guest — remote server
+
+You are operating a QEMU guest through the oligarchy CLI in this repository. Run every command from the repository root. Everything you need to operate the guest is in this prompt; do not explore this repo's docs or source to learn the control plane.
+
+## The server
+
+The oligarchy proxy runs on another machine. The CLI reads its address from `OLIGARCHY_ADDR` — host:port, no scheme; the CLI speaks plain HTTP — so export it once before your first command:
+
+```bash
+export OLIGARCHY_ADDR={{ADDR}}
+```
+
+The server is not yours to manage: if a command fails to connect, report it; do not try to start a proxy anywhere.
+
+## The commands
+
+The CLI is the only way you touch the guest. Do not call the HTTP API directly, and do not run `qemu-*` commands yourself.
+
+Boot a session — prints the session id every other command needs:
+
+```bash
+node --experimental-strip-types src/qemu/cli.ts start --iso {{ISO_URL}}
+```
+
+The ISO must be an http(s) URL. A file path cannot work here: the CLI would check it on this machine, and the server would try to open it on its own disk. The server downloads the URL into its cache on the first start and reuses it afterwards, so a first boot of a new URL takes as long as the download. Never pass `--disk` — a disk path would also have to exist on the server's machine; leaving it out makes the server create a fresh 40G disk.
+
+Capture the guest display as a PNG — the file is written on your machine, nothing to copy from the server:
+
+```bash
+node --experimental-strip-types src/qemu/cli.ts get-image <id> -o step-01.png
+```
+
+Type into the guest:
+
+```bash
+node --experimental-strip-types src/qemu/cli.ts send-keys <id> 'hello<ENTER>'
+```
+
+## Key encoding
+
+- Literal characters are typed as written. `A` already sends shift+a; never add your own shift.
+- Special keys go in angle brackets: `<ENTER>`, `<ESC>`, `<TAB>`, `<BS>`, `<DEL>`, `<SPACE>`, `<UP>`, `<DOWN>`, `<LEFT>`, `<RIGHT>`, `<HOME>`, `<END>`, `<PGUP>`, `<PGDN>`, `<F1>`–`<F24>`.
+- Modifiers: `<C-c>` control, `<A-x>` alt, `<S-x>` shift, `<M-x>` meta. They combine: `<C-S-c>`.
+- Literal `<` and `>` are `<LT>` and `<GT>`.
+- Single-quote the key string so the shell keeps `<`, `>`, and spaces.
+
+## How to work
+
+Look, act, look again:
+
+1. Take a screenshot and read it.
+2. Send the keys that screen calls for.
+3. Take another screenshot to confirm the effect before deciding the next step.
+
+Never type blind. When the guest is busy — boot messages, spinners, progress bars — `sleep 20` and re-screenshot instead of pressing keys. Number the screenshots (`step-01.png`, `step-02.png`, ...) so the run leaves a trail.
+
+## Your task
+
+{{TASK}}

--- a/prompts/ci-boot-to-desktop.md
+++ b/prompts/ci-boot-to-desktop.md
@@ -1,0 +1,66 @@
+# CI: boot the ISO to a desktop
+
+You are running this repository's smoke test: take a QEMU guest from cold boot to a signed-in graphical desktop. Everything you need is in this prompt. Do not read this repo's docs or source, do not install anything, and run no commands beyond the ones given here, `sleep`, and viewing the screenshots you take. Run every command from the repository root.
+
+Already in place — touch neither:
+
+- The oligarchy proxy is running on this machine at `127.0.0.1:42069`, the CLI's default. Never start, stop, or restart it; leave `OLIGARCHY_ADDR` unset.
+- The guest ISO is on disk at `{{ISO}}`.
+
+## Mission
+
+Boot a session from the ISO and drive the guest through its installer: create the user below, let the install finish, and keep going — through any reboot, disk-encryption passphrase, or login screen — until the installed system shows its graphical desktop. Read the screens and react to them; do not assume a fixed sequence.
+
+## Commands
+
+Boot — prints the session id every other command needs. Do not pass `--disk`; the server creates a fresh disk:
+
+```bash
+node --experimental-strip-types src/qemu/cli.ts start --iso {{ISO}}
+```
+
+Screenshot:
+
+```bash
+node --experimental-strip-types src/qemu/cli.ts get-image <id> -o step-01.png
+```
+
+Type:
+
+```bash
+node --experimental-strip-types src/qemu/cli.ts send-keys <id> 'text<ENTER>'
+```
+
+## Key encoding
+
+- Literal characters are typed as written. `A` already sends shift+a; never add your own shift.
+- Special keys go in angle brackets: `<ENTER>`, `<ESC>`, `<TAB>`, `<BS>`, `<DEL>`, `<SPACE>`, `<UP>`, `<DOWN>`, `<LEFT>`, `<RIGHT>`, `<HOME>`, `<END>`, `<PGUP>`, `<PGDN>`, `<F1>`–`<F24>`.
+- Modifiers: `<C-c>` control, `<A-x>` alt, `<S-x>` shift, `<M-x>` meta. They combine: `<C-S-c>`.
+- Literal `<` and `>` are `<LT>` and `<GT>`.
+- Single-quote the key string so the shell keeps `<`, `>`, and spaces.
+
+## Answers for the guest
+
+Use these wherever the guest asks. Anything it asks that is not listed here, answer with the simplest acceptable choice and move on.
+
+- Full name: `CI Oligarch`
+- Email: `ci@oligarchy.test`
+- Username: `ci`
+- Every password — user account, disk encryption, login: `oligarchy-ci`
+
+## The loop
+
+1. Take a screenshot and read it.
+2. If the screen wants input, send exactly the keys it calls for, then screenshot again to confirm the effect.
+3. If the guest is working — boot text, spinners, progress bars — `sleep 20` and re-screenshot. A full install can run fifteen minutes or more; waiting is normal, and pressing keys at a busy screen is how runs get wrecked.
+
+Number the screenshots in order (`step-01.png`, `step-02.png`, ...) and keep every one; they are the run's audit trail.
+
+If a reboot drops you back at the ISO's boot menu instead of the installed system, pick the menu entry that boots the existing local disk. If the menu has no such entry, that is a FAIL — do not reinstall.
+
+## Verdict
+
+Your reply must end with exactly one of these lines, nothing after it:
+
+- `PASS <session-id>` — a screenshot shows the installed system's desktop. Save that screenshot as `desktop.png` too.
+- `FAIL: <one line: the screen you were on and what went wrong>` — the screen has not changed in ten minutes, or the guest shows an error the answers above cannot get past. Keep all screenshots.

--- a/prompts/ci-boot-to-desktop.md
+++ b/prompts/ci-boot-to-desktop.md
@@ -16,7 +16,7 @@ Boot a session from the ISO and drive the guest through its installer: create th
 Boot — prints the session id every other command needs. Do not pass `--disk`; the server creates a fresh disk:
 
 ```bash
-node --experimental-strip-types src/qemu/cli.ts start --iso {{ISO}}
+node --experimental-strip-types src/qemu/cli.ts start --iso '{{ISO}}'
 ```
 
 Screenshot:
@@ -56,11 +56,11 @@ Use these wherever the guest asks. Anything it asks that is not listed here, ans
 
 Number the screenshots in order (`step-01.png`, `step-02.png`, ...) and keep every one; they are the run's audit trail.
 
-If a reboot drops you back at the ISO's boot menu instead of the installed system, pick the menu entry that boots the existing local disk. If the menu has no such entry, that is a FAIL — do not reinstall.
+If a reboot drops you back at the ISO's boot menu instead of the installed system, pick the menu entry that boots the existing local disk. If the menu has no such entry, or the guest lands back in the installer, that is a FAIL — never reinstall.
 
 ## Verdict
 
 Your reply must end with exactly one of these lines, nothing after it:
 
 - `PASS <session-id>` — a screenshot shows the installed system's desktop. Save that screenshot as `desktop.png` too.
-- `FAIL: <one line: the screen you were on and what went wrong>` — the screen has not changed in ten minutes, or the guest shows an error the answers above cannot get past. Keep all screenshots.
+- `FAIL: <one line: where you were and what went wrong>` — a CLI command fails and keeps failing on retry, the screen has not changed in ten minutes, or the guest shows an error the answers above cannot get past. Keep all screenshots.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Re-lands [#12](https://github.com/ThePrimeagen/Oligarchy/pull/12), which was merged by accident and reverted on master in 8fdc6b8. The content is identical to the reviewed original — the two commits are cherry-picked from that branch unchanged.

## What

Adds a `prompts/` directory: ready-to-send prompts for agents that drive a QEMU guest through the oligarchy CLI, and links it from the field guide index.

- `prompts/base-local.md` — template for a server on the agent's machine (default `127.0.0.1:42069`, local ISO path). Fill `{{ISO}}` and `{{TASK}}`.
- `prompts/base-remote.md` — template for a server elsewhere: the agent exports `OLIGARCHY_ADDR` (host:port, plain HTTP), the ISO must be an http(s) URL for the server to download and cache, and `--disk` is never passed (a disk path would have to exist on the server's machine). Fill `{{ADDR}}`, `{{ISO_URL}}`, `{{TASK}}`.
- `prompts/ci-boot-to-desktop.md` — the CI smoke test, concrete except for `{{ISO}}`: proxy already running locally, ISO already on disk; the agent boots a session, drives the installer with a screenshot→keys→screenshot loop, creates the fixed `ci` user, signs in, and must end its reply with exactly `PASS <session-id>` or `FAIL: <reason>`, leaving `desktop.png` and numbered `step-NN.png` screenshots as artifacts.
- `prompts/README.md` — what the files are, the `{{...}}` placeholder convention, and the pre-send checks (`grep '{{'`; the CI prompt means `127.0.0.1` literally, so it needs an agent on the runner itself, not a cloud agent).

## Why

Agents interacting with this repo always go through the CLI to a proxy that is either local or remote. These prompts inline everything an agent needs — the three commands, the key encoding, the look-act-look loop — so it does as little exploring as possible and stays on task. The local/remote split is two complete files rather than one file with conditionals: each is sendable as-is, and the small repetition keeps both readable on their own, per the field guide philosophy.

No code changes; the remote case needs none, since the CLI already reads `OLIGARCHY_ADDR`.

## Review

GPT-5.6 Sol pass done on the original (diff here is identical). Accepted: quoted ISO placeholders in example commands, FAIL covers a persistently failing CLI command, the post-reboot rule also catches landing back in the installer (QEMU keeps the ISO attached with `-boot order=d`), and the remote template's ISO wording no longer overstates ("a path on this machine's disk is not on the server's"). Declined as ceremony: a 1–2 second screenshot polling loop after reboot, and demanding extra "evidence the desktop belongs to the installed system" — the FAIL rules already catch the wrong-boot paths.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04e9a-245a-705e-bf1b-3216f16dbdd5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04e9a-245a-705e-bf1b-3216f16dbdd5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

