### PR TITLE
Report proxy errors to Sentry

### DIFF
--- a/field-guide/database.md
+++ b/field-guide/database.md
@@ -38,7 +38,9 @@ A still-running exchange has no state yet: `state`, `response`, and `finished_at
 
 Levels are severity of the operation, not of the state it records: a `/stop` carrying a `failed` verdict still logs at info — the stop worked; the verdict lives on the session row. For the same reason a failed `/start` is one error line from the boundary, not two — attributed to the session and agent as far as the handler got before it threw, with the session row's `failed` status and reason as the state record.
 
-Paths that end in `process.exit` — shutdown, a fatal — await `flushLogs()` first, the chain settling, so the last lines are not lost with the process. The db's own write failures (a log insert refused, a "recording the failure failed too") report to stderr only: a database that is not taking writes cannot hold the line saying so.
+Paths that end in `process.exit` — shutdown, a fatal — await `flushLogs()` and `flushSentry()` first, the chain settling, so the last lines are not lost with the process. The db's own write failures (a log insert refused, a "recording the failure failed too") report to stderr and to Sentry: a database that is not taking writes cannot hold the line saying so.
+
+When `SENTRY_DSN` is set, `log()` also sends error and fatal lines to Sentry, with the exception when the caller has one. 4xx request refusals stay in the logs table and skip Sentry — they are the client's mistake. A missing DSN is a no-op.
 
 ## Timing
 

--- a/field-guide/database.md
+++ b/field-guide/database.md
@@ -40,7 +40,7 @@ Levels are severity of the operation, not of the state it records: a `/stop` car
 
 Paths that end in `process.exit` — shutdown, a fatal — await `flushLogs()` then `flushSentry()` first, the chain settling, so the last lines (and a log-insert failure discovered while flushing) are not lost with the process. The db's own write failures (a log insert refused, a "recording the failure failed too") report to stderr and to Sentry: a database that is not taking writes cannot hold the line saying so.
 
-When `SENTRY_DSN` is set, `log()` also sends error and fatal lines to Sentry, with the exception when the caller has one. 4xx request refusals stay in the logs table and skip Sentry — they are the client's mistake. A missing DSN is a no-op.
+`log()` also sends error and fatal lines to Sentry, with the exception when the caller has one. 4xx request refusals stay in the logs table and skip Sentry — they are the client's mistake. The dashboard worker is wrapped with `@sentry/cloudflare`; the proxy reports through `@sentry/node` because it is a Node process (it boots QEMU). Both use the same project DSN.
 
 ## Timing
 

--- a/field-guide/database.md
+++ b/field-guide/database.md
@@ -38,7 +38,7 @@ A still-running exchange has no state yet: `state`, `response`, and `finished_at
 
 Levels are severity of the operation, not of the state it records: a `/stop` carrying a `failed` verdict still logs at info — the stop worked; the verdict lives on the session row. For the same reason a failed `/start` is one error line from the boundary, not two — attributed to the session and agent as far as the handler got before it threw, with the session row's `failed` status and reason as the state record.
 
-Paths that end in `process.exit` — shutdown, a fatal — await `flushLogs()` and `flushSentry()` first, the chain settling, so the last lines are not lost with the process. The db's own write failures (a log insert refused, a "recording the failure failed too") report to stderr and to Sentry: a database that is not taking writes cannot hold the line saying so.
+Paths that end in `process.exit` — shutdown, a fatal — await `flushLogs()` then `flushSentry()` first, the chain settling, so the last lines (and a log-insert failure discovered while flushing) are not lost with the process. The db's own write failures (a log insert refused, a "recording the failure failed too") report to stderr and to Sentry: a database that is not taking writes cannot hold the line saying so.
 
 When `SENTRY_DSN` is set, `log()` also sends error and fatal lines to Sentry, with the exception when the caller has one. 4xx request refusals stay in the logs table and skip Sentry — they are the client's mistake. A missing DSN is a no-op.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@cursor/sdk": "^1.0.30",
         "@effect/platform-node": "4.0.0-rc.112",
+        "@sentry/node": "^10.72.0",
         "drizzle-orm": "^0.45.2",
         "effect": "4.0.0-rc.112",
         "hono": "^4.13.5",
@@ -1873,6 +1874,119 @@
         "win32"
       ]
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxlint-tsgolint/darwin-arm64": {
       "version": "7.0.2001",
       "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-7.0.2001.tgz",
@@ -2386,6 +2500,117 @@
         "@redis/client": "^6.2.1"
       }
     },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.72.0.tgz",
+      "integrity": "sha512-UJMHZfbjP4qk+g4AQhZmzosMdICC2D9p0/hLrm1LofPsp+WBfcSnv9jsY1a9TfmpS4WCAmTx8nANYTIXifcBjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.72.0.tgz",
+      "integrity": "sha512-eQHQFxSX26MhG/nB+tAY4QRslnPvJse7pww/hd3zXAqNULRa5lFtjSLALcHx/KUVDCZdTPdUVZEj4nGidcHrow==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0",
+        "@sentry/node-core": "10.72.0",
+        "@sentry/opentelemetry": "10.72.0",
+        "@sentry/server-utils": "10.72.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.72.0.tgz",
+      "integrity": "sha512-xYuYWmWEWnN8h3YHa7mds212ANFgrxfrbmLvVg0p0wf9m6MFjLowOTmjaiK0XW20sM/veSelicre650bx8UFtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0",
+        "@sentry/opentelemetry": "10.72.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.72.0.tgz",
+      "integrity": "sha512-ZVbAM1rGU/awN7cH/jvC87WpQw0NOJx5id6dKnnefStXpP/kUnZXYhtX9gfBnofYvJWa5I5VUSeuKCLUcKL75w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.72.0.tgz",
+      "integrity": "sha512-CWpHMYW81RDBSVBdnxulGUvvBhkBb/OpSr72ubSe1UkKTcgT0NDMCWxE3dLFXqSxzT4DaF5UlUVv9ii5Sse53w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.72.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
@@ -2805,6 +3030,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "license": "MIT"
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -2827,6 +3058,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/detect-libc": {
@@ -3000,6 +3248,12 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -3101,6 +3355,20 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -3175,6 +3443,18 @@
           "optional": true
         }
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/msgpackr": {
       "version": "2.1.0",
@@ -3462,6 +3742,19 @@
       },
       "engines": {
         "node": ">= 20.0.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@cursor/sdk": "^1.0.30",
         "@effect/platform-node": "4.0.0-rc.112",
+        "@sentry/cloudflare": "^10.72.0",
         "@sentry/node": "^10.72.0",
         "drizzle-orm": "^0.45.2",
         "effect": "4.0.0-rc.112",
@@ -34,7 +35,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
       "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -44,7 +45,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
       "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
@@ -180,7 +181,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -1245,7 +1246,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1772,7 +1773,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1782,14 +1783,13 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
       "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2398,7 +2398,7 @@
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
       "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^4.1.5"
@@ -2408,7 +2408,7 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
       "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -2420,7 +2420,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@redis/bloom": {
@@ -2498,6 +2498,33 @@
       },
       "peerDependencies": {
         "@redis/client": "^6.2.1"
+      }
+    },
+    "node_modules/@sentry/cloudflare": {
+      "version": "10.72.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.72.0.tgz",
+      "integrity": "sha512-fRMlu916jqB5iYSfJlV1MVsM76nLVG1KxkQHmqD/Bg+DyqxiY/ETsP2mL0rscxSuznR3Kjh4fh76PZ+KiGclIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@sentry/core": "10.72.0",
+        "@sentry/server-utils": "10.72.0",
+        "magic-string": "~0.30.21"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.x || ^5.x",
+        "wrangler": "^4.x"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "wrangler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sentry/conventions": {
@@ -2615,7 +2642,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
       "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2628,7 +2655,7 @@
       "version": "1.2.24",
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
       "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/@statsig/client-core": {
@@ -3020,7 +3047,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/buffer-from": {
@@ -3050,7 +3077,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3242,7 +3269,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
       "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3373,10 +3400,19 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mime": {
@@ -3398,7 +3434,7 @@
       "version": "5.20260828.0-alpha",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260828.0-alpha.tgz",
       "integrity": "sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -3416,7 +3452,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
       "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -3426,7 +3462,7 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3573,14 +3609,14 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -3771,7 +3807,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3784,7 +3820,7 @@
       "version": "0.35.2",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
       "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
@@ -3859,7 +3895,7 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
       "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4436,7 +4472,7 @@
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
@@ -4446,7 +4482,7 @@
       "version": "1.20260828.1",
       "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260828.1.tgz",
       "integrity": "sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4467,7 +4503,7 @@
       "version": "4.127.1",
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.1.tgz",
       "integrity": "sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
@@ -4945,7 +4981,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5017,7 +5053,7 @@
       "version": "4.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
       "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -5031,7 +5067,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
       "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/exception": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@cursor/sdk": "^1.0.30",
     "@effect/platform-node": "4.0.0-rc.112",
+    "@sentry/node": "^10.72.0",
     "drizzle-orm": "^0.45.2",
     "effect": "4.0.0-rc.112",
     "hono": "^4.13.5",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@cursor/sdk": "^1.0.30",
     "@effect/platform-node": "4.0.0-rc.112",
+    "@sentry/cloudflare": "^10.72.0",
     "@sentry/node": "^10.72.0",
     "drizzle-orm": "^0.45.2",
     "effect": "4.0.0-rc.112",

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1,6 +1,8 @@
-import { Hono } from "hono";
+import * as Sentry from "@sentry/cloudflare";
+import { Hono, type ExecutionContext } from "hono";
 import type { FC } from "hono/jsx";
 import { jsxRenderer } from "hono/jsx-renderer";
+import { SENTRY_DSN } from "./sentry-dsn.ts";
 
 const HTMX_URL = "https://cdn.jsdelivr.net/npm/htmx.org@4.0.0";
 const HTMX_INTEGRITY = "sha384-BvJpBiO8Kh31EqtJe5DRIeWrHWnCGkwytKs9NKFi86Hhw96dEqdEMzZDeK9iEGTc";
@@ -43,4 +45,14 @@ app.get("/", (context) =>
 
 app.get("/greeting", (context) => context.html(<Greeting message="Hello again" />));
 
-export default app;
+export default Sentry.withSentry(
+  () => ({
+    dsn: SENTRY_DSN,
+    dataCollection: {},
+  }),
+  {
+    async fetch(request: Request, env: unknown, ctx: ExecutionContext) {
+      return app.fetch(request, env, ctx);
+    },
+  },
+);

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/cloudflare";
-import { Hono, type ExecutionContext } from "hono";
+import { Hono } from "hono";
 import type { FC } from "hono/jsx";
 import { jsxRenderer } from "hono/jsx-renderer";
 import { SENTRY_DSN } from "./sentry-dsn.ts";
@@ -50,9 +50,5 @@ export default Sentry.withSentry(
     dsn: SENTRY_DSN,
     dataCollection: {},
   }),
-  {
-    async fetch(request: Request, env: unknown, ctx: ExecutionContext) {
-      return app.fetch(request, env, ctx);
-    },
-  },
+  app,
 );

--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -7,9 +7,17 @@
 //   log(db, { text: `iso: downloading ${url}`, sessionId, agentId });
 //   log(db, { level: "error", text: `POST /start failed: ${message}` });
 //
+// error and fatal also go to Sentry when SENTRY_DSN is set — that is the
+// one reporting path, so a failed request, a db write that would not
+// record, and a dying proxy show up in the same place. A 4xx is still an
+// error line (a refused request is a failed request) but is the client's
+// mistake: the caller passes skipSentry. The optional cause is the
+// exception Sentry should group on; without one the text is the event.
+//
 // The db is the one client connectDatabase() built (see ops.ts); this file
 // never touches connection details.
 
+import { capture } from "../sentry.ts";
 import type { Db } from "./ops.ts";
 import { logs } from "./schema.ts";
 
@@ -34,11 +42,24 @@ export type LogEntry = {
 // and never fails the caller or the lines behind it.
 let chain: Promise<void> = Promise.resolve();
 
-export function log(db: Db, entry: string | LogEntry): void {
+export function log(
+  db: Db,
+  entry: string | LogEntry,
+  report?: { cause?: unknown; skipSentry?: true },
+): void {
   const line: LogEntry = typeof entry === "string" ? { text: entry } : entry;
   // info stays bare on stderr — it is the default story; the levels worth
   // noticing carry their name.
   console.error(line.level === undefined || line.level === "info" ? line.text : `${line.level}: ${line.text}`);
+  if ((line.level === "error" || line.level === "fatal") && report?.skipSentry !== true) {
+    capture({
+      text: line.text,
+      level: line.level,
+      sessionId: line.sessionId,
+      agentId: line.agentId,
+      cause: report?.cause,
+    });
+  }
   chain = chain.then(async () => {
     try {
       await db.insert(logs).values(line);
@@ -46,7 +67,9 @@ export function log(db: Db, entry: string | LogEntry): void {
       // Drizzle buries the reason (ECONNREFUSED etc.) in the cause; its own
       // message is the failed SQL and the params — noise here.
       const e = err as Error;
-      console.error(`db: log insert failed: ${e.cause instanceof Error ? e.cause.message : e.message}`);
+      const detail = e.cause instanceof Error ? e.cause.message : e.message;
+      console.error(`db: log insert failed: ${detail}`);
+      capture({ text: `db: log insert failed: ${detail}`, level: "error", cause: err });
     }
   });
 }

--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -7,12 +7,12 @@
 //   log(db, { text: `iso: downloading ${url}`, sessionId, agentId });
 //   log(db, { level: "error", text: `POST /start failed: ${message}` });
 //
-// error and fatal also go to Sentry when SENTRY_DSN is set — that is the
-// one reporting path, so a failed request, a db write that would not
-// record, and a dying proxy show up in the same place. A 4xx is still an
-// error line (a refused request is a failed request) but is the client's
-// mistake: the caller passes skipSentry. The optional cause is the
-// exception Sentry should group on; without one the text is the event.
+// error and fatal also go to Sentry — that is the one reporting path, so
+// a failed request, a db write that would not record, and a dying proxy
+// show up in the same place. A 4xx is still an error line (a refused
+// request is a failed request) but is the client's mistake: the caller
+// passes skipSentry. The optional cause is the exception Sentry should
+// group on; without one the text is the event.
 //
 // The db is the one client connectDatabase() built (see ops.ts); this file
 // never touches connection details.

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -10,9 +10,8 @@
 // as it happens. Major actions also land in the logs table through log():
 // the lifecycle at info with how long each took, failed requests at error,
 // the death of the proxy at fatal (see field-guide/database.md). Error and
-// fatal lines also go to Sentry when SENTRY_DSN is set; SENTRY_ENVIRONMENT
-// is forwarded when set. A missing DSN is a no-op — Sentry is not required
-// to drive guests.
+// fatal lines also go to Sentry. 4xx request refusals stay in the logs
+// table and skip Sentry — they are the client's mistake.
 //
 //   POST /start      -> {"iso"?, "disk"?, "agent"}; boots a qemu, returns
 //                       {"id": uuid}; an http(s) iso is downloaded into

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -9,7 +9,10 @@
 // boot, and every session, QMP exchange, image, and iso event is recorded
 // as it happens. Major actions also land in the logs table through log():
 // the lifecycle at info with how long each took, failed requests at error,
-// the death of the proxy at fatal (see field-guide/database.md).
+// the death of the proxy at fatal (see field-guide/database.md). Error and
+// fatal lines also go to Sentry when SENTRY_DSN is set; SENTRY_ENVIRONMENT
+// is forwarded when set. A missing DSN is a no-op — Sentry is not required
+// to drive guests.
 //
 //   POST /start      -> {"iso"?, "disk"?, "agent"}; boots a qemu, returns
 //                       {"id": uuid}; an http(s) iso is downloaded into
@@ -46,10 +49,13 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstab
 import { NodeHttpServer, NodeRuntime } from "@effect/platform-node";
 import { flushLogs, log } from "../db/log.ts";
 import { connectDatabase, endSession, finishAction, insertSession, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
+import { flushSentry, initSentry } from "../sentry.ts";
 import { createDisk, createQemu, screendump, sendKey, start, stop, type Qemu } from "./client.ts";
 import { getIso } from "./iso.ts";
 import { parseKeys } from "./keys.ts";
 import { collectStats, startCpuSampler } from "./stats.ts";
+
+initSentry();
 
 const defaultIso = process.argv[2] ?? process.env.OLIGARCHY_ISO;
 if (defaultIso === undefined) {
@@ -93,7 +99,7 @@ function recorder(sessionId: string, agentId: string): QemuExchangeRecorder {
       try {
         await finishAction(db, id, outcome);
       } catch (err) {
-        log(db, { level: "error", text: `db: closing action ${id} failed: ${errorDetail(err)}`, sessionId, agentId });
+        log(db, { level: "error", text: `db: closing action ${id} failed: ${errorDetail(err)}`, sessionId, agentId }, { cause: err });
         throw err;
       }
     };
@@ -112,8 +118,8 @@ function recorder(sessionId: string, agentId: string): QemuExchangeRecorder {
 type ApiError =
   | { readonly _tag: "BadRequest"; readonly message: string; readonly sessionId?: string; readonly agentId?: string }
   | { readonly _tag: "UnknownSession"; readonly id: string; readonly agentId?: string }
-  | { readonly _tag: "StartFailed"; readonly message: string; readonly sessionId: string; readonly agentId: string }
-  | { readonly _tag: "ExchangeFailed"; readonly message: string; readonly sessionId: string; readonly agentId: string }
+  | { readonly _tag: "StartFailed"; readonly message: string; readonly cause: unknown; readonly sessionId: string; readonly agentId: string }
+  | { readonly _tag: "ExchangeFailed"; readonly message: string; readonly cause: unknown; readonly sessionId: string; readonly agentId: string }
   | { readonly _tag: "Internal"; readonly cause: unknown; readonly sessionId: string; readonly agentId?: string };
 
 function badRequest(message: string, who: { sessionId?: string; agentId?: string } = {}): ApiError {
@@ -123,11 +129,11 @@ function badRequest(message: string, who: { sessionId?: string; agentId?: string
 // The cast is the same contract the rest of the repo leans on: everything
 // the wrapped subsystems throw is an Error.
 function startFailed(err: unknown, who: { sessionId: string; agentId: string }): ApiError {
-  return { _tag: "StartFailed", message: (err as Error).message, ...who };
+  return { _tag: "StartFailed", message: (err as Error).message, cause: err, ...who };
 }
 
 function exchangeFailed(err: unknown, who: { sessionId: string; agentId: string }): ApiError {
-  return { _tag: "ExchangeFailed", message: (err as Error).message, ...who };
+  return { _tag: "ExchangeFailed", message: (err as Error).message, cause: err, ...who };
 }
 
 function internal(cause: unknown, who: { sessionId: string; agentId?: string }): ApiError {
@@ -235,7 +241,7 @@ async function launchQemu(qemu: Qemu, cfg: { disk?: string; agent: string }, iso
     // The start error is the one worth seeing if cleanup fails too.
     await stop(qemu).catch(() => {});
     await endSession(db, qemu.id, "failed", (err as Error).message).catch((e: unknown) => {
-      log(db, { level: "error", text: `db: recording a failed start failed too: ${(e as Error).message}`, sessionId: qemu.id, agentId: cfg.agent });
+      log(db, { level: "error", text: `db: recording a failed start failed too: ${(e as Error).message}`, sessionId: qemu.id, agentId: cfg.agent }, { cause: e });
     });
     throw err;
   }
@@ -319,7 +325,7 @@ const routes = HttpRouter.use((router) =>
             Effect.promise(async () => {
               if (opened !== undefined && outcome !== undefined && outcome.state === "failed") {
                 await finishAction(db, opened, outcome).catch((e: unknown) => {
-                  log(db, { level: "error", text: `db: recording a failed screendump failed too: ${(e as Error).message}`, sessionId: qemu.id, agentId: agent });
+                  log(db, { level: "error", text: `db: recording a failed screendump failed too: ${(e as Error).message}`, sessionId: qemu.id, agentId: agent }, { cause: e });
                 });
               }
             })
@@ -397,17 +403,26 @@ function errorBody(status: number, message: string): HttpServerResponse.HttpServ
 // One error line per failed request — method, url, and what went wrong —
 // attributed as far as the route knew, then the wire answer. The log line
 // and the client's message differ only for Internal: the client gets no
-// internals. When Sentry arrives, its captureException belongs here and
-// in the defect arm below, nowhere else.
+// internals. Sentry is fed from log(): 5xx send the cause, 4xx skip
+// (the client's mistake), and the defect arm below passes the defect.
 function answer(
   request: HttpServerRequest.HttpServerRequest,
   status: number,
   message: string,
-  who: { sessionId?: string; agentId?: string },
+  who: { sessionId?: string; agentId?: string; cause?: unknown },
   detail = message,
 ): Effect.Effect<HttpServerResponse.HttpServerResponse> {
   return Effect.sync(() => {
-    log(db, { level: "error", text: `${request.method} ${request.originalUrl} failed: ${detail}`, ...who });
+    log(
+      db,
+      {
+        level: "error",
+        text: `${request.method} ${request.originalUrl} failed: ${detail}`,
+        sessionId: who.sessionId,
+        agentId: who.agentId,
+      },
+      status < 500 ? { skipSentry: true } : { cause: who.cause },
+    );
     return errorBody(status, message);
   });
 }
@@ -446,10 +461,14 @@ const respond = HttpRouter.middleware<{ handles: ApiError }>()((handler) =>
           // A defect is a bug: the stack names the spot, so it rides the
           // line. A defect is also by definition not ours, so the boundary
           // that keeps the process alive assumes nothing about its shape.
-          log(db, {
-            level: "error",
-            text: `${request.method} ${request.originalUrl} failed: ${defect instanceof Error ? defect.stack ?? defect.message : String(defect)}`,
-          });
+          log(
+            db,
+            {
+              level: "error",
+              text: `${request.method} ${request.originalUrl} failed: ${defect instanceof Error ? defect.stack ?? defect.message : String(defect)}`,
+            },
+            { cause: defect },
+          );
           return errorBody(500, "internal error");
         })
       ),
@@ -472,7 +491,7 @@ async function stopTimedOutSessions(): Promise<void> {
       } catch (err) {
         // stop() has already destroyed the socket and signaled QEMU before
         // removing the directory, so still close the database record.
-        log(db, { level: "error", text: `session ${qemu.id}: timeout cleanup failed: ${errorDetail(err)}`, sessionId: qemu.id });
+        log(db, { level: "error", text: `session ${qemu.id}: timeout cleanup failed: ${errorDetail(err)}`, sessionId: qemu.id }, { cause: err });
       }
       await endSession(db, qemu.id, "timed_out", SESSION_TIMEOUT_REASON);
       log(db, { text: `session ${qemu.id}: timed out; ${SESSION_TIMEOUT_REASON}`, sessionId: qemu.id });
@@ -485,7 +504,7 @@ async function stopTimedOutSessions(): Promise<void> {
         level: "error",
         text: `session ${timedOut[i].qemu.id}: recording timeout failed: ${errorDetail(result.reason)}`,
         sessionId: timedOut[i].qemu.id,
-      });
+      }, { cause: result.reason });
     }
   }
 }
@@ -499,7 +518,7 @@ const sessionTimeoutTimer = setInterval(() => {
   timeoutCleanupRunning = true;
   timeoutCleanup = stopTimedOutSessions()
     .catch((err: unknown) => {
-      log(db, { level: "error", text: `session timeout cleanup failed: ${errorDetail(err)}` });
+      log(db, { level: "error", text: `session timeout cleanup failed: ${errorDetail(err)}` }, { cause: err });
     })
     .finally(() => {
       timeoutCleanupRunning = false;
@@ -527,7 +546,7 @@ const drainSessions = Layer.effectDiscard(
           } catch (err) {
             // Logged here, where the session is known — the sessions that
             // fail are the ones whose absence from the story matters most.
-            log(db, { level: "error", text: `shutdown: session ${qemu.id}: ${(err as Error).message}`, sessionId: qemu.id });
+            log(db, { level: "error", text: `shutdown: session ${qemu.id}: ${(err as Error).message}`, sessionId: qemu.id }, { cause: err });
             throw err;
           }
         }),
@@ -549,8 +568,8 @@ const main = Layer.effectDiscard(
   Effect.sync(() => {
     log(db, `oligarchy proxy listening on ${addr}`);
     server.on("error", (err) => {
-      log(db, { level: "fatal", text: `proxy: ${err.message}` });
-      void flushLogs().then(() => process.exit(1));
+      log(db, { level: "fatal", text: `proxy: ${err.message}` }, { cause: err });
+      void Promise.all([flushLogs(), flushSentry()]).then(() => process.exit(1));
     });
   }),
 ).pipe(
@@ -561,18 +580,19 @@ const main = Layer.effectDiscard(
 // The exit contract is unchanged: a clean shutdown (signals included) exits
 // 0, a session whose cleanup failed makes it 1, and a server that could not
 // come up is a fatal line and exit 1. Every exit path flushes the log chain
-// first — the last lines are the ones most worth having when the proxy is
-// gone — and runMain's own error report is off: the fatal line is the story.
+// and Sentry first — the last lines are the ones most worth having when the
+// proxy is gone — and runMain's own error report is off: the fatal line is
+// the story.
 NodeRuntime.runMain(
   Layer.launch(main).pipe(
     // The platform's ServeError says nothing itself; the reason (the port
     // is taken) is the cause underneath.
-    Effect.tapError((err) => Effect.sync(() => log(db, { level: "fatal", text: `proxy: ${errorDetail(err)}` }))),
+    Effect.tapError((err) => Effect.sync(() => log(db, { level: "fatal", text: `proxy: ${errorDetail(err)}` }, { cause: err }))),
   ),
   {
     disableErrorReporting: true,
     teardown: (exit, onExit) => {
-      void flushLogs().then(() => {
+      void Promise.all([flushLogs(), flushSentry()]).then(() => {
         if (Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause)) {
           return onExit(1);
         }

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -569,7 +569,7 @@ const main = Layer.effectDiscard(
     log(db, `oligarchy proxy listening on ${addr}`);
     server.on("error", (err) => {
       log(db, { level: "fatal", text: `proxy: ${err.message}` }, { cause: err });
-      void Promise.all([flushLogs(), flushSentry()]).then(() => process.exit(1));
+      void flushLogs().then(flushSentry).then(() => process.exit(1));
     });
   }),
 ).pipe(
@@ -592,7 +592,7 @@ NodeRuntime.runMain(
   {
     disableErrorReporting: true,
     teardown: (exit, onExit) => {
-      void Promise.all([flushLogs(), flushSentry()]).then(() => {
+      void flushLogs().then(flushSentry).then(() => {
         if (Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause)) {
           return onExit(1);
         }

--- a/src/qemu/stats.ts
+++ b/src/qemu/stats.ts
@@ -7,6 +7,7 @@
 // p10/p25/p75/p90 percentiles. The cpu fields are 0 until the first tick.
 
 import os from "node:os";
+import { capture } from "../sentry.ts";
 
 const SAMPLE_INTERVAL_MS = 5_000;
 const MAX_SAMPLES = 60; // 60 samples x 5s ticks = a 5 minute window
@@ -91,6 +92,7 @@ function sampleCpu(sampler: CpuSampler): void {
   } catch (error) {
     // An uncaught throw in a timer callback would take down the whole proxy.
     console.error("failed to sample cpu usage:", error);
+    capture({ text: "failed to sample cpu usage", level: "error", cause: error });
   }
 }
 

--- a/src/sentry-dsn.ts
+++ b/src/sentry-dsn.ts
@@ -1,0 +1,3 @@
+// The Sentry project DSN. Public by design — it can send events, not read them.
+export const SENTRY_DSN =
+  "https://8537fd5d18e270275f263f9af70f773f@o4510324148862976.ingest.us.sentry.io/4512001067581440";

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,0 +1,53 @@
+// Sentry for the proxy. Init reads SENTRY_DSN; with no DSN every call is a
+// no-op so a local boot does not need a project. capture() is what log()
+// calls for error and fatal (and for the log-insert failure that cannot
+// go through log() again). flush() is for the process.exit paths so the
+// last event is not dropped.
+
+import * as Sentry from "@sentry/node";
+
+const dsn = process.env.SENTRY_DSN;
+
+export function initSentry(): void {
+  if (dsn === undefined || dsn === "") {
+    return;
+  }
+  Sentry.init({
+    dsn,
+    environment: process.env.SENTRY_ENVIRONMENT,
+  });
+}
+
+export function capture(ctx: {
+  text: string;
+  level: "warning" | "error" | "fatal";
+  sessionId?: string;
+  agentId?: string;
+  cause?: unknown;
+}): void {
+  if (dsn === undefined || dsn === "") {
+    return;
+  }
+  Sentry.withScope((scope) => {
+    if (ctx.sessionId !== undefined) {
+      scope.setTag("session_id", ctx.sessionId);
+    }
+    if (ctx.agentId !== undefined) {
+      scope.setTag("agent_id", ctx.agentId);
+    }
+    scope.setExtra("log", ctx.text);
+    scope.setLevel(ctx.level);
+    if (ctx.cause !== undefined) {
+      Sentry.captureException(ctx.cause);
+    } else {
+      Sentry.captureMessage(ctx.text);
+    }
+  });
+}
+
+export function flushSentry(): Promise<void> {
+  if (dsn === undefined || dsn === "") {
+    return Promise.resolve();
+  }
+  return Sentry.flush().then(() => undefined);
+}

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,20 +1,17 @@
-// Sentry for the proxy. Init reads SENTRY_DSN; with no DSN every call is a
-// no-op so a local boot does not need a project. capture() is what log()
-// calls for error and fatal (and for the log-insert failure that cannot
-// go through log() again). flush() is for the process.exit paths so the
-// last event is not dropped.
+// Sentry for the proxy. The DSN is the Cloudflare project's — this process
+// is Node (QEMU cannot run on a worker), so the SDK is @sentry/node, and
+// Effect's respond middleware plus log() decide what is an event: 5xx and
+// operational failures, not 4xx. capture() is what log() calls for error
+// and fatal (and for the log-insert failure that cannot go through log()
+// again). flush() is for the process.exit paths so the last event is not
+// dropped.
 
 import * as Sentry from "@sentry/node";
-
-const dsn = process.env.SENTRY_DSN;
+import { SENTRY_DSN } from "./sentry-dsn.ts";
 
 export function initSentry(): void {
-  if (dsn === undefined || dsn === "") {
-    return;
-  }
   Sentry.init({
-    dsn,
-    environment: process.env.SENTRY_ENVIRONMENT,
+    dsn: SENTRY_DSN,
   });
 }
 
@@ -25,9 +22,6 @@ export function capture(ctx: {
   agentId?: string;
   cause?: unknown;
 }): void {
-  if (dsn === undefined || dsn === "") {
-    return;
-  }
   Sentry.withScope((scope) => {
     if (ctx.sessionId !== undefined) {
       scope.setTag("session_id", ctx.sessionId);
@@ -46,9 +40,6 @@ export function capture(ctx: {
 }
 
 export function flushSentry(): Promise<void> {
-  if (dsn === undefined || dsn === "") {
-    return Promise.resolve();
-  }
   // Two seconds: a stalled ingest must not hold the exit.
   return Sentry.flush(2_000).then(() => undefined);
 }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -49,5 +49,6 @@ export function flushSentry(): Promise<void> {
   if (dsn === undefined || dsn === "") {
     return Promise.resolve();
   }
-  return Sentry.flush().then(() => undefined);
+  // Two seconds: a stalled ingest must not hold the exit.
+  return Sentry.flush(2_000).then(() => undefined);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The DSN is now in the repo (`src/sentry-dsn.ts`). You do not need to set `SENTRY_DSN`.

The snippet you sent is the Cloudflare wizard's Hello World wrapper. This app has two processes, so it is adapted:

- **Dashboard** (Cloudflare worker) — `Sentry.withSentry` from `@sentry/cloudflare` wraps the Hono app with that DSN.
- **Proxy** (Node, boots QEMU) — cannot be a worker. `@sentry/node` inits with the same DSN. Effect's respond middleware plus `log()` decide what is an event.

## What is reported (proxy)

`log()` is the one reporting path. Error and fatal lines go to Sentry, with the original exception when we have one, plus `session_id` / `agent_id` tags.

- **500s** and defects (bugs)
- **502s** — QEMU failed to start, QMP exchange failed, handshake timeout, ISO download failure
- **Database failures** — action close, session record, log insert, timeout/shutdown recording
- **Timeout failures** — handshake timeout, and a timeout cleanup that could not stop or record the session
- **Fatal** — listen/acceptor death, the proxy going down

Exit paths flush the log chain first, then Sentry (2s bound).

## What is not reported

- **4xx** — bad request and unknown session. Still an error line in the logs table; they are the client's mistake.
- **Successful 10-minute inactivity timeouts** — those stay at info in the database (`timed_out`). Cleanup *failures* on that path do go to Sentry.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a053a2-fc0d-7821-9265-7cc844086328?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a053a2-fc0d-7821-9265-7cc844086328&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

