### PR TITLE
Drop sslrootcert=system from DATABASE_URL before pg parses it

### DIFF
--- a/field-guide/database.md
+++ b/field-guide/database.md
@@ -4,13 +4,13 @@ One PlanetScale Postgres database holds the record of everything the proxy does.
 
 ## The state that threads through
 
-`connectDatabase()` builds one drizzle client from `DATABASE_URL` (the password rides inside the url). That client is the server state: every operation below is a standalone function taking it as its first argument, so no other code carries connection details around. A missing `DATABASE_URL` throws — a control plane that cannot record its sessions is not allowed to limp into requests (see the [philosophy](philosophy.md): startup requirements fail at startup).
+`connectDatabase()` builds one drizzle client from `DATABASE_URL` (the password rides inside the url). That client is the server state: every operation below is a standalone function taking it as its first argument, so no other code carries connection details around. A missing or unparseable `DATABASE_URL` throws — a control plane that cannot record its sessions is not allowed to limp into requests (see the [philosophy](philosophy.md): startup requirements fail at startup). One parameter is rewritten on the way in: PlanetScale urls end in `sslmode=verify-full&sslrootcert=system`, and node-postgres reads `sslrootcert` as a literal file path — a file named `system` does not exist, so the first query would die with ENOENT. Node's default TLS verification already is the system trust store that value asks for, so `connectDatabase()` drops the parameter and passes the rest of the url through, `sslmode=verify-full` included.
 
 ## The operations
 
 | Function | Arguments | What it writes |
 | --- | --- | --- |
-| `connectDatabase` | — | nothing; builds the `Db` client from `DATABASE_URL`, throws when unset |
+| `connectDatabase` | — | nothing; builds the `Db` client from `DATABASE_URL` (dropping a `sslrootcert=system` parameter), throws when unset or unparseable |
 | `insertSession` | `db, id, config, status` | the session row, before any boot work; status `downloading` for a url iso, else `running` |
 | `sessionRunning` | `db, id` | status → `running` once the QEMU is up, whatever status the session entered in |
 | `endSession` | `db, id, status, reason` | verdict (`succeeded`/`failed`/`aborted`/`timed_out`), reason, `ended_at` — on the session and its open agent runs, in one transaction stamped by one `now()` |

--- a/src/db/ops.ts
+++ b/src/db/ops.ts
@@ -14,12 +14,30 @@ export type Db = NodePgDatabase;
 
 /**
  * Builds the database client from DATABASE_URL. A server that cannot record
- * its sessions must not boot, so a missing url throws instead of degrading.
+ * its sessions must not boot, so a missing or unparseable url throws instead
+ * of degrading.
  */
 export function connectDatabase(): Db {
   const url = process.env.DATABASE_URL;
   if (url === undefined || url === "") {
     throw new Error("db: DATABASE_URL is not set");
+  }
+  // canParse instead of letting new URL throw: that TypeError carries the
+  // url — password included — into the logs.
+  if (!URL.canParse(url)) {
+    throw new Error("db: DATABASE_URL is not a valid url");
+  }
+  // PlanetScale urls carry sslrootcert=system — libpq 16's "verify against
+  // the system trust store". node-postgres has no such special value: it
+  // reads sslrootcert as a literal file path, so the first query dies with
+  // ENOENT, no file named "system" (node-postgres#3101). Node's default TLS
+  // verification already is the system trust store, so dropping the
+  // parameter keeps the exact semantics the url asks for — the
+  // sslmode=verify-full beside it stays, and pg honors it.
+  const parsed = new URL(url);
+  if (parsed.searchParams.get("sslrootcert") === "system") {
+    parsed.searchParams.delete("sslrootcert");
+    return drizzle(parsed.toString());
   }
   return drizzle(url);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A PlanetScale Postgres URL ending in `?sslmode=verify-full&sslrootcert=system` crashes the proxy at its first query with:

```
Error: ENOENT: no such file or directory, open 'system'
```

`pg`'s connection-string parser reads `sslrootcert` as a literal file path, unconditionally (`pg-connection-string@2.14.0`, the latest shipped with `pg@8.23.0` — the `fs.readFileSync` runs even in `uselibpqcompat` mode). The value `system` is a libpq 16+ special value meaning "verify against the system trust store", which node-postgres has never implemented — upstream issue [brianc/node-postgres#3101](https://github.com/brianc/node-postgres/issues/3101) is still open, and the maintainer confirms there that node-postgres's **default** TLS behavior already is `sslrootcert=system` semantics.

## Fix

`connectDatabase()` drops the `sslrootcert` parameter when its value is exactly `system` — Node's default verification (full chain + hostname against trusted roots) is precisely what the value asks for, and the `sslmode=verify-full` beside it stays in the URL, which `pg` honors natively. Any URL without that parameter passes through as the original string. A real `sslrootcert=/path/to/ca.pem` is untouched and `pg` still reads the file.

One supporting guard: `URL.canParse` rejects an unparseable `DATABASE_URL` at boot with a named error. Letting `new URL` throw instead would print a `TypeError` whose `input` property carries the full URL — password included — into the logs, and previously a malformed URL only failed at the first query, after the proxy had already booted.

The field guide (`field-guide/database.md`) documents the rewrite.

## Verification

Disposable harness (not committed, per the field guide's testing philosophy), all five cases pass:

1. The poisoned URL previously threw ENOENT at first query through drizzle; it now parses and proceeds to the network (fails only on DNS for a fake host).
2. `pg` receives `ssl: {}` + `sslmode=verify-full` for the stripped URL — TLS on, full verification.
3. URLs without the parameter reach drizzle byte-identical.
4. `sslrootcert` pointing at a real file path is still read by `pg` as before.
5. A garbage `DATABASE_URL` fails at boot with `db: DATABASE_URL is not a valid url`.

`oxlint --type-aware` and all 28 existing tests pass. GPT-5.6 Sol review pass per AGENTS.md: no findings.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a053a7-cc10-7519-9d1f-18b3b25372aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a053a7-cc10-7519-9d1f-18b3b25372aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

