### PR TITLE
Effect 4 HTTP layer on the proxy

### DIFF
--- a/field-guide/http-api.md
+++ b/field-guide/http-api.md
@@ -4,19 +4,19 @@ The control plane spoken between the CLI and the proxy (`src/qemu/proxy.ts`).
 
 The proxy defaults to `127.0.0.1:42069`. Bodies are JSON except the PNG. Errors are `4xx`/`5xx` with `{"error": "<message>"}`.
 
-Session-driving requests (`/start`, `/image`, `/send-keys`) carry the calling agent's id — `agent` in the POST body, a query param on the GET — so the server attributes the session's [actions](database.md) to that agent. The CLI always sends it; a request without one is unattributed manual use (the schema's null `agent_id`). `/stop` carries none because a stop exchanges nothing over QMP and is not an action — it carries the session's verdict instead; `/stats` has no session at all.
+`/start` always names the calling agent — `agent` in the POST body. There is no unattributed start: a session is born with both its uuid and that agent. `/image` and `/send-keys` still take `agent` (query param on the GET, body on the POST) so later actions can be attributed; a request without one is unattributed manual use (the schema's null `agent_id`). `/stop` carries none because a stop exchanges nothing over QMP and is not an action — it carries the session's verdict instead; `/stats` has no session at all.
 
 ## POST /start
 
 Boots a QEMU session. Returns `{"id": "<uuid>"}`.
 
-The body is JSON with three keys, all optional (an empty body works too):
+The body is JSON. `agent` is required (an empty body is a usage error). `iso` and `disk` are optional:
 
+- `agent` — the calling agent's id. Manual use fakes one. There is no start without it.
 - `iso` — guest ISO path or http(s) url. Defaults to the proxy's own default ISO (its argv, or `OLIGARCHY_ISO`).
 - `disk` — qcow2 path, which must already exist. When the key is **absent**, the proxy creates a fresh disk (40G virtual) in the session dir.
-- `agent` — the calling agent's id, for attribution. Absent means unattributed manual use.
 
-Clients that want the server-managed disk must therefore omit the key, not send `""`. The CLI does this; keep it that way.
+The session row and the agent_runs row are written together at the start of `/start`, before any boot work. Those writes are not operational errors — if either fails, the start dies. Clients that want the server-managed disk must omit the `disk` key, not send `""`. The CLI does this; keep it that way.
 
 A url iso is downloaded into `~/.oligarchy/isos` on first use — verified against the publisher's `<url>.sha256` sidecar when one is published — and served from that cache on every later start. The cache file is the url with `:`, `/`, and every other character a file name cannot hold replaced by `_`. A `manifest.json` beside the isos records each entry's status: while a download runs, a claim whose heartbeat advances as bytes flow; once cached, when it was cached and last used, so the cache can be pruned by size later. A start that finds a live claim — another proxy mid-download — waits and rechecks every ten seconds instead of downloading the same iso twice; a claim gone three beats stale is a dead downloader, and the start takes the download over.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
       "name": "oligarchy",
       "dependencies": {
         "@cursor/sdk": "^1.0.30",
+        "@effect/platform-node": "^4.0.0-rc.112",
         "drizzle-orm": "^0.45.2",
+        "effect": "^4.0.0-rc.112",
         "pg": "^8.23.0"
       },
       "devDependencies": {
@@ -170,6 +172,49 @@
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@effect/platform-node": {
+      "version": "4.0.0-rc.112",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node/-/platform-node-4.0.0-rc.112.tgz",
+      "integrity": "sha512-/BMAcdNGQQskLmI0Zoa95KfTZkr9HV9N4NSxaSrusG6GeW6Ulp9KvZ+Rlaiw8lnOt43CXjFLdfll5/k5rxL4hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@effect/platform-node-shared": "^4.0.0-rc.112",
+        "mime": "^4.1.0",
+        "undici": "^8.10.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "effect": "^4.0.0-rc.112",
+        "redis": ">=5.0.0 <7.0.0"
+      }
+    },
+    "node_modules/@effect/platform-node-shared": {
+      "version": "4.0.0-rc.112",
+      "resolved": "https://registry.npmjs.org/@effect/platform-node-shared/-/platform-node-shared-4.0.0-rc.112.tgz",
+      "integrity": "sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.18.1",
+        "ws": "^8.21.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "effect": "^4.0.0-rc.112"
+      }
+    },
+    "node_modules/@effect/platform-node/node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -1058,6 +1103,84 @@
         "node": ">=14"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@oxlint-tsgolint/darwin-arm64": {
       "version": "7.0.2001",
       "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-7.0.2001.tgz",
@@ -1465,6 +1588,83 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-6.2.1.tgz",
+      "integrity": "sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.2.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.2.1.tgz",
+      "integrity": "sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-6.2.1.tgz",
+      "integrity": "sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.2.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-6.2.1.tgz",
+      "integrity": "sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.2.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-6.2.1.tgz",
+      "integrity": "sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^6.2.1"
+      }
+    },
     "node_modules/@statsig/client-core": {
       "version": "3.31.0",
       "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
@@ -1484,7 +1684,6 @@
       "version": "26.4.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
       "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -1500,6 +1699,15 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -1849,6 +2057,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/drizzle-kit": {
       "version": "0.31.10",
       "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
@@ -1990,6 +2218,16 @@
         }
       }
     },
+    "node_modules/effect": {
+      "version": "4.0.0-rc.112",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-rc.112.tgz",
+      "integrity": "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-check": "^4.9.0",
+        "msgpackr": "^2.0.5"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -2032,6 +2270,28 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2058,6 +2318,67 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/mime": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
+      "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
+      "bin": {
+        "mime": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/msgpackr": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.1.0.tgz",
+      "integrity": "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/oxlint": {
@@ -2253,6 +2574,39 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/redis": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-6.2.1.tgz",
+      "integrity": "sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@redis/bloom": "6.2.1",
+        "@redis/client": "6.2.1",
+        "@redis/json": "6.2.1",
+        "@redis/search": "6.2.1",
+        "@redis/time-series": "6.2.1"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2849,8 +3203,28 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "dependencies": {
     "@cursor/sdk": "^1.0.30",
+    "@effect/platform-node": "^4.0.0-rc.112",
     "drizzle-orm": "^0.45.2",
+    "effect": "^4.0.0-rc.112",
     "pg": "^8.23.0"
   }
 }

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -147,11 +147,13 @@ const startSession = Effect.gen(function* () {
   // (no db refactor) but they are not operational errors: if either
   // fails, something is very wrong and the start dies.
   yield* Effect.orDie(
-    Effect.tryPromise(() =>
-      insertSession(db, qemu.id, { iso: isoName, disk: cfg.disk }, isUrl ? "downloading" : "running").then(() =>
-        registerAgent(db, agent, qemu.id),
-      ),
-    ),
+    Effect.tryPromise({
+      try: () =>
+        insertSession(db, qemu.id, { iso: isoName, disk: cfg.disk }, isUrl ? "downloading" : "running").then(() =>
+          registerAgent(db, agent, qemu.id),
+        ),
+      catch: opError,
+    }),
   );
   yield* fromPromise(async () => {
     try {

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -13,7 +13,7 @@
 // qemu, iso, keys, and db stay Promise/throw code; this file lifts them at
 // the edge with tryPromise and turns every failure into {"error": "..."}.
 //
-//   POST /start      -> {"iso"?, "disk"?, "agent"?}; boots a qemu, returns
+//   POST /start      -> {"agent", "iso"?, "disk"?}; boots a qemu, returns
 //                       {"id": uuid}; an http(s) iso is downloaded into
 //                       ~/.oligarchy/isos once (a start that finds a running
 //                       download waits for it) and reused from there on
@@ -136,21 +136,26 @@ function session(id: string | null | undefined): Qemu {
 
 const startSession = Effect.gen(function* () {
   const cfg = yield* readJson(StartBody);
+  if (cfg.agent === undefined || cfg.agent === "") {
+    return yield* Effect.fail(opError(new Error("agent is required")));
+  }
+  const agent = cfg.agent;
   const isoName = cfg.iso ?? defaultIso;
   const isUrl = isoName.startsWith("http://") || isoName.startsWith("https://");
   const qemu = createQemu();
-  // The session row exists before any boot work, so iso events have a
-  // session to hang on: a url iso enters as "downloading", a local path
-  // goes straight to "running".
-  yield* fromPromise(() => insertSession(db, qemu.id, { iso: isoName, disk: cfg.disk }, isUrl ? "downloading" : "running"));
+  // Session + agent are one initialization. The two writes stay separate
+  // (no db refactor) but they are not operational errors: if either
+  // fails, something is very wrong and the start dies.
+  yield* Effect.orDie(
+    Effect.tryPromise(() =>
+      insertSession(db, qemu.id, { iso: isoName, disk: cfg.disk }, isUrl ? "downloading" : "running").then(() =>
+        registerAgent(db, agent, qemu.id),
+      ),
+    ),
+  );
   yield* fromPromise(async () => {
     try {
-      // Inside the try: a rejected registration (the agent already drives
-      // a session) must close this session as failed, not leave it open.
-      if (cfg.agent !== undefined) {
-        await registerAgent(db, cfg.agent, qemu.id);
-      }
-      const iso = await getIso(db, isoName, { sessionId: qemu.id, agentId: cfg.agent });
+      const iso = await getIso(db, isoName, { sessionId: qemu.id, agentId: agent });
       if (cfg.disk === undefined) {
         await createDisk(qemu);
       } else {
@@ -158,7 +163,7 @@ const startSession = Effect.gen(function* () {
         // dir; with a caller-provided disk, createDisk never made it.
         await mkdir(qemu.dir, { recursive: true, mode: 0o700 });
       }
-      await start(qemu, { iso, disk: cfg.disk }, recorder(qemu.id, cfg.agent));
+      await start(qemu, { iso, disk: cfg.disk }, recorder(qemu.id, agent));
       if (isUrl) {
         await sessionRunning(db, qemu.id);
       }
@@ -245,17 +250,17 @@ const sendKeys = Effect.gen(function* () {
   return HttpServerResponse.jsonUnsafe({ ok: "true" });
 });
 
-function clientResponse(err: unknown): HttpServerResponse.HttpServerResponse {
-  const status = errorMessage(err) === "not found" ? 404 : 400;
+function clientResponse(err: unknown, status: number): HttpServerResponse.HttpServerResponse {
   return HttpServerResponse.jsonUnsafe({ error: errorMessage(err) }, { status });
 }
 
 function fromCause<E>(cause: Cause.Cause<E>): HttpServerResponse.HttpServerResponse {
   const failed = Option.getOrUndefined(Cause.findErrorOption(cause));
   if (failed !== undefined) {
-    return clientResponse(failed);
+    return clientResponse(failed, errorMessage(failed) === "not found" ? 404 : 400);
   }
-  return clientResponse(Cause.squash(cause));
+  // Die: session init, or anything else that is not an operational fail.
+  return clientResponse(Cause.squash(cause), 500);
 }
 
 // Handler errors become the {"error": "..."} the CLI already prints.

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -9,6 +9,10 @@
 // boot, and every session, QMP exchange, image, and iso event is recorded
 // as it happens (see field-guide/database.md).
 //
+// HTTP is Effect 4's HttpRouter (effect/unstable/http) on NodeHttpServer.
+// qemu, iso, keys, and db stay Promise/throw code; this file lifts them at
+// the edge with tryPromise and turns every failure into {"error": "..."}.
+//
 //   POST /start      -> {"iso"?, "disk"?, "agent"?}; boots a qemu, returns
 //                       {"id": uuid}; an http(s) iso is downloaded into
 //                       ~/.oligarchy/isos once (a start that finds a running
@@ -21,9 +25,12 @@
 //                       its session dir, and records the verdict (default
 //                       aborted)
 
-import { createServer, type IncomingMessage } from "node:http";
 import { mkdir, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
 import { join } from "node:path";
+import { NodeHttpServer, NodeRuntime } from "@effect/platform-node";
+import { Cause, Effect, Layer, Option, Schema } from "effect";
+import { HttpRouter, HttpServerError, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { connectDatabase, endSession, finishAction, insertSession, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
 import { createDisk, createQemu, screendump, sendKey, start, stop, type Qemu } from "./client.ts";
 import { getIso } from "./iso.ts";
@@ -36,6 +43,7 @@ if (defaultIso === undefined) {
   process.exit(1);
 }
 const addr = process.env.OLIGARCHY_ADDR ?? "127.0.0.1:42069";
+const [host, port] = addr.split(":");
 
 // A control plane that cannot record its sessions must not boot.
 const db = connectDatabase();
@@ -54,165 +62,71 @@ function recorder(sessionId: string, agentId: string | undefined): QemuExchangeR
   };
 }
 
-const [host, port] = addr.split(":");
-createServer(async (req, res) => {
-  try {
-    const url = new URL(req.url ?? "/", `http://${addr}`);
+// The HTTP layer's only error: a sentence the client can print. qemu / iso /
+// db still throw Error; we lift the message here and never let an unknown
+// value become {"error": undefined}.
+const OpError = Schema.Struct({
+  _tag: Schema.tag("OpError"),
+  message: Schema.String,
+});
+type OpError = typeof OpError.Type;
 
-    if (req.method === "POST" && url.pathname === "/start") {
-      const raw = await body(req);
-      const cfg = (raw === "" ? {} : JSON.parse(raw)) as { iso?: string; disk?: string; agent?: string };
-      const isoName = cfg.iso ?? defaultIso;
-      const isUrl = isoName.startsWith("http://") || isoName.startsWith("https://");
-      const qemu = createQemu();
-      // The session row exists before any boot work, so iso events have a
-      // session to hang on: a url iso enters as "downloading", a local path
-      // goes straight to "running".
-      await insertSession(db, qemu.id, { iso: isoName, disk: cfg.disk }, isUrl ? "downloading" : "running");
-      try {
-        // Inside the try: a rejected registration (the agent already drives
-        // a session) must close this session as failed, not leave it open.
-        if (cfg.agent !== undefined) {
-          await registerAgent(db, cfg.agent, qemu.id);
-        }
-        const iso = await getIso(db, isoName, { sessionId: qemu.id, agentId: cfg.agent });
-        if (cfg.disk === undefined) {
-          await createDisk(qemu);
-        } else {
-          // start() puts the firmware copy and the QMP socket in the session
-          // dir; with a caller-provided disk, createDisk never made it.
-          await mkdir(qemu.dir, { recursive: true, mode: 0o700 });
-        }
-        await start(qemu, { iso, disk: cfg.disk }, recorder(qemu.id, cfg.agent));
-        if (isUrl) {
-          await sessionRunning(db, qemu.id);
-        }
-      } catch (err) {
-        // The qemu must not outlive its failed start — a machine the map
-        // never held would be unreachable and unkillable through the API.
-        // The boot error is the one worth seeing if cleanup fails too.
-        await stop(qemu).catch(() => {});
-        await endSession(db, qemu.id, "failed", (err as Error).message).catch((e: unknown) => {
-          console.error(`db: recording a failed start failed too: ${(e as Error).message}`);
-        });
-        throw err;
-      }
-      sessions.set(qemu.id, qemu);
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ id: qemu.id }));
-      return;
-    }
-
-    if (req.method === "GET" && url.pathname === "/image") {
-      const qemu = session(url.searchParams.get("id"));
-      const agent = url.searchParams.get("agent") ?? undefined;
-      const path = join(qemu.dir, `image-${process.hrtime.bigint()}.png`);
-      // The PNG is read back only after the exchange closes, and the images
-      // row must ride the same transaction that closes the action (they are
-      // 1:1) — so the recorder only stashes, and the handler closes.
-      let opened: number | undefined;
-      let outcome: QemuExchangeOutcome | undefined;
-      try {
-        await screendump(qemu, path, "png", async (command) => {
-          opened = await startAction(db, { sessionId: qemu.id, agentId: agent, request: command });
-          return async (result) => {
-            outcome = result;
-          };
-        });
-        const data = await readFile(path);
-        // screendump resolved, so the recorder ran: opened and outcome are set.
-        await finishAction(db, opened!, outcome!, data);
-        res.writeHead(200, { "Content-Type": "image/png", "Content-Length": data.length });
-        res.end(data);
-      } catch (err) {
-        // Only a failed exchange is closed without an image. A completed one
-        // whose image write failed stays open — the row state database.md
-        // documents as a completion that was never persisted; closing it
-        // imageless would break the 1:1 promise instead.
-        if (opened !== undefined && outcome !== undefined && outcome.state === "failed") {
-          await finishAction(db, opened, outcome).catch((e: unknown) => {
-            console.error(`db: recording a failed screendump failed too: ${(e as Error).message}`);
-          });
-        }
-        throw err;
-      } finally {
-        await rm(path, { force: true });
-      }
-      return;
-    }
-
-    if (req.method === "GET" && url.pathname === "/stats") {
-      const payload = JSON.stringify(collectStats(cpuSampler, sessions.size));
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(payload);
-      return;
-    }
-
-    if (req.method === "POST" && url.pathname === "/stop") {
-      const { id, status, reason } = JSON.parse(await body(req)) as {
-        id?: string;
-        status?: "succeeded" | "failed" | "aborted";
-        reason?: string;
-      };
-      // The verdict is checked before the machine dies: a bad status must
-      // not kill the qemu and then fail to record the end.
-      if (status !== undefined && status !== "succeeded" && status !== "failed" && status !== "aborted") {
-        throw new Error(`unknown status "${status as string}"`);
-      }
-      const qemu = session(id);
-      sessions.delete(qemu.id);
-      await stop(qemu);
-      // The stop ends the session; a stop without a verdict is an abort.
-      await endSession(db, qemu.id, status ?? "aborted", reason ?? null);
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: "true" }));
-      return;
-    }
-
-    if (req.method === "POST" && url.pathname === "/send-keys") {
-      const { id, keys, encoding, agent } = JSON.parse(await body(req)) as {
-        id?: string;
-        keys: string;
-        encoding?: string;
-        agent?: string;
-      };
-      const qemu = session(id);
-      const record = recorder(qemu.id, agent);
-      for (const chord of parseKeys(keys, encoding)) {
-        await sendKey(qemu, chord.map((code): QemuKeyValue => ({ type: "qcode", data: code })), record);
-      }
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: "true" }));
-      return;
-    }
-
-    res.writeHead(404, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "not found" }));
-  } catch (err) {
-    res.writeHead(400, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: (err as Error).message }));
+function errorMessage(err: unknown): string {
+  if (HttpServerError.isHttpServerError(err) && err.reason._tag === "RouteNotFound") {
+    return "not found";
   }
-}).listen(Number(port), host, () => {
-  console.error(`oligarchy proxy listening on ${addr}`);
+  if (typeof err === "object" && err !== null && "_tag" in err && err._tag === "RouteNotFound") {
+    return "not found";
+  }
+  if (typeof err === "object" && err !== null && "message" in err && typeof err.message === "string" && err.message !== "") {
+    return err.message;
+  }
+  const e = err as Error;
+  return e.cause instanceof Error ? `${e.message}: ${e.cause.message}` : String(e.message ?? err);
+}
+
+function opError(err: unknown): OpError {
+  return OpError.make({ message: errorMessage(err) });
+}
+
+function fromPromise<A>(f: (signal: AbortSignal) => Promise<A>): Effect.Effect<A, OpError> {
+  return Effect.tryPromise({ try: f, catch: opError });
+}
+
+function fromSync<A>(f: () => A): Effect.Effect<A, OpError> {
+  return Effect.try({ try: f, catch: opError });
+}
+
+const StartBody = Schema.Struct({
+  iso: Schema.optionalKey(Schema.String),
+  disk: Schema.optionalKey(Schema.String),
+  agent: Schema.optionalKey(Schema.String),
 });
 
-for (const signal of ["SIGINT", "SIGTERM"] as const) {
-  process.once(signal, () => {
-    // Settled, not raced: one session failing to stop or record must not
-    // cut short the cleanup of the others.
-    void Promise.allSettled(
-      [...sessions.values()].map(async (qemu) => {
-        await stop(qemu);
-        await endSession(db, qemu.id, "aborted", "proxy shutdown");
-      }),
-    ).then((results) => {
-      for (const result of results) {
-        if (result.status === "rejected") {
-          console.error(`shutdown: ${(result.reason as Error).message}`);
-        }
-      }
-      process.exit(results.some((result) => result.status === "rejected") ? 1 : 0);
-    });
+const StopBody = Schema.Struct({
+  id: Schema.optionalKey(Schema.String),
+  status: Schema.optionalKey(Schema.String),
+  reason: Schema.optionalKey(Schema.String),
+});
+
+const SendKeysBody = Schema.Struct({
+  id: Schema.optionalKey(Schema.String),
+  keys: Schema.String,
+  encoding: Schema.optionalKey(Schema.String),
+  agent: Schema.optionalKey(Schema.String),
+});
+
+const ImageQuery = Schema.Struct({
+  id: Schema.optionalKey(Schema.String),
+  agent: Schema.optionalKey(Schema.String),
+});
+
+function readJson<S extends Schema.Top>(schema: S) {
+  return Effect.gen(function* () {
+    const req = yield* HttpServerRequest.HttpServerRequest;
+    const raw = yield* req.text.pipe(Effect.mapError(opError));
+    const value = raw === "" ? {} : yield* fromSync(() => JSON.parse(raw) as unknown);
+    return yield* Schema.decodeUnknownEffect(schema)(value).pipe(Effect.mapError(opError));
   });
 }
 
@@ -227,10 +141,176 @@ function session(id: string | null | undefined): Qemu {
   return qemu;
 }
 
-async function body(req: IncomingMessage): Promise<string> {
-  let out = "";
-  for await (const chunk of req) {
-    out += chunk;
+const startSession = Effect.gen(function* () {
+  const cfg = yield* readJson(StartBody);
+  const isoName = cfg.iso ?? defaultIso;
+  const isUrl = isoName.startsWith("http://") || isoName.startsWith("https://");
+  const qemu = createQemu();
+  // The session row exists before any boot work, so iso events have a
+  // session to hang on: a url iso enters as "downloading", a local path
+  // goes straight to "running".
+  yield* fromPromise(() => insertSession(db, qemu.id, { iso: isoName, disk: cfg.disk }, isUrl ? "downloading" : "running"));
+  yield* fromPromise(async () => {
+    try {
+      // Inside the try: a rejected registration (the agent already drives
+      // a session) must close this session as failed, not leave it open.
+      if (cfg.agent !== undefined) {
+        await registerAgent(db, cfg.agent, qemu.id);
+      }
+      const iso = await getIso(db, isoName, { sessionId: qemu.id, agentId: cfg.agent });
+      if (cfg.disk === undefined) {
+        await createDisk(qemu);
+      } else {
+        // start() puts the firmware copy and the QMP socket in the session
+        // dir; with a caller-provided disk, createDisk never made it.
+        await mkdir(qemu.dir, { recursive: true, mode: 0o700 });
+      }
+      await start(qemu, { iso, disk: cfg.disk }, recorder(qemu.id, cfg.agent));
+      if (isUrl) {
+        await sessionRunning(db, qemu.id);
+      }
+    } catch (err) {
+      // The qemu must not outlive its failed start — a machine the map
+      // never held would be unreachable and unkillable through the API.
+      // The boot error is the one worth seeing if cleanup fails too.
+      await stop(qemu).catch(() => {});
+      await endSession(db, qemu.id, "failed", (err as Error).message).catch((e: unknown) => {
+        console.error(`db: recording a failed start failed too: ${(e as Error).message}`);
+      });
+      throw err;
+    }
+  });
+  sessions.set(qemu.id, qemu);
+  return HttpServerResponse.jsonUnsafe({ id: qemu.id });
+});
+
+const getImage = Effect.gen(function* () {
+  const query = yield* HttpServerRequest.schemaSearchParams(ImageQuery).pipe(Effect.mapError(opError));
+  const qemu = yield* fromSync(() => session(query.id));
+  const agent = query.agent;
+  const path = join(qemu.dir, `image-${process.hrtime.bigint()}.png`);
+  // The PNG is read back only after the exchange closes, and the images
+  // row must ride the same transaction that closes the action (they are
+  // 1:1) — so the recorder only stashes, and the handler closes.
+  const data = yield* fromPromise(async () => {
+    let opened: number | undefined;
+    let outcome: QemuExchangeOutcome | undefined;
+    try {
+      await screendump(qemu, path, "png", async (command) => {
+        opened = await startAction(db, { sessionId: qemu.id, agentId: agent, request: command });
+        return async (result) => {
+          outcome = result;
+        };
+      });
+      const bytes = await readFile(path);
+      // screendump resolved, so the recorder ran: opened and outcome are set.
+      await finishAction(db, opened!, outcome!, bytes);
+      return bytes;
+    } catch (err) {
+      // Only a failed exchange is closed without an image. A completed one
+      // whose image write failed stays open — the row state database.md
+      // documents as a completion that was never persisted; closing it
+      // imageless would break the 1:1 promise instead.
+      if (opened !== undefined && outcome !== undefined && outcome.state === "failed") {
+        await finishAction(db, opened, outcome).catch((e: unknown) => {
+          console.error(`db: recording a failed screendump failed too: ${(e as Error).message}`);
+        });
+      }
+      throw err;
+    } finally {
+      await rm(path, { force: true });
+    }
+  });
+  return HttpServerResponse.uint8Array(data, { contentType: "image/png" });
+});
+
+const getStats = Effect.sync(() => HttpServerResponse.jsonUnsafe(collectStats(cpuSampler, sessions.size)));
+
+const stopSession = Effect.gen(function* () {
+  const { id, status, reason } = yield* readJson(StopBody);
+  // The verdict is checked before the machine dies: a bad status must
+  // not kill the qemu and then fail to record the end.
+  if (status !== undefined && status !== "succeeded" && status !== "failed" && status !== "aborted") {
+    return yield* Effect.fail(opError(new Error(`unknown status "${status}"`)));
   }
-  return out;
+  const qemu = yield* fromSync(() => session(id));
+  sessions.delete(qemu.id);
+  yield* fromPromise(() => stop(qemu));
+  // The stop ends the session; a stop without a verdict is an abort.
+  yield* fromPromise(() => endSession(db, qemu.id, status ?? "aborted", reason ?? null));
+  return HttpServerResponse.jsonUnsafe({ ok: "true" });
+});
+
+const sendKeys = Effect.gen(function* () {
+  const { id, keys, encoding, agent } = yield* readJson(SendKeysBody);
+  const qemu = yield* fromSync(() => session(id));
+  const record = recorder(qemu.id, agent);
+  const chords = yield* fromSync(() => parseKeys(keys, encoding));
+  for (const chord of chords) {
+    yield* fromPromise(() => sendKey(qemu, chord.map((code): QemuKeyValue => ({ type: "qcode", data: code })), record));
+  }
+  return HttpServerResponse.jsonUnsafe({ ok: "true" });
+});
+
+function clientResponse(err: unknown): HttpServerResponse.HttpServerResponse {
+  const status = errorMessage(err) === "not found" ? 404 : 400;
+  return HttpServerResponse.jsonUnsafe({ error: errorMessage(err) }, { status });
 }
+
+function fromCause<E>(cause: Cause.Cause<E>): HttpServerResponse.HttpServerResponse {
+  const failed = Option.getOrUndefined(Cause.findErrorOption(cause));
+  if (failed !== undefined) {
+    return clientResponse(failed);
+  }
+  return clientResponse(Cause.squash(cause));
+}
+
+// Handler errors become the {"error": "..."} the CLI already prints.
+// HttpRouter's catch-all for unknown paths is a miss, so that route says
+// "not found" itself — Effect's RouteNotFound would be an empty 404.
+function asHttp<E, R>(
+  effect: Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>,
+): Effect.Effect<HttpServerResponse.HttpServerResponse, never, R> {
+  return Effect.catchCause(effect, (cause) => Effect.succeed(fromCause(cause)));
+}
+
+// Settled, not raced: one session failing to stop or record must not
+// cut short the cleanup of the others. NodeRuntime.runMain interrupts
+// this scope on SIGINT/SIGTERM.
+const Shutdown = Layer.effectDiscard(
+  Effect.gen(function* () {
+    console.error(`oligarchy proxy listening on ${addr}`);
+    yield* Effect.addFinalizer(() =>
+      Effect.promise(() =>
+        Promise.allSettled(
+          [...sessions.values()].map(async (qemu) => {
+            await stop(qemu);
+            await endSession(db, qemu.id, "aborted", "proxy shutdown");
+          }),
+        ).then((results) => {
+          for (const result of results) {
+            if (result.status === "rejected") {
+              console.error(`shutdown: ${(result.reason as Error).message}`);
+            }
+          }
+        }),
+      ),
+    );
+  }),
+);
+
+const Routes = Layer.mergeAll(
+  HttpRouter.add("POST", "/start", asHttp(startSession)),
+  HttpRouter.add("GET", "/image", asHttp(getImage)),
+  HttpRouter.add("GET", "/stats", asHttp(getStats)),
+  HttpRouter.add("POST", "/stop", asHttp(stopSession)),
+  HttpRouter.add("POST", "/send-keys", asHttp(sendKeys)),
+  HttpRouter.add("*", "/*", HttpServerResponse.jsonUnsafe({ error: "not found" }, { status: 404 })),
+  Shutdown,
+);
+
+const App = HttpRouter.serve(Routes, { disableLogger: true, disableListenLog: true }).pipe(
+  Layer.provide(NodeHttpServer.layer(() => createServer(), { host, port: Number(port) })),
+);
+
+NodeRuntime.runMain(Layer.launch(App));

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -30,7 +30,7 @@ import { createServer } from "node:http";
 import { join } from "node:path";
 import { NodeHttpServer, NodeRuntime } from "@effect/platform-node";
 import { Cause, Effect, Layer, Option, Schema } from "effect";
-import { HttpRouter, HttpServerError, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { connectDatabase, endSession, finishAction, insertSession, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
 import { createDisk, createQemu, screendump, sendKey, start, stop, type Qemu } from "./client.ts";
 import { getIso } from "./iso.ts";
@@ -65,28 +65,21 @@ function recorder(sessionId: string, agentId: string | undefined): QemuExchangeR
 // The HTTP layer's only error: a sentence the client can print. qemu / iso /
 // db still throw Error; we lift the message here and never let an unknown
 // value become {"error": undefined}.
-const OpError = Schema.Struct({
-  _tag: Schema.tag("OpError"),
-  message: Schema.String,
-});
-type OpError = typeof OpError.Type;
+type OpError = { readonly _tag: "OpError"; readonly message: string };
 
 function errorMessage(err: unknown): string {
-  if (HttpServerError.isHttpServerError(err) && err.reason._tag === "RouteNotFound") {
-    return "not found";
-  }
-  if (typeof err === "object" && err !== null && "_tag" in err && err._tag === "RouteNotFound") {
-    return "not found";
-  }
-  if (typeof err === "object" && err !== null && "message" in err && typeof err.message === "string" && err.message !== "") {
-    return err.message;
-  }
   const e = err as Error;
-  return e.cause instanceof Error ? `${e.message}: ${e.cause.message}` : String(e.message ?? err);
+  if (e.cause instanceof Error) {
+    return `${e.message}: ${e.cause.message}`;
+  }
+  if (typeof e.message === "string" && e.message !== "") {
+    return e.message;
+  }
+  return String(err);
 }
 
 function opError(err: unknown): OpError {
-  return OpError.make({ message: errorMessage(err) });
+  return { _tag: "OpError", message: errorMessage(err) };
 }
 
 function fromPromise<A>(f: (signal: AbortSignal) => Promise<A>): Effect.Effect<A, OpError> {
@@ -300,16 +293,22 @@ const Shutdown = Layer.effectDiscard(
 );
 
 const Routes = Layer.mergeAll(
-  HttpRouter.add("POST", "/start", asHttp(startSession)),
-  HttpRouter.add("GET", "/image", asHttp(getImage)),
+  HttpRouter.add("POST", "/start", asHttp(startSession), { uninterruptible: true }),
+  HttpRouter.add("GET", "/image", asHttp(getImage), { uninterruptible: true }),
   HttpRouter.add("GET", "/stats", asHttp(getStats)),
-  HttpRouter.add("POST", "/stop", asHttp(stopSession)),
-  HttpRouter.add("POST", "/send-keys", asHttp(sendKeys)),
+  HttpRouter.add("POST", "/stop", asHttp(stopSession), { uninterruptible: true }),
+  HttpRouter.add("POST", "/send-keys", asHttp(sendKeys), { uninterruptible: true }),
   HttpRouter.add("*", "/*", HttpServerResponse.jsonUnsafe({ error: "not found" }, { status: 404 })),
   Shutdown,
 );
 
-const App = HttpRouter.serve(Routes, { disableLogger: true, disableListenLog: true }).pipe(
+const App = HttpRouter.serve(Routes, {
+  disableLogger: true,
+  disableListenLog: true,
+  // The old handler compared URL.pathname literally. FindMyWay's defaults
+  // fold case, trailing slashes, and duplicate slashes.
+  routerConfig: { caseSensitive: true, ignoreTrailingSlash: false, ignoreDuplicateSlashes: false },
+}).pipe(
   Layer.provide(NodeHttpServer.layer(() => createServer(), { host, port: Number(port) })),
 );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A small swing at Effect 4 on **just** the HTTP layer (`src/qemu/proxy.ts`). qemu, iso, keys, and db are unchanged Promise/throw code.

## Why this shape

Michael Arnaldi’s Effect 4 work (the “smol” rewrite, then the RC) is aiming at a smaller tree-shakeable runtime and a single package: HTTP lives in `effect/unstable/http`, the Node adapter is `@effect/platform-node`, and you start a process with `Layer.launch` + `NodeRuntime.runMain`. The HTTPAPI guide is schemas-first for a *contract* (OpenAPI, typed client). That is more than this swing. This PR is the layer under that: `HttpRouter` + Schema only for JSON bodies + one catch that turns every failure into the existing `{"error": "..."}`.

No error classes. The HTTP edge uses a plain `{ _tag: "OpError", message }` so the client always gets a sentence we can print.

## `/start` is always an agent + a session

There is no unattributed start. `agent` is required (empty or missing → `400 {"error":"agent is required"}`). The session row and the agent_runs row are written together at the top of `/start` — still two db ops, no schema refactor. Those writes are not operational errors: if either fails, the start **dies** (`orDie` → `500` with the database's sentence). Iso/qemu boot failures stay `400` with the existing stop + `endSession("failed")` cleanup.

Manual use fakes an agent id. The CLI already always sends one.

## What you get to look at

- Routes are `HttpRouter.add(...)` layers, served by `NodeHttpServer`
- Request JSON is `Schema.decodeUnknownEffect` (empty `/start` body still parses, then fails on missing agent)
- Existing `throw new Error(...)` / rejected promises become `OpError` via `try` / `tryPromise`
- `asHttp` maps Fail → 400 and Die → 500, both `{"error": "<sentence>"}`
- Unknown paths stay `404 {"error":"not found"}`
- `/start`, `/image`, `/stop`, `/send-keys` are uninterruptible — a dropped client must not cancel a boot or skip a session close
- Shutdown is a scope finalizer (SIGINT/SIGTERM from `runMain`)

## What this is not

Not HttpApi. Not Sentry. Not typed qemu/iso/db errors, and not a combined insertSession+registerAgent in `ops.ts`. Combining those two writes into one operation is the next db change, not this HTTP swing.

## Verified against a live proxy

`/stats` 200. Unknown path / `/STATS` / `/stats/` → `404 {"error":"not found"}`. Missing/empty agent on `/start` → `400 {"error":"agent is required"}`. `/start` with an agent and no Postgres → `500` with the drizzle + `ECONNREFUSED` sentence (no `endSession` cleanup — init never completed). Unknown session / bad stop status stay `400`.

`runMain` still exits 130 on SIGINT instead of the old 0/1-from-cleanup. Left that.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a052d3-f5c6-7e80-a86a-e2ee26f40876?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a052d3-f5c6-7e80-a86a-e2ee26f40876&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

