### PR TITLE
cli: require --agent-id and attach the agent to every request

### DIFF
--- a/field-guide/cli.md
+++ b/field-guide/cli.md
@@ -3,12 +3,14 @@
 The TypeScript client for the oligarchy control plane. It sends HTTP requests to a running proxy (`src/qemu/proxy.ts`) and prints the result. It is a main file, not a library: running it executes `main`, and it exports nothing.
 
 ```bash
-node --experimental-strip-types src/qemu/cli.ts start [--iso <path>] [--disk <path>]
-node --experimental-strip-types src/qemu/cli.ts get-image <id> [-o file]
-node --experimental-strip-types src/qemu/cli.ts send-keys <id> <keys> [encoding]
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> start [--iso <path>] [--disk <path>]
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> get-image <id> [-o file]
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-keys <id> <keys> [encoding]
 ```
 
 The server address comes from `OLIGARCHY_ADDR`, default `127.0.0.1:42069`.
+
+`--agent-id <agent>` leads every invocation, required with no default: every request carries the calling agent's id so the server can attribute the session's actions to that agent. This client is used by agents, not humans — the inconvenience of typing it is deliberate. An invocation without it prints usage and exits `2`, same as a missing command; `main` peels the pair off before dispatching, so the commands themselves never parse it.
 
 ## start
 
@@ -17,7 +19,7 @@ Boots a QEMU session and prints its session id (a UUID). Every other command tak
 - Arguments are strict `--flag value` pairs: `--iso <path>` and `--disk <path>`, either order, both optional. Anything else — positionals, unknown flags, a flag without a value — is a usage error. These are intentionally the only two options: the qemu client underneath supports more (memory, SMP, firmware paths), neither the proxy nor the CLI exposes them.
 - The ISO defaults to `omarchy.iso` in the current directory, mostly a debug convenience. A path is resolved to absolute and must exist; the CLI fails fast with the real path in the error instead of making the server discover it. An http(s) url is passed through untouched — downloading and caching it is the server's job (see [http-api.md](http-api.md)).
 - The disk is resolved to an absolute path when given. When not given, the `disk` key is omitted from the JSON entirely, not sent as `""`: the proxy creates the default disk only when the key is absent — an empty string would be taken as a real path. `JSON.stringify` dropping `undefined` properties is what makes the omission work.
-- Wire call: `POST /start` with `{"iso": "...", "disk"?: "..."}` → `{"id": "<uuid>"}`.
+- Wire call: `POST /start` with `{"iso": "...", "disk"?: "...", "agent": "..."}` → `{"id": "<uuid>"}`.
 
 ## get-image
 
@@ -25,21 +27,21 @@ Captures the session's current display as a PNG.
 
 - Exactly three accepted argument forms: `<id>`, `<id> -o <file>`, and `-o <file> <id>`.
 - With `-o`, the PNG is written to the file (mode 0644); without it, raw PNG bytes go to stdout, so redirect: `... get-image <id> > shot.png`.
-- Wire call: `GET /image?id=<id>` → `image/png` bytes.
+- Wire call: `GET /image?id=<id>&agent=<agent>` → `image/png` bytes.
 
 ## send-keys
 
 Types a key string into the session.
 
 - `send-keys <id> <keys> [encoding]`; the encoding defaults to `oligarchy` and is passed through untouched — the server does the parsing. The encoding itself (literal characters, `<ENTER>`, `<C-c>`, ...) is documented in [how-to.md](how-to.md) and implemented server-side in `src/qemu/keys.ts`.
-- Wire call: `POST /send-keys` with `{"id", "keys", "encoding"}` → `{"ok": "true"}`.
+- Wire call: `POST /send-keys` with `{"id", "keys", "encoding", "agent"}` → `{"ok": "true"}`.
 
 ## Errors and exit codes
 
-- `0` success; `1` any command failure, including a command's own usage errors; `2` no command or an unknown command. The codes come from the retired Go client — see [porting](philosophy.md#porting-the-reference-implementation-is-the-spec).
+- `0` success; `1` any command failure, including a command's own usage errors; `2` a missing `--agent-id`, no command, or an unknown command. The codes come from the retired Go client — see [porting](philosophy.md#porting-the-reference-implementation-is-the-spec).
 - Failed requests print the server's `{"error": "..."}` message. A non-JSON error body is printed raw; an empty one prints `request failed`.
 - Network failures print `fetch failed: <cause>` — the cause (e.g. `connect ECONNREFUSED ...`) is unwrapped on purpose, because `fetch failed` alone says nothing.
 
 ## Reading the file
 
-`main` dispatches to one `cmd*` function per command. Each command parses its own arguments inline and throws usage errors, which `main` prints to stderr. Three shared helpers: `postJSON` (POST, status check, body text), `readAPIError` (error body to message), and `errorMessage` (thrown error to printable string, unwrapping `cause`). There is no other machinery — see the [philosophy](philosophy.md) for why it should stay that way.
+`main` peels the leading `--agent-id` pair, then dispatches to one `cmd*` function per command, passing the agent id first. Each command parses its own remaining arguments inline and throws usage errors, which `main` prints to stderr. Three shared helpers: `postJSON` (POST, status check, body text), `readAPIError` (error body to message), and `errorMessage` (thrown error to printable string, unwrapping `cause`). There is no other machinery — see the [philosophy](philosophy.md) for why it should stay that way.

--- a/field-guide/how-to.md
+++ b/field-guide/how-to.md
@@ -4,11 +4,13 @@ The CLI talks to a running proxy (`src/qemu/proxy.ts`). Start the proxy first, t
 
 ```bash
 node --experimental-strip-types src/qemu/proxy.ts omarchy.iso
-node --experimental-strip-types src/qemu/cli.ts start
-node --experimental-strip-types src/qemu/cli.ts start --iso omarchy.iso --disk qemu-img.qcow2
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> start
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> start --iso omarchy.iso --disk qemu-img.qcow2
 ```
 
 Both default to `127.0.0.1:42069`. Override with `OLIGARCHY_ADDR`.
+
+Every CLI invocation leads with `--agent-id <agent>`, the calling agent's id — required, see [cli.md](cli.md).
 
 ## Get an image
 
@@ -16,10 +18,10 @@ Captures the current guest desktop as a PNG.
 
 ```bash
 # write to a file
-node --experimental-strip-types src/qemu/cli.ts get-image <id> -o desktop.png
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> get-image <id> -o desktop.png
 
 # write PNG bytes to stdout
-node --experimental-strip-types src/qemu/cli.ts get-image <id> > desktop.png
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> get-image <id> > desktop.png
 ```
 
 `-o` can sit before or after the session id.
@@ -27,15 +29,15 @@ node --experimental-strip-types src/qemu/cli.ts get-image <id> > desktop.png
 ## Send keys
 
 ```bash
-node --experimental-strip-types src/qemu/cli.ts send-keys <id> "hello"
-node --experimental-strip-types src/qemu/cli.ts send-keys <id> "hello<ENTER>"
-node --experimental-strip-types src/qemu/cli.ts send-keys <id> "<C-c>"
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-keys <id> "hello"
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-keys <id> "hello<ENTER>"
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-keys <id> "<C-c>"
 ```
 
 The key string uses the `oligarchy` encoding (that name is optional; it is the default):
 
 ```bash
-node --experimental-strip-types src/qemu/cli.ts send-keys <id> "Hi<ENTER>" oligarchy
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-keys <id> "Hi<ENTER>" oligarchy
 ```
 
 ### Encoding

--- a/field-guide/http-api.md
+++ b/field-guide/http-api.md
@@ -4,20 +4,23 @@ The control plane spoken between the CLI and the proxy (`src/qemu/proxy.ts`).
 
 The proxy defaults to `127.0.0.1:42069`. Bodies are JSON except the PNG. Errors are `4xx`/`5xx` with `{"error": "<message>"}`.
 
+Session-driving requests (`/start`, `/image`, `/send-keys`) carry the calling agent's id — `agent` in the POST body, a query param on the GET — so the server can attribute the session's [actions](database.md) to that agent. The CLI always sends it; a request without one is unattributed manual use (the schema's null `agent_id`). The proxy does not record it yet: that lands with the database wiring. `/stop` carries none because a stop exchanges nothing over QMP and is not an action; `/stats` has no session at all.
+
 ## POST /start
 
 Boots a QEMU session. Returns `{"id": "<uuid>"}`.
 
-The body is JSON with two keys, both optional (an empty body works too):
+The body is JSON with three keys, all optional (an empty body works too):
 
 - `iso` — guest ISO path or http(s) url. Defaults to the proxy's own default ISO (its argv, or `OLIGARCHY_ISO`).
 - `disk` — qcow2 path, which must already exist. When the key is **absent**, the proxy creates a fresh disk (40G virtual) in the session dir.
+- `agent` — the calling agent's id, for attribution. Absent means unattributed manual use.
 
 Clients that want the server-managed disk must therefore omit the key, not send `""`. The CLI does this; keep it that way.
 
 A url iso is downloaded into `~/.oligarchy/isos` on first use — verified against the publisher's `<url>.sha256` sidecar when one is published — and served from that cache on every later start. The cache file is the url with `:`, `/`, and every other character a file name cannot hold replaced by `_`. A `manifest.json` beside the isos records each entry's status: while a download runs, a claim whose heartbeat advances as bytes flow; once cached, when it was cached and last used, so the cache can be pruned by size later. A start that finds a live claim — another proxy mid-download — waits and rechecks every ten seconds instead of downloading the same iso twice; a claim gone three beats stale is a dead downloader, and the start takes the download over.
 
-## GET /image?id=<id>
+## GET /image?id=<id>&agent=<agent>
 
 Returns the session's current display as `image/png` bytes (QMP `screendump` under the hood).
 
@@ -39,7 +42,7 @@ Stats for the machine the proxy runs on, plus how many sessions it is running:
 
 ## POST /send-keys
 
-Body `{"id", "keys", "encoding"}`. The server parses the key string (encoding `oligarchy`, see [how-to.md](how-to.md)) and types it into the guest via QMP `send-key`. Returns `{"ok": "true"}`.
+Body `{"id", "keys", "encoding", "agent"}`. The server parses the key string (encoding `oligarchy`, see [how-to.md](how-to.md)) and types it into the guest via QMP `send-key`. Returns `{"ok": "true"}`.
 
 ## POST /stop
 

--- a/src/qemu/cli.ts
+++ b/src/qemu/cli.ts
@@ -1,11 +1,14 @@
 // The oligarchy CLI: a main file, not a library. It drives the oligarchy
 // control plane (src/qemu/proxy.ts) over HTTP.
 //
-//   node --experimental-strip-types src/qemu/cli.ts start [--iso <path>] [--disk <path>]
-//   node --experimental-strip-types src/qemu/cli.ts get-image <id> [-o file]
-//   node --experimental-strip-types src/qemu/cli.ts send-keys <id> <keys> [encoding]
+//   node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> start [--iso <path>] [--disk <path>]
+//   node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> get-image <id> [-o file]
+//   node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-keys <id> <keys> [encoding]
 //
 // The server address comes from OLIGARCHY_ADDR (default 127.0.0.1:42069).
+// --agent-id leads every invocation: this client is driven by agents, not
+// humans, and every request names the agent so the server can attribute the
+// session's actions to it.
 
 import { stat, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
@@ -15,21 +18,24 @@ const DEFAULT_ISO = "omarchy.iso";
 const DEFAULT_ENCODING = "oligarchy";
 
 async function main(args: string[]): Promise<void> {
-  if (args.length < 1) {
+  // --agent-id leads every invocation. This client is used by agents, not
+  // humans; a request that names no agent has no business being sent.
+  if (args.length < 3 || args[0] !== "--agent-id" || args[1] === "") {
     usage();
     process.exitCode = 2;
     return;
   }
+  const agent = args[1];
   try {
-    switch (args[0]) {
+    switch (args[2]) {
       case "start":
-        await cmdStart(args.slice(1));
+        await cmdStart(agent, args.slice(3));
         break;
       case "get-image":
-        await cmdGetImage(args.slice(1));
+        await cmdGetImage(agent, args.slice(3));
         break;
       case "send-keys":
-        await cmdSendKeys(args.slice(1));
+        await cmdSendKeys(agent, args.slice(3));
         break;
       default:
         usage();
@@ -45,9 +51,9 @@ function usage(): void {
   console.error(`oligarchy is the client for the oligarchy proxy
 
 Usage:
-  oligarchy start [--iso <path>] [--disk <path>]
-  oligarchy get-image <id> [-o file]
-  oligarchy send-keys <id> <keys> [encoding]
+  oligarchy --agent-id <agent> start [--iso <path>] [--disk <path>]
+  oligarchy --agent-id <agent> get-image <id> [-o file]
+  oligarchy --agent-id <agent> send-keys <id> <keys> [encoding]
 `);
 }
 
@@ -55,9 +61,9 @@ function addr(): string {
   return process.env.OLIGARCHY_ADDR || DEFAULT_ADDR;
 }
 
-async function cmdStart(args: string[]): Promise<void> {
+async function cmdStart(agent: string, args: string[]): Promise<void> {
   if (args.length % 2 !== 0) {
-    throw new Error("usage: oligarchy start [--iso <path>] [--disk <path>]");
+    throw new Error("usage: oligarchy --agent-id <agent> start [--iso <path>] [--disk <path>]");
   }
   let iso = "";
   let disk = "";
@@ -67,7 +73,7 @@ async function cmdStart(args: string[]): Promise<void> {
     } else if (args[i] === "--disk") {
       disk = args[i + 1];
     } else {
-      throw new Error("usage: oligarchy start [--iso <path>] [--disk <path>]");
+      throw new Error("usage: oligarchy --agent-id <agent> start [--iso <path>] [--disk <path>]");
     }
   }
   iso = iso === "" ? DEFAULT_ISO : iso;
@@ -86,12 +92,13 @@ async function cmdStart(args: string[]): Promise<void> {
       iso,
       // An undefined disk is left out of the JSON, so the server creates one.
       disk: disk === "" ? undefined : resolve(disk),
+      agent,
     }),
   ) as QemuStartResult;
   console.log(out.id);
 }
 
-async function cmdGetImage(args: string[]): Promise<void> {
+async function cmdGetImage(agent: string, args: string[]): Promise<void> {
   // The three accepted forms: <id>, <id> -o <file>, and -o <file> <id>.
   let id = "";
   let out = "";
@@ -104,9 +111,9 @@ async function cmdGetImage(args: string[]): Promise<void> {
     out = args[1];
     id = args[2];
   } else {
-    throw new Error("usage: oligarchy get-image <id> [-o file]");
+    throw new Error("usage: oligarchy --agent-id <agent> get-image <id> [-o file]");
   }
-  const res = await fetch(`http://${addr()}/image?id=${encodeURIComponent(id)}`);
+  const res = await fetch(`http://${addr()}/image?id=${encodeURIComponent(id)}&agent=${encodeURIComponent(agent)}`);
   if (res.status !== 200) {
     throw new Error(await readAPIError(res));
   }
@@ -120,12 +127,12 @@ async function cmdGetImage(args: string[]): Promise<void> {
   });
 }
 
-async function cmdSendKeys(args: string[]): Promise<void> {
+async function cmdSendKeys(agent: string, args: string[]): Promise<void> {
   if (args.length < 2 || args.length > 3) {
-    throw new Error("usage: oligarchy send-keys <id> <keys> [encoding]");
+    throw new Error("usage: oligarchy --agent-id <agent> send-keys <id> <keys> [encoding]");
   }
   const encoding = args.length === 3 ? args[2] : DEFAULT_ENCODING;
-  await postJSON("/send-keys", { id: args[0], keys: args[1], encoding });
+  await postJSON("/send-keys", { id: args[0], keys: args[1], encoding, agent });
 }
 
 async function postJSON(path: string, body: unknown): Promise<string> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The CLI now requires the calling agent's id and attaches it to every request it sends. `--agent-id <agent>` leads every invocation:

```bash
oligarchy --agent-id <agent> start [--iso <path>] [--disk <path>]
oligarchy --agent-id <agent> get-image <id> [-o file]
oligarchy --agent-id <agent> send-keys <id> <keys> [encoding]
```

`main` peels the pair off once before command dispatch — one parse site, no flag machinery — and passes the id to each `cmd*` function. An invocation without it (missing, empty value, or no command after it) prints usage and exits `2`, and nothing is sent.

On the wire, the id rides as `agent`, parallel to how the session `id` already travels:

- `POST /start` body: `{"iso", "disk"?, "agent"}`
- `GET /image?id=<id>&agent=<agent>`
- `POST /send-keys` body: `{"id", "keys", "encoding", "agent"}`

## Why

This client is used by agents, not humans — the inconvenience of typing the flag is deliberate. The database schema already models attribution (`agent_runs`, `actions.agent_id`), but no request ever carried an agent identity, so the proxy could never fill it. This puts the id on every request so attribution is guaranteed present from CLI callers once the database wiring lands (which stays its own change, per the field guide). The server remains permissive: a request without `agent` is the schema's unattributed manual use (null `agent_id`), e.g. raw curl.

## Verification

Per the [philosophy](field-guide/philosophy.md) (no test-first, verify by running the real thing), the CLI was run against a throwaway stub server that records every request:

- missing `--agent-id`, empty value, and flag-without-command each print usage and exit `2` with no request sent
- `start` body carries `agent` (and still omits `disk` when not given), `get-image` carries the query param, `send-keys` carries the body field
- `npm run lint` clean, `npm test` 28/28 pass

Field guide updated: `cli.md` (usage, required flag, exit codes, reading-the-file), `http-api.md` (the `agent` field on the three session-driving endpoints, and why `/stop` and `/stats` carry none), and `how-to.md` (all CLI examples lead with the flag).

## Review

GPT-5.6 Sol review pass done per `AGENTS.md`. One finding — the how-to's CLI examples omitted the now-required flag — fixed in the second commit. No other findings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04f75-fc53-722e-970f-17e88ba3b5d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04f75-fc53-722e-970f-17e88ba3b5d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

