### PR TITLE
db: don't treat sslrootcert=system as a file path

### DIFF
--- a/src/db/ops.ts
+++ b/src/db/ops.ts
@@ -17,9 +17,21 @@ export type Db = NodePgDatabase;
  * its sessions must not boot, so a missing url throws instead of degrading.
  */
 export function connectDatabase(): Db {
-  const url = process.env.DATABASE_URL;
+  let url = process.env.DATABASE_URL;
   if (url === undefined || url === "") {
     throw new Error("db: DATABASE_URL is not set");
+  }
+  // pg-connection-string treats sslrootcert as a file path. libpq's
+  // sslrootcert=system means the system CA store, which is already pg's
+  // default — drop the param so the driver does not open a file named
+  // "system" (ENOENT). sslmode=verify-full stays and does the verifying.
+  const q = url.indexOf("?");
+  if (q !== -1) {
+    const params = url.slice(q + 1).split("&");
+    const kept = params.filter((p) => p !== "sslrootcert=system");
+    if (kept.length !== params.length) {
+      url = kept.length === 0 ? url.slice(0, q) : url.slice(0, q + 1) + kept.join("&");
+    }
   }
   return drizzle(url);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PlanetScale Postgres URLs often look like:

```
postgresql://…/postgres?sslmode=verify-full&sslrootcert=system
```

`pg-connection-string` (used by drizzle / node-postgres) treats `sslrootcert` as a filesystem path and calls `readFileSync`. The libpq special value `system` is not a file, so the first connection throws:

```
ENOENT: no such file or directory, open 'system'
```

That is already pg's default: verify against the system CA store. This change drops only `sslrootcert=system` from `DATABASE_URL` and leaves `sslmode=verify-full` (and every other param) alone.

A URL with no query string, or with a real cert path, is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0539d-8255-750c-8cb6-6b9133d32a4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0539d-8255-750c-8cb6-6b9133d32a4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

