### PR TITLE
db: accept PlanetScale sslrootcert=system URLs

### DIFF
--- a/src/db/ops.ts
+++ b/src/db/ops.ts
@@ -21,7 +21,19 @@ export function connectDatabase(): Db {
   if (url === undefined || url === "") {
     throw new Error("db: DATABASE_URL is not set");
   }
-  return drizzle(url);
+  // PlanetScale's copied URL includes sslrootcert=system. That word is
+  // special to libpq 16; node-postgres treats it as a filename and throws
+  // ENOENT. Drop it and verify against Node's system CA store — the same
+  // thing sslmode=verify-full & sslrootcert=system means in psql.
+  const parsed = new URL(url);
+  parsed.searchParams.delete("sslrootcert");
+  parsed.searchParams.delete("sslmode");
+  return drizzle({
+    connection: {
+      connectionString: parsed.toString(),
+      ssl: { rejectUnauthorized: true },
+    },
+  });
 }
 
 /** Creates the session row, before any boot work happens. */

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -239,7 +239,7 @@ function qemuArgs(opts: {
     "-drive",
     `if=pflash,format=raw,file=${opts.varsPath}`,
     "-display",
-    "gtk",
+    "none",
     "-chardev",
     `socket,id=qmp,path=${opts.sockPath}`,
     "-mon",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PlanetScale’s copied Postgres URL includes `sslmode=verify-full&sslrootcert=system`. That `sslrootcert=system` token is a libpq 16 keyword. node-postgres treats it as a file path and throws `ENOENT: no such file or directory, open 'system'` before a socket is opened.

`connectDatabase` now drops those libpq-only query params and verifies TLS against Node’s system CA store (`ssl: { rejectUnauthorized: true }`), which is what PlanetScale’s Node.js docs recommend.

Also switches QEMU to `-display none` so the control plane can complete the QMP handshake on a headless host. Screendump still works; a GTK window is not part of the loop.

Verified by booting the proxy against the real remote database, starting a session with [Omarchy 4.0.1](https://iso.omarchy.org/omarchy-4.0.1.iso), and driving the installer to a logged-in desktop as user `prime`.

[User account confirmed](https://cursor.com/agents/bc-01a05395-a18e-711a-a639-69e27ce3ef0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fomarchy_user_account_confirmed.png)
[Install complete](https://cursor.com/agents/bc-01a05395-a18e-711a-a639-69e27ce3ef0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fomarchy_install_complete.png)
[Omarchy desktop](https://cursor.com/agents/bc-01a05395-a18e-711a-a639-69e27ce3ef0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fomarchy_desktop.png)
[Desktop session as user prime](https://cursor.com/agents/bc-01a05395-a18e-711a-a639-69e27ce3ef0f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fomarchy_desktop_user_prime.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05395-a18e-711a-a639-69e27ce3ef0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05395-a18e-711a-a639-69e27ce3ef0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

