### PR TITLE
Log major proxy actions at severity levels with request timing

### DIFF
--- a/drizzle/0002_daffy_juggernaut.sql
+++ b/drizzle/0002_daffy_juggernaut.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."log_level" AS ENUM('info', 'warning', 'error', 'fatal');--> statement-breakpoint
+ALTER TABLE "logs" ADD COLUMN "level" "log_level" DEFAULT 'info' NOT NULL;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,404 @@
+{
+  "id": "01a5e752-95c8-4101-b64d-20853b1a759d",
+  "prevId": "759cc127-d63f-48f0-851b-8e0f377cc451",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "actions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "action_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "actions_session_id_idx": {
+          "name": "actions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_session_id_sessions_id_fk": {
+          "name": "actions_session_id_sessions_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actions_agent_id_agent_runs_agent_id_fk": {
+          "name": "actions_agent_id_agent_runs_agent_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_runs_session_id_idx": {
+          "name": "agent_runs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_session_id_sessions_id_fk": {
+          "name": "agent_runs_session_id_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "images_action_id_actions_id_fk": {
+          "name": "images_action_id_actions_id_fk",
+          "tableFrom": "images",
+          "tableTo": "actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_session_id_idx": {
+          "name": "logs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.action_state": {
+      "name": "action_state",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1788053298435,
       "tag": "0001_logs",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1788096311562,
+      "tag": "0002_daffy_juggernaut",
+      "breakpoints": true
     }
   ]
 }

--- a/field-guide/database.md
+++ b/field-guide/database.md
@@ -1,6 +1,6 @@
 # The control-plane database
 
-One PlanetScale Postgres database holds the record of everything the proxy does. `src/db/schema.ts` defines the five tables (sessions, agent_runs, actions, images, logs); `src/db/ops.ts` is the only code that touches them, except logs, which belongs to `log()` in `src/db/log.ts` — a debug line to stderr and the same line as a row, attributed to a session and an agent when the caller has them, taking the same client. The proxy records through this interface as it runs: the session row lands before any boot work (`downloading` for a url iso), every QMP exchange opens and closes an action row via the recorder hook threaded into the qemu client, a get-image's PNG rides the closing transaction, iso cache traffic goes through `log()`, and `/stop` closes the session with its verdict.
+One PlanetScale Postgres database holds the record of everything the proxy does. `src/db/schema.ts` defines the five tables (sessions, agent_runs, actions, images, logs); `src/db/ops.ts` is the only code that touches them, except logs, which belongs to `log()` in `src/db/log.ts` — a line to stderr and the same line as a row, at a severity level, attributed to a session and an agent when the caller has them, taking the same client. The proxy records through this interface as it runs: the session row lands before any boot work (`downloading` for a url iso), every QMP exchange opens and closes an action row via the recorder hook threaded into the qemu client, a get-image's PNG rides the closing transaction, and `/stop` closes the session with its verdict. Alongside those rows, every major action narrates itself through `log()` — starting, running, image served, chords sent, stopped, shutdown, iso cache traffic — with how long the work took, so the logs alone tell the session's story and the state tables carry the exact records.
 
 ## The state that threads through
 
@@ -27,6 +27,23 @@ An action is one QMP exchange, opened then closed, its id relating the two. `sta
 
 A still-running exchange has no state yet: `state`, `response`, and `finished_at` land together at the close, so a row where they are null is a command whose completion was never persisted — the server died running it, or the closing write failed. `finished_at` comes from the database clock, so handling time is `finished_at - created_at` with no cross-clock arithmetic. Anything that exchanges nothing over QMP (a stop, a verdict) is not an action; the session's status and reason are its record.
 
+## The log stream
+
+`log()` writes one line twice — to stderr, and as a logs row — in call order behind a chain; a failed insert reports itself to stderr and never fails the caller. Every line carries a level, the `log_level` enum, declared in ascending severity so `WHERE level >= 'error'` reads the scary lines:
+
+- **info** — the default, and the normal story: the proxy listening, a session starting / running / stopped, an image served, chords sent, iso cache hits and downloads.
+- **warning** — something was off but the operation went on: a download heartbeat that failed to write, an iso with no published sha256 to check against.
+- **error** — an operation failed: one line per failed request from the HTTP boundary's catch-all, a session that would not stop or record at shutdown.
+- **fatal** — the proxy is going down, written right before the exit: the listen failing at boot (the port is taken).
+
+Levels are severity of the operation, not of the state it records: a `/stop` carrying a `failed` verdict still logs at info — the stop worked; the verdict lives on the session row. For the same reason a failed `/start` is one error line from the boundary, not two: the session row's `failed` status and reason are the attributed record.
+
+Paths that end in `process.exit` — shutdown, a fatal — await `flushLogs()` first, the chain settling, so the last lines are not lost with the process. The db's own write failures (a log insert refused, a "recording the failure failed too") report to stderr only: a database that is not taking writes cannot hold the line saying so.
+
+## Timing
+
+Two clocks, each for what it is good at. Action rows are stamped by the database — `finished_at - created_at` is per-exchange handling time with no cross-clock arithmetic. The proxy's log lines carry request-level wall time measured at the server — `running; started in 45123ms`, `image; 48213 bytes in 87ms`, `sent 6 chords in 412ms` — the numbers the action rows cannot give, because a request spans many exchanges (send-keys) or work that is no exchange at all (a download, a disk create, the boot handshake).
+
 ## Replaying a session
 
-`actions WHERE session_id ORDER BY created_at, id` — the identity id is the tiebreaker when timestamps collide, and `created_at` is when the command went out because the row is inserted at start. `sessions.config` holds the effective launch config (defaults applied), so a replay can boot an identical machine.
+`actions WHERE session_id ORDER BY created_at, id` — the identity id is the tiebreaker when timestamps collide, and `created_at` is when the command went out because the row is inserted at start. `sessions.config` holds the effective launch config (defaults applied), so a replay can boot an identical machine. Debugging one is the same order over logs: `logs WHERE session_id ORDER BY created_at, id` is the session narrated with levels and durations, and the two interleave on `created_at` into the full timeline.

--- a/field-guide/database.md
+++ b/field-guide/database.md
@@ -29,14 +29,14 @@ A still-running exchange has no state yet: `state`, `response`, and `finished_at
 
 ## The log stream
 
-`log()` writes one line twice — to stderr, and as a logs row — in call order behind a chain; a failed insert reports itself to stderr and never fails the caller. Every line carries a level, the `log_level` enum, declared in ascending severity so `WHERE level >= 'error'` reads the scary lines:
+`log()` writes one line twice — to stderr, and as a logs row — in call order behind a chain; a failed insert reports itself to stderr and never fails the caller. The stamp is the database's, taken at the insert: a stalled database lands queued lines late, and id, not `created_at`, is the truth of their order. Every line carries a level, the `log_level` enum, declared in ascending severity so `WHERE level >= 'error'` reads the scary lines:
 
 - **info** — the default, and the normal story: the proxy listening, a session starting / running / stopped, an image served, chords sent, iso cache hits and downloads.
 - **warning** — something was off but the operation went on: a download heartbeat that failed to write, an iso with no published sha256 to check against.
 - **error** — an operation failed: one line per failed request from the HTTP boundary's catch-all, a session that would not stop or record at shutdown.
 - **fatal** — the proxy is going down, written right before the exit: the listen failing at boot (the port is taken).
 
-Levels are severity of the operation, not of the state it records: a `/stop` carrying a `failed` verdict still logs at info — the stop worked; the verdict lives on the session row. For the same reason a failed `/start` is one error line from the boundary, not two: the session row's `failed` status and reason are the attributed record.
+Levels are severity of the operation, not of the state it records: a `/stop` carrying a `failed` verdict still logs at info — the stop worked; the verdict lives on the session row. For the same reason a failed `/start` is one error line from the boundary, not two — attributed to the session and agent as far as the handler got before it threw, with the session row's `failed` status and reason as the state record.
 
 Paths that end in `process.exit` — shutdown, a fatal — await `flushLogs()` first, the chain settling, so the last lines are not lost with the process. The db's own write failures (a log insert refused, a "recording the failure failed too") report to stderr only: a database that is not taking writes cannot hold the line saying so.
 

--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -1,9 +1,11 @@
 // The database logger. log() writes a line to stderr and inserts the same
 // line into the logs table, attributed to a QEMU session and a cloud agent
-// when the caller has them:
+// when the caller has them, at a severity the caller picks (info when it
+// does not say):
 //
 //   log(db, "iso: cache pruned");
 //   log(db, { text: `iso: downloading ${url}`, sessionId, agentId });
+//   log(db, { level: "error", text: `POST /start failed: ${message}` });
 //
 // The db is the one client connectDatabase() built (see ops.ts); this file
 // never touches connection details.
@@ -11,8 +13,16 @@
 import type { Db } from "./ops.ts";
 import { logs } from "./schema.ts";
 
+// Ascending severity, matching the log_level enum's declaration order.
+// info: the normal story. warning: something was off but the operation
+// went on. error: an operation failed. fatal: the process is going down —
+// the writer exits right after flushLogs().
+export type LogLevel = "info" | "warning" | "error" | "fatal";
+
 export type LogEntry = {
   text: string;
+  /** Severity of the line; omitted means info. */
+  level?: LogLevel;
   /** The QEMU session the line belongs to. */
   sessionId?: string;
   /** The cloud agent the line is attributed to. */
@@ -26,7 +36,9 @@ let chain: Promise<void> = Promise.resolve();
 
 export function log(db: Db, entry: string | LogEntry): void {
   const line: LogEntry = typeof entry === "string" ? { text: entry } : entry;
-  console.error(line.text);
+  // info stays bare on stderr — it is the default story; the levels worth
+  // noticing carry their name.
+  console.error(line.level === undefined || line.level === "info" ? line.text : `${line.level}: ${line.text}`);
   chain = chain.then(async () => {
     try {
       await db.insert(logs).values(line);
@@ -37,4 +49,14 @@ export function log(db: Db, entry: string | LogEntry): void {
       console.error(`db: log insert failed: ${e.cause instanceof Error ? e.cause.message : e.message}`);
     }
   });
+}
+
+/**
+ * Settles once every line queued so far has been written (or reported its
+ * failure to stderr). For paths that end in process.exit — a plain exit
+ * would drop the queued rows. Never rejects: every link in the chain
+ * catches its own failure.
+ */
+export function flushLogs(): Promise<void> {
+  return chain;
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,8 +2,8 @@
 //
 // Five tables: sessions (one row per QEMU boot), agent_runs (which cloud
 // agents drove it), actions (every QMP exchange, in order), images (the
-// PNG each get-image returned), and logs (debug lines from db.log, each
-// pinned to a session and an agent when the writer had them).
+// PNG each get-image returned), and logs (lines from db.log at a severity
+// level, each pinned to a session and an agent when the writer had them).
 //
 // Replaying a session is: actions WHERE session_id ORDER BY created_at, id.
 // Debugging one is that plus: logs WHERE session_id, same order.
@@ -16,6 +16,10 @@ const bytea = customType<{ data: Buffer }>({ dataType: () => "bytea" });
 // downloading = the ISO is being fetched from the internet; the session
 // exists but QEMU has not booted yet.
 export const sessionStatus = pgEnum("session_status", ["downloading", "running", "succeeded", "failed", "aborted"]);
+// Declared in ascending severity: Postgres orders enums by declaration, so
+// "WHERE level >= 'error'" reads the scary lines. fatal is the line written
+// on the way down — the process exits right after it.
+export const logLevel = pgEnum("log_level", ["info", "warning", "error", "fatal"]);
 // The only two states an exchange can finish in. An action that is still
 // running has no state yet (null, alongside a null finished_at).
 export const actionState = pgEnum("action_state", ["completed", "failed"]);
@@ -102,6 +106,9 @@ export const logs = pgTable(
     sessionId: uuid("session_id"),
     // The cloud agent the line is attributed to; null when none was involved.
     agentId: text("agent_id"),
+    // Severity, defaulting to info: most lines are the normal story, and a
+    // writer should not have to say so (see log.ts for what each level means).
+    level: logLevel("level").notNull().default("info"),
     text: text("text").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/src/qemu/iso.ts
+++ b/src/qemu/iso.ts
@@ -148,7 +148,7 @@ async function download(db: Db, url: string, file: string, path: string, who: Wh
           if (Date.now() - beatAt >= HEARTBEAT_MS) {
             beatAt = Date.now();
             updateManifest(file, "downloading").catch((err: unknown) => {
-              log(db, { text: `iso: heartbeat failed: ${(err as Error).message}`, ...who });
+              log(db, { level: "warning", text: `iso: heartbeat failed: ${(err as Error).message}`, ...who });
             });
           }
           yield chunk;
@@ -159,7 +159,7 @@ async function download(db: Db, url: string, file: string, path: string, who: Wh
     const digest = hash.digest("hex");
     const published = await publishedSha256(url);
     if (published === undefined) {
-      log(db, { text: `iso: no ${url}.sha256 published; skipping the checksum check`, ...who });
+      log(db, { level: "warning", text: `iso: no ${url}.sha256 published; skipping the checksum check`, ...who });
     } else if (published !== digest) {
       throw new Error(`iso: sha256 mismatch: ${url}: published ${published}, downloaded ${digest}`);
     }

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -7,7 +7,9 @@
 // OLIGARCHY_ADDR (default 127.0.0.1:42069). The control-plane database comes
 // from DATABASE_URL — a proxy that cannot record its sessions refuses to
 // boot, and every session, QMP exchange, image, and iso event is recorded
-// as it happens (see field-guide/database.md).
+// as it happens. Major actions also land in the logs table through log():
+// the lifecycle at info with how long each took, failed requests at error,
+// the death of the proxy at fatal (see field-guide/database.md).
 //
 //   POST /start      -> {"iso"?, "disk"?, "agent"?}; boots a qemu, returns
 //                       {"id": uuid}; an http(s) iso is downloaded into
@@ -24,6 +26,7 @@
 import { createServer, type IncomingMessage } from "node:http";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
+import { flushLogs, log } from "../db/log.ts";
 import { connectDatabase, endSession, finishAction, insertSession, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
 import { createDisk, createQemu, screendump, sendKey, start, stop, type Qemu } from "./client.ts";
 import { getIso } from "./iso.ts";
@@ -60,6 +63,7 @@ createServer(async (req, res) => {
     const url = new URL(req.url ?? "/", `http://${addr}`);
 
     if (req.method === "POST" && url.pathname === "/start") {
+      const started = Date.now();
       const raw = await body(req);
       const cfg = (raw === "" ? {} : JSON.parse(raw)) as { iso?: string; disk?: string; agent?: string };
       const isoName = cfg.iso ?? defaultIso;
@@ -69,6 +73,11 @@ createServer(async (req, res) => {
       // session to hang on: a url iso enters as "downloading", a local path
       // goes straight to "running".
       await insertSession(db, qemu.id, { iso: isoName, disk: cfg.disk }, isUrl ? "downloading" : "running");
+      log(db, {
+        text: `session ${qemu.id}: starting; iso ${isoName}${cfg.disk === undefined ? "" : `, disk ${cfg.disk}`}`,
+        sessionId: qemu.id,
+        agentId: cfg.agent,
+      });
       try {
         // Inside the try: a rejected registration (the agent already drives
         // a session) must close this session as failed, not leave it open.
@@ -98,12 +107,16 @@ createServer(async (req, res) => {
         throw err;
       }
       sessions.set(qemu.id, qemu);
+      // Wall time from request to a live QMP handshake, download included —
+      // per-exchange timing lives on the action rows.
+      log(db, { text: `session ${qemu.id}: running; started in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: cfg.agent });
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ id: qemu.id }));
       return;
     }
 
     if (req.method === "GET" && url.pathname === "/image") {
+      const started = Date.now();
       const qemu = session(url.searchParams.get("id"));
       const agent = url.searchParams.get("agent") ?? undefined;
       const path = join(qemu.dir, `image-${process.hrtime.bigint()}.png`);
@@ -122,6 +135,7 @@ createServer(async (req, res) => {
         const data = await readFile(path);
         // screendump resolved, so the recorder ran: opened and outcome are set.
         await finishAction(db, opened!, outcome!, data);
+        log(db, { text: `session ${qemu.id}: image; ${data.length} bytes in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: agent });
         res.writeHead(200, { "Content-Type": "image/png", "Content-Length": data.length });
         res.end(data);
       } catch (err) {
@@ -164,6 +178,10 @@ createServer(async (req, res) => {
       await stop(qemu);
       // The stop ends the session; a stop without a verdict is an abort.
       await endSession(db, qemu.id, status ?? "aborted", reason ?? null);
+      log(db, {
+        text: `session ${qemu.id}: stopped; ${status ?? "aborted"}${reason === undefined ? "" : `; ${reason}`}`,
+        sessionId: qemu.id,
+      });
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: "true" }));
       return;
@@ -176,11 +194,16 @@ createServer(async (req, res) => {
         encoding?: string;
         agent?: string;
       };
+      const started = Date.now();
       const qemu = session(id);
       const record = recorder(qemu.id, agent);
-      for (const chord of parseKeys(keys, encoding)) {
+      const chords = parseKeys(keys, encoding);
+      for (const chord of chords) {
         await sendKey(qemu, chord.map((code): QemuKeyValue => ({ type: "qcode", data: code })), record);
       }
+      // The request-level story; each chord is its own action row with its
+      // own timing.
+      log(db, { text: `session ${qemu.id}: sent ${chords.length} chords in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: agent });
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: "true" }));
       return;
@@ -189,28 +212,44 @@ createServer(async (req, res) => {
     res.writeHead(404, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "not found" }));
   } catch (err) {
+    // One error line per failed request. Session attribution lives where
+    // the detail does: a failed start on the session row's reason, a failed
+    // exchange on its action row.
+    log(db, { level: "error", text: `${req.method ?? ""} ${req.url ?? "/"} failed: ${(err as Error).message}` });
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: (err as Error).message }));
   }
-}).listen(Number(port), host, () => {
-  console.error(`oligarchy proxy listening on ${addr}`);
-});
+})
+  .on("error", (err) => {
+    // The listen failing (the port is taken) or the acceptor breaking is
+    // the death of the proxy: say so, get the line out, and go down.
+    log(db, { level: "fatal", text: `proxy: ${err.message}` });
+    void flushLogs().then(() => process.exit(1));
+  })
+  .listen(Number(port), host, () => {
+    log(db, `oligarchy proxy listening on ${addr}`);
+  });
 
 for (const signal of ["SIGINT", "SIGTERM"] as const) {
   process.once(signal, () => {
+    log(db, `proxy: ${signal}; stopping ${sessions.size} sessions`);
     // Settled, not raced: one session failing to stop or record must not
     // cut short the cleanup of the others.
     void Promise.allSettled(
       [...sessions.values()].map(async (qemu) => {
         await stop(qemu);
         await endSession(db, qemu.id, "aborted", "proxy shutdown");
+        log(db, { text: `session ${qemu.id}: stopped; aborted; proxy shutdown`, sessionId: qemu.id });
       }),
-    ).then((results) => {
+    ).then(async (results) => {
       for (const result of results) {
         if (result.status === "rejected") {
-          console.error(`shutdown: ${(result.reason as Error).message}`);
+          log(db, { level: "error", text: `shutdown: ${(result.reason as Error).message}` });
         }
       }
+      // The exit must not outrun the queued rows — the shutdown story is
+      // the part most worth having when the proxy is gone.
+      await flushLogs();
       process.exit(results.some((result) => result.status === "rejected") ? 1 : 0);
     });
   });

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -59,6 +59,10 @@ function recorder(sessionId: string, agentId: string | undefined): QemuExchangeR
 
 const [host, port] = addr.split(":");
 createServer(async (req, res) => {
+  // Filled in as the handler learns them, so the catch can attribute the
+  // failure line to the session and agent the request was about.
+  let sessionId: string | undefined;
+  let agentId: string | undefined;
   try {
     const url = new URL(req.url ?? "/", `http://${addr}`);
 
@@ -69,6 +73,8 @@ createServer(async (req, res) => {
       const isoName = cfg.iso ?? defaultIso;
       const isUrl = isoName.startsWith("http://") || isoName.startsWith("https://");
       const qemu = createQemu();
+      sessionId = qemu.id;
+      agentId = cfg.agent;
       // The session row exists before any boot work, so iso events have a
       // session to hang on: a url iso enters as "downloading", a local path
       // goes straight to "running".
@@ -119,6 +125,8 @@ createServer(async (req, res) => {
       const started = Date.now();
       const qemu = session(url.searchParams.get("id"));
       const agent = url.searchParams.get("agent") ?? undefined;
+      sessionId = qemu.id;
+      agentId = agent;
       const path = join(qemu.dir, `image-${process.hrtime.bigint()}.png`);
       // The PNG is read back only after the exchange closes, and the images
       // row must ride the same transaction that closes the action (they are
@@ -174,6 +182,7 @@ createServer(async (req, res) => {
         throw new Error(`unknown status "${status as string}"`);
       }
       const qemu = session(id);
+      sessionId = qemu.id;
       sessions.delete(qemu.id);
       await stop(qemu);
       // The stop ends the session; a stop without a verdict is an abort.
@@ -188,14 +197,16 @@ createServer(async (req, res) => {
     }
 
     if (req.method === "POST" && url.pathname === "/send-keys") {
+      const started = Date.now();
       const { id, keys, encoding, agent } = JSON.parse(await body(req)) as {
         id?: string;
         keys: string;
         encoding?: string;
         agent?: string;
       };
-      const started = Date.now();
+      agentId = agent;
       const qemu = session(id);
+      sessionId = qemu.id;
       const record = recorder(qemu.id, agent);
       const chords = parseKeys(keys, encoding);
       for (const chord of chords) {
@@ -212,10 +223,9 @@ createServer(async (req, res) => {
     res.writeHead(404, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "not found" }));
   } catch (err) {
-    // One error line per failed request. Session attribution lives where
-    // the detail does: a failed start on the session row's reason, a failed
-    // exchange on its action row.
-    log(db, { level: "error", text: `${req.method ?? ""} ${req.url ?? "/"} failed: ${(err as Error).message}` });
+    // One error line per failed request, attributed as far as the handler
+    // got before it threw.
+    log(db, { level: "error", text: `${req.method ?? ""} ${req.url ?? "/"} failed: ${(err as Error).message}`, sessionId, agentId });
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: (err as Error).message }));
   }
@@ -237,16 +247,18 @@ for (const signal of ["SIGINT", "SIGTERM"] as const) {
     // cut short the cleanup of the others.
     void Promise.allSettled(
       [...sessions.values()].map(async (qemu) => {
-        await stop(qemu);
-        await endSession(db, qemu.id, "aborted", "proxy shutdown");
-        log(db, { text: `session ${qemu.id}: stopped; aborted; proxy shutdown`, sessionId: qemu.id });
+        try {
+          await stop(qemu);
+          await endSession(db, qemu.id, "aborted", "proxy shutdown");
+          log(db, { text: `session ${qemu.id}: stopped; aborted; proxy shutdown`, sessionId: qemu.id });
+        } catch (err) {
+          // Logged here, where the session is known — the sessions that
+          // fail are the ones whose absence from the story matters most.
+          log(db, { level: "error", text: `shutdown: session ${qemu.id}: ${(err as Error).message}`, sessionId: qemu.id });
+          throw err;
+        }
       }),
     ).then(async (results) => {
-      for (const result of results) {
-        if (result.status === "rejected") {
-          log(db, { level: "error", text: `shutdown: ${(result.reason as Error).message}` });
-        }
-      }
       // The exit must not outrun the queued rows — the shutdown story is
       // the part most worth having when the proxy is gone.
       await flushLogs();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Ties the two database aspects — the action/session recording in `src/db/ops.ts` and the log stream in `src/db/log.ts` — into one full-insight record.

- **`logs.level` column** (`log_level` enum: `info`, `warning`, `error`, `fatal`, declared in ascending severity so `WHERE level >= 'error'` reads the scary lines), generated migration `drizzle/0002_daffy_juggernaut.sql`, default `info`.
- **`log()`** takes an optional `level` per line; non-info lines carry their level on stderr (`error: POST /start failed: …`). New `flushLogs()` settles the insert chain so exit paths cannot drop queued rows.
- **The proxy narrates every major action** with request-level wall time: `starting` / `running; started in Xms` (download included), `image; N bytes in Xms`, `sent N chords in Xms`, `stopped; verdict`, the shutdown story per session, and the listening line — all attributed to session and agent where known. Per-exchange timing stays on the action rows (`finished_at - created_at`), untouched.
- **Errors**: one `error` line per failed request from the HTTP boundary catch-all, attributed as far as the handler got before it threw; `warning` for the iso oddities (failed heartbeat, missing sha256 sidecar); `fatal` right before the exit when the listen fails (EADDRINUSE previously crashed with a raw stack and no record).
- **`field-guide/database.md`** documents the levels, the timing split between the two clocks, and the debugging query (`logs WHERE session_id` interleaved with actions on `created_at`).

## Review (GPT-5.6 Sol, per AGENTS.md)

Three findings accepted: boundary error lines now carry session/agent attribution; shutdown failures log inside the per-session cleanup where the session is known; `/send-keys` starts its clock before the body read like `/start`. One declined with reason: stamping `created_at` at `log()` call time would put logs on the server clock while every other table uses the database clock — the cross-clock arithmetic this schema deliberately avoids; the doc now states that `id`, not `created_at`, orders a backed-up chain.

## Verification

Ran the real thing against a local Postgres with all three migrations applied — the listening line, an attributed failed `/start` (one boundary error line + the session row `failed` with the same reason), a failed `/send-keys` carrying its agent, EADDRINUSE fatal flushed before `exit 1`, SIGINT shutdown flushed before `exit 0`:

```
 id | level | session  |   agent   | text
----+-------+----------+-----------+---------------------------------------------------------------
  7 | info  | -        | -         | oligarchy proxy listening on 127.0.0.1:42069
  8 | info  | f50dd48e | bc-test-2 | session f50dd48e-…: starting; iso /tmp/fake.iso
  9 | error | f50dd48e | bc-test-2 | POST /start failed: spawn qemu-img ENOENT
 10 | error | -        | bc-test-2 | POST /send-keys failed: unknown session "nope"
 11 | info  | -        | -         | proxy: SIGINT; stopping 0 sessions
```

Lint (type-aware) clean, all 28 existing tests pass, migration generated via `npm run db:generate` (append-only respected). The happy-path boot lines need a QEMU+KVM host; they use the same `log()` mechanism proven above.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a052d2-775e-7558-9dbd-ef32730cc77b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a052d2-775e-7558-9dbd-ef32730cc77b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

