### PR TITLE
Strip comments down to the tricky edge cases

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -11,8 +11,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # Committed migrations are history: they may only be added, never
-      # changed. The journal is the one file the generator itself appends to.
       - name: fail if an existing migration file was edited, deleted, or renamed
         run: |
           violations=$(git diff --name-status --diff-filter=MDRT \
@@ -35,8 +33,6 @@ jobs:
           node-version: 22
       - run: npm ci
       - run: npx drizzle-kit check
-      # If the schema changed without a migration, generate produces new
-      # files and the tree goes dirty — that is the failure.
       - name: fail if drizzle-kit generate produces changes
         run: |
           npm run db:generate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@ Check the field guide: [field-guide/index.md](field-guide/index.md).
 - We do not use classes. Never write a class. Use a functional style instead: plain state objects created by factory functions, operated on by standalone functions that take the state object as their first argument.
 - Use the TypeScript `private` modifier for private class members and methods. Never use JavaScript private identifiers (`#name`). TypeScript `private` works good enough.
 
+## Comments
+
+- Do not write comments. Code says what it does; a comment restating it is noise. This covers doc comments, file headers, and narration of any kind.
+- The one exception is a genuinely tricky edge case whose intent cannot live in the code: an upstream bug worked around, an ordering that correctness depends on, a deliberate race, a magic number's meaning. One or two lines naming the constraint, nothing more.
+
 ## Tests
 
 - Do not add tests unless explicitly told to.

--- a/src/cursor-agent/client.ts
+++ b/src/cursor-agent/client.ts
@@ -1,18 +1,13 @@
 import { Agent } from "@cursor/sdk";
 
-// Auth comes from the CURSOR_API_KEY environment variable, the SDK's default.
-
 export type StartOptions = {
-  /** Model id for the session. The server picks one when omitted. */
   model?: string;
 };
 
 export type CursorAgent = {
-  /** The session ID: the SDK's bc-… cloud agent id. */
   readonly session: string;
 };
 
-/** Starts a new Cursor cloud agent session. */
 export async function start(options: StartOptions = {}): Promise<CursorAgent> {
   const handle = await Agent.create({
     model: options.model === undefined ? undefined : { id: options.model },
@@ -23,7 +18,6 @@ export async function start(options: StartOptions = {}): Promise<CursorAgent> {
   return { session };
 }
 
-/** Sends text to the agent's session and resolves with the reply once the run finishes. */
 export async function prompt(agent: CursorAgent, text: string): Promise<string> {
   const handle = await Agent.resume(agent.session);
   try {
@@ -39,7 +33,6 @@ export async function prompt(agent: CursorAgent, text: string): Promise<string> 
   }
 }
 
-/** Stops the agent's session: cancels its active run, if any, and archives it. */
 export async function stop(agent: CursorAgent): Promise<void> {
   const runs = await Agent.listRuns(agent.session, { runtime: "cloud", limit: 1 });
   const run = runs.items.at(0);
@@ -49,16 +42,12 @@ export async function stop(agent: CursorAgent): Promise<void> {
   await Agent.archive(agent.session);
 }
 
-/** One-shot: starts a session, prompts it, stops it, and returns the reply. */
 export async function oneShotPrompt(text: string): Promise<string> {
   const agent = await start();
   let reply: string;
   try {
     reply = await prompt(agent, text);
   } catch (err) {
-    // The prompt error is the one worth seeing: stop still runs, but its own
-    // failure is swallowed so it cannot replace err. Worst case the session
-    // stays unarchived.
     await stop(agent).catch(() => {});
     throw err;
   }

--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -1,45 +1,18 @@
-// The database logger. log() writes a line to stderr and inserts the same
-// line into the logs table, attributed to a QEMU session and a cloud agent
-// when the caller has them, at a severity the caller picks (info when it
-// does not say):
-//
-//   log(db, "iso: cache pruned");
-//   log(db, { text: `iso: downloading ${url}`, sessionId, agentId });
-//   log(db, { level: "error", text: `POST /start failed: ${message}` });
-//
-// error and fatal also go to Sentry — that is the one reporting path, so
-// a failed request, a db write that would not record, and a dying proxy
-// show up in the same place. A 4xx is still an error line (a refused
-// request is a failed request) but is the client's mistake: the caller
-// passes skipSentry. The optional cause is the exception Sentry should
-// group on; without one the text is the event.
-//
-// The db is the one client connectDatabase() built (see ops.ts); this file
-// never touches connection details.
-
 import { capture } from "../sentry.ts";
 import type { Db } from "./ops.ts";
 import { logs } from "./schema.ts";
 
-// Ascending severity, matching the log_level enum's declaration order.
-// info: the normal story. warning: something was off but the operation
-// went on. error: an operation failed. fatal: the process is going down —
-// the writer exits right after flushLogs().
 export type LogLevel = "info" | "warning" | "error" | "fatal";
 
 export type LogEntry = {
   text: string;
-  /** Severity of the line; omitted means info. */
   level?: LogLevel;
-  /** The QEMU session the line belongs to. */
   sessionId?: string;
-  /** The cloud agent the line is attributed to. */
   agentId?: string;
 };
 
-// Inserts are chained so rows land in call order — id is the tiebreaker for
-// lines whose created_at collide. A failed insert reports itself to stderr
-// and never fails the caller or the lines behind it.
+// Inserts are chained so rows land in call order; a failed insert reports itself to
+// stderr and never fails the caller or the lines behind it.
 let chain: Promise<void> = Promise.resolve();
 
 export function log(
@@ -48,8 +21,6 @@ export function log(
   report?: { cause?: unknown; skipSentry?: true },
 ): void {
   const line: LogEntry = typeof entry === "string" ? { text: entry } : entry;
-  // info stays bare on stderr — it is the default story; the levels worth
-  // noticing carry their name.
   console.error(line.level === undefined || line.level === "info" ? line.text : `${line.level}: ${line.text}`);
   if ((line.level === "error" || line.level === "fatal") && report?.skipSentry !== true) {
     capture({
@@ -64,8 +35,7 @@ export function log(
     try {
       await db.insert(logs).values(line);
     } catch (err) {
-      // Drizzle buries the reason (ECONNREFUSED etc.) in the cause; its own
-      // message is the failed SQL and the params — noise here.
+      // Drizzle buries the reason (ECONNREFUSED etc.) in the cause; its own message is the failed SQL.
       const e = err as Error;
       const detail = e.cause instanceof Error ? e.cause.message : e.message;
       console.error(`db: log insert failed: ${detail}`);
@@ -74,12 +44,6 @@ export function log(
   });
 }
 
-/**
- * Settles once every line queued so far has been written (or reported its
- * failure to stderr). For paths that end in process.exit — a plain exit
- * would drop the queued rows. Never rejects: every link in the chain
- * catches its own failure.
- */
 export function flushLogs(): Promise<void> {
   return chain;
 }

--- a/src/db/ops.ts
+++ b/src/db/ops.ts
@@ -1,39 +1,24 @@
-// The control-plane database interface. connectDatabase() turns DATABASE_URL
-// (a PlanetScale Postgres url; the password rides inside it) into the one
-// client every operation below takes as its first argument — no other file
-// touches connection details.
-//
-// Write-only on purpose: recording happens here, reading belongs to replay
-// tooling.
-
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { actions, agentRuns, images, sessions } from "./schema.ts";
 
 export type Db = NodePgDatabase;
 
-/**
- * Builds the database client from DATABASE_URL. A server that cannot record
- * its sessions must not boot, so a missing or unparseable url throws instead
- * of degrading.
- */
 export function connectDatabase(): Db {
   const url = process.env.DATABASE_URL;
   if (url === undefined || url === "") {
     throw new Error("db: DATABASE_URL is not set");
   }
-  // canParse instead of letting new URL throw: that TypeError carries the
-  // url — password included — into the logs.
+  // canParse instead of letting new URL throw: that TypeError carries the url —
+  // password included — into the logs.
   if (!URL.canParse(url)) {
     throw new Error("db: DATABASE_URL is not a valid url");
   }
-  // PlanetScale urls carry sslrootcert=system — libpq 16's "verify against
-  // the system trust store". node-postgres has no such special value: it
-  // reads sslrootcert as a literal file path, so the first query dies with
-  // ENOENT, no file named "system" (node-postgres#3101). Node's default TLS
-  // verification already is the system trust store, so dropping the
-  // parameter keeps the exact semantics the url asks for — the
-  // sslmode=verify-full beside it stays, and pg honors it.
+  // PlanetScale urls carry sslrootcert=system — libpq 16's "verify against the system
+  // trust store". node-postgres reads sslrootcert as a literal file path, so the first
+  // query dies with ENOENT (node-postgres#3101). Node's default TLS verification
+  // already is the system trust store, so dropping the parameter keeps the url's exact
+  // semantics; the sslmode=verify-full beside it stays.
   const parsed = new URL(url);
   if (parsed.searchParams.get("sslrootcert") === "system") {
     parsed.searchParams.delete("sslrootcert");
@@ -42,29 +27,22 @@ export function connectDatabase(): Db {
   return drizzle(url);
 }
 
-/** Creates the session row, before any boot work happens. */
 export async function insertSession(db: Db, id: string, config: unknown, status: SessionStartStatus): Promise<void> {
   await db.insert(sessions).values({ id, config, status });
 }
 
-/** Marks the session running once its QEMU is up. */
 export async function sessionRunning(db: Db, id: string): Promise<void> {
   await db.update(sessions).set({ status: "running" }).where(eq(sessions.id, id));
 }
 
-/**
- * Closes a session with its verdict and stamps ended_at — on the session and
- * on every agent run still driving it. One transaction: a session cannot end
- * while its runs stay open.
- */
 export async function endSession(
   db: Db,
   id: string,
   status: SessionEndStatus,
   reason: string | null,
 ): Promise<void> {
-  // now() is transaction-start time in Postgres: the session and its runs
-  // stamp the same instant, from the same clock that wrote started_at.
+  // now() is transaction-start time in Postgres: the session and its runs stamp the
+  // same instant, from the same clock that wrote started_at.
   const endedAt = sql`now()`;
   await db.transaction(async (tx) => {
     await tx.update(sessions).set({ status, reason, endedAt }).where(eq(sessions.id, id));
@@ -72,56 +50,26 @@ export async function endSession(
   });
 }
 
-/**
- * Ties a cloud agent to the session it drives. The agent id is the primary
- * key, so an agent registering a second session is a database error — by
- * design, an agent drives exactly one session.
- */
 export async function registerAgent(db: Db, agentId: string, sessionId: string): Promise<void> {
   await db.insert(agentRuns).values({ agentId, sessionId });
 }
 
-/**
- * One QMP exchange: the exact JSON sent to QEMU, whose execute field names
- * the command. Anything that exchanges nothing over QMP (a stop, a verdict)
- * is not an action — the session's status and reason are its record.
- */
 export type Action = {
   sessionId: string;
-  /** The agent driving the session — every request names one. */
   agentId: string;
   request: QemuCommand;
 };
 
-/**
- * How the exchange ended — the only two states an action can finish in.
- * completed: the response is QEMU's exact reply. failed: the response is
- * QEMU's {error} reply, or this server's error message when the failure
- * never reached QEMU (a timeout, a dead socket).
- */
 export type Outcome =
   | { state: "completed"; response: QemuGreetingResponse | QemuSuccessResponse }
   | { state: "failed"; response: QemuErrorResponse | string };
 
-/**
- * Opens an action: one replay-log row per QMP exchange, inserted when the
- * command goes out. Returns the action's id — the auto-incrementing number
- * finishAction closes it by.
- */
 export async function startAction(db: Db, action: Action): Promise<number> {
   const [row] = await db.insert(actions).values(action).returning({ id: actions.id });
   return row.id;
 }
 
-/**
- * Closes an action with its outcome and stamps finished_at. A completed
- * get-image passes its PNG, and the update and image insert land in one
- * transaction: images are 1:1 with their action, and a torn pair would
- * break that promise.
- */
 export async function finishAction(db: Db, id: number, outcome: Outcome, image?: Buffer): Promise<void> {
-  // The database clock stamps both ends: finished_at - created_at is real
-  // handling time, not cross-clock arithmetic.
   const close = { state: outcome.state, response: outcome.response, finishedAt: sql`now()` };
   if (image === undefined) {
     await db.update(actions).set(close).where(eq(actions.id, id));

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,37 +1,18 @@
-// Drizzle schema for the control-plane database (PlanetScale Postgres).
-//
-// Five tables: sessions (one row per QEMU boot), agent_runs (which cloud
-// agents drove it), actions (every QMP exchange, in order), images (the
-// PNG each get-image returned), and logs (lines from db.log at a severity
-// level, each pinned to a session and an agent when the writer had them).
-//
-// Replaying a session is: actions WHERE session_id ORDER BY created_at, id.
-// Debugging one is that plus: logs WHERE session_id, same order.
-
 import { bigint, customType, index, jsonb, pgEnum, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
 // drizzle-orm has no built-in bytea column type for postgres.
 const bytea = customType<{ data: Buffer }>({ dataType: () => "bytea" });
 
-// downloading = the ISO is being fetched from the internet; the session
-// exists but QEMU has not booted yet.
 export const sessionStatus = pgEnum("session_status", ["downloading", "running", "succeeded", "failed", "aborted", "timed_out"]);
 // Declared in ascending severity: Postgres orders enums by declaration, so
-// "WHERE level >= 'error'" reads the scary lines. fatal is the line written
-// on the way down — the process exits right after it.
+// "WHERE level >= 'error'" reads the scary lines.
 export const logLevel = pgEnum("log_level", ["info", "warning", "error", "fatal"]);
-// The only two states an exchange can finish in. An action that is still
-// running has no state yet (null, alongside a null finished_at).
 export const actionState = pgEnum("action_state", ["completed", "failed"]);
 
 export const sessions = pgTable("sessions", {
-  // The uuid minted by the server at /start — not a database default.
   id: uuid("id").primaryKey(),
-  // The effective launch config after server defaults were applied, so a
-  // replay can boot an identical machine — not just what the client asked for.
   config: jsonb("config").notNull(),
   status: sessionStatus("status").notNull().default("running"),
-  // Optional explanation for the verdict, in practice the failure reason.
   reason: text("reason"),
   startedAt: timestamp("started_at", { withTimezone: true }).notNull().defaultNow(),
   endedAt: timestamp("ended_at", { withTimezone: true }),
@@ -40,8 +21,8 @@ export const sessions = pgTable("sessions", {
 export const agentRuns = pgTable(
   "agent_runs",
   {
-    // The cloud agent's own external id. An agent drives exactly one session,
-    // so this is the primary key: registering it twice is a database error.
+    // An agent drives exactly one session, so its id is the primary key:
+    // registering a second session is a database error by design.
     agentId: text("agent_id").primaryKey(),
     sessionId: uuid("session_id")
       .notNull()
@@ -55,29 +36,15 @@ export const agentRuns = pgTable(
 export const actions = pgTable(
   "actions",
   {
-    // Insert order at the single server; the replay tiebreaker for actions
-    // whose created_at collide.
     id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
     sessionId: uuid("session_id")
       .notNull()
       .references(() => sessions.id),
-    // Kept nullable for historical rows; the proxy now always writes an
-    // agent id (the HTTP layer requires one on every driving request).
+    // Nullable for historical rows only; the proxy now always writes an agent id.
     agentId: text("agent_id").references(() => agentRuns.agentId),
-    // The exact JSON sent to QEMU over QMP (a QemuCommand); its execute
-    // field names the command.
     request: jsonb("request").notNull(),
-    // How the exchange ended. completed: response is QEMU's exact reply
-    // (the greeting for qmp_capabilities at boot, the {return} reply
-    // otherwise; a get-image's PNG lives in images). failed: response is
-    // QEMU's {error} reply, or this server's error message when the failure
-    // never reached QEMU (a timeout, a dead socket).
     state: actionState("state"),
     response: jsonb("response"),
-    // The row is inserted when the command goes out and closed when the
-    // exchange ends; state, response, and finished_at land together. A row
-    // where they are null is an exchange whose completion was never
-    // persisted. Handling time is finished_at - created_at.
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     finishedAt: timestamp("finished_at", { withTimezone: true }),
   },
@@ -85,30 +52,20 @@ export const actions = pgTable(
 );
 
 export const images = pgTable("images", {
-  // 1:1 with its get-image action, so the action id is the primary key.
   actionId: bigint("action_id", { mode: "number" })
     .primaryKey()
     .references(() => actions.id),
-  // Blob for now: when images move somewhere smarter, only this table changes.
   data: bytea("data").notNull(),
 });
 
-// Debug lines written by log() in src/db/log.ts; every line also goes to
-// stderr. session_id and agent_id are attribution, not relations — a log
-// must never be refused because the row it names is missing or already
-// gone, so neither is a foreign key.
+// session_id and agent_id are attribution, not relations: a log must never be refused
+// because the row it names is missing or already gone, so neither is a foreign key.
 export const logs = pgTable(
   "logs",
   {
-    // Assigned in insert order; the tiebreaker for lines whose created_at
-    // collide.
     id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
-    // The QEMU session the line belongs to; null for server-wide work.
     sessionId: uuid("session_id"),
-    // The cloud agent the line is attributed to; null when none was involved.
     agentId: text("agent_id"),
-    // Severity, defaulting to info: most lines are the normal story, and a
-    // writer should not have to say so (see log.ts for what each level means).
     level: logLevel("level").notNull().default("info"),
     text: text("text").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/src/qemu/cli.ts
+++ b/src/qemu/cli.ts
@@ -1,15 +1,3 @@
-// The oligarchy CLI: a main file, not a library. It drives the oligarchy
-// control plane (src/qemu/proxy.ts) over HTTP.
-//
-//   node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> start [--iso <path>] [--disk <path>]
-//   node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> get-image <id> [-o file]
-//   node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-keys <id> <keys> [encoding]
-//
-// The server address comes from OLIGARCHY_ADDR (default 127.0.0.1:42069).
-// --agent-id leads every invocation: this client is driven by agents, not
-// humans, and every request names the agent so the server can attribute the
-// session's actions to it.
-
 import { stat, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
@@ -18,8 +6,6 @@ const DEFAULT_ISO = "omarchy.iso";
 const DEFAULT_ENCODING = "oligarchy";
 
 async function main(args: string[]): Promise<void> {
-  // --agent-id leads every invocation. This client is used by agents, not
-  // humans; a request that names no agent has no business being sent.
   if (args.length < 3 || args[0] !== "--agent-id" || args[1] === "") {
     usage();
     process.exitCode = 2;
@@ -77,8 +63,6 @@ async function cmdStart(agent: string, args: string[]): Promise<void> {
     }
   }
   iso = iso === "" ? DEFAULT_ISO : iso;
-  // An http(s) iso is the server's to download and cache; only a file path
-  // is resolved and checked here.
   if (!iso.startsWith("http://") && !iso.startsWith("https://")) {
     iso = resolve(iso);
     try {
@@ -99,7 +83,6 @@ async function cmdStart(agent: string, args: string[]): Promise<void> {
 }
 
 async function cmdGetImage(agent: string, args: string[]): Promise<void> {
-  // The three accepted forms: <id>, <id> -o <file>, and -o <file> <id>.
   let id = "";
   let out = "";
   if (args.length === 1) {
@@ -147,8 +130,6 @@ async function postJSON(path: string, body: unknown): Promise<string> {
   return res.text();
 }
 
-// The server writes errors as {"error": "..."}; anything else (a proxy in
-// the way, a wrong port) falls back to the raw body.
 async function readAPIError(res: Response): Promise<string> {
   const data = await res.text();
   try {

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -266,6 +266,7 @@ async function execute(qemu: Qemu, name: string, args: unknown, record?: QemuExc
     });
     throw err;
   }
+  // Outside the try: a failing close must surface as itself, not relabel the completed exchange as failed.
   await close?.({ state: "completed", response });
   return response.return;
 }

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -63,7 +63,6 @@ export function createQemu(options: QemuOptions = {}): Qemu {
   };
 }
 
-/** Creates the backing qcow2 at diskPath inside the session dir. */
 export async function createDisk(qemu: Qemu): Promise<string> {
   await mkdir(qemu.dir, { recursive: true, mode: 0o700 });
   const size = qemu.options.diskSize ?? DEFAULT_DISK_SIZE;
@@ -83,10 +82,6 @@ export async function createDisk(qemu: Qemu): Promise<string> {
   return qemu.diskPath;
 }
 
-/**
- * Launches QEMU and negotiates QMP over the session socket.
- * The session dir must already exist; createDisk creates it.
- */
 export async function start(
   qemu: Qemu,
   options: QemuStartOptions = {},
@@ -118,8 +113,7 @@ export async function start(
     timer = setTimeout(() => reject(new Error("qemu: handshake timeout")), HANDSHAKE_MS);
   });
 
-  // QEMU connects to us: listen on the session socket, then spawn. The
-  // listener accepts the one QMP connection and is closed in the finally.
+  // QEMU connects to us: listen on the session socket, then spawn.
   const server = createServer();
   try {
     const connection = new Promise<Socket>((resolve, reject) => {
@@ -161,8 +155,7 @@ export async function start(
           }
           qemu.pending.delete(id);
           if ("error" in msg) {
-            // QEMU's raw {error} reply rides the rejection so a recorder
-            // can store the exact JSON, not just the flattened message.
+            // The raw {error} reply rides the rejection so a recorder can store the exact JSON.
             pending.reject(Object.assign(new Error(`${msg.error.class}: ${msg.error.desc}`), { qmp: msg }));
           } else {
             pending.resolve(msg);
@@ -177,8 +170,7 @@ export async function start(
     socket.on("close", () => failAll(qemu, new Error("qemu: socket closed")));
 
     const greetingMsg = (await Promise.race([greeting, timeout])) as QemuGreetingResponse;
-    // The greeting is the recorded reply for the boot's qmp_capabilities:
-    // its own {return} is empty, the greeting is what the handshake said.
+    // The greeting is the recorded reply for the boot's qmp_capabilities: its own {return} is empty.
     const bootRecord: QemuExchangeRecorder | undefined =
       record === undefined
         ? undefined
@@ -260,8 +252,6 @@ async function execute(qemu: Qemu, name: string, args: unknown, record?: QemuExc
   }
   const id = ++qemu.nextId;
   const command = { execute: name, arguments: args, id } as QemuCommand;
-  // The row opens before the command goes out — awaited, so a refused
-  // insert fails the exchange up front instead of dying unhandled later.
   const close = record === undefined ? undefined : await record(command);
   let response: QemuSuccessResponse;
   try {
@@ -271,15 +261,11 @@ async function execute(qemu: Qemu, name: string, args: unknown, record?: QemuExc
     })) as QemuSuccessResponse;
   } catch (err) {
     const failure = (err as { qmp?: QemuErrorResponse }).qmp ?? (err as Error).message;
-    // The exchange error is the one worth seeing; a failed close cannot
-    // replace it (the one-shot cleanup pattern in cursor-agent/client.ts).
     await close?.({ state: "failed", response: failure }).catch((closeErr: unknown) => {
       console.error(`db: recording a failed exchange failed too: ${(closeErr as Error).message}`);
     });
     throw err;
   }
-  // Closed outside the catch: a failing close surfaces as itself and can
-  // never relabel a completed exchange as failed.
   await close?.({ state: "completed", response });
   return response.return;
 }

--- a/src/qemu/iso.ts
+++ b/src/qemu/iso.ts
@@ -1,11 +1,3 @@
-// ISO resolution for the proxy. getIso turns whatever a client named as
-// "iso" into an absolute file path: a plain path is resolved and must
-// exist, an http(s) url is downloaded into ~/.oligarchy/isos once and
-// served from the cache ever after. manifest.json sits beside the cached
-// isos and records when each was cached and last used, so the cache can be
-// pruned by size later — and, while a download runs, carries its claim so
-// other proxies wait for it instead of downloading the same iso twice.
-
 import { createHash } from "node:crypto";
 import { createWriteStream } from "node:fs";
 import type { Stats } from "node:fs";
@@ -18,22 +10,17 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { log } from "../db/log.ts";
 import type { Db } from "../db/ops.ts";
 
-// Who an iso event is logged for: the session whose /start needs the iso,
-// and the agent driving it.
 type Who = { sessionId: string; agentId: string };
 
 const ISO_DIR = join(homedir(), ".oligarchy", "isos");
 const MANIFEST_PATH = join(ISO_DIR, "manifest.json");
 
-// A downloader refreshes its claim's heartbeat while bytes flow; waiters
-// recheck on the same ten-second cadence and treat three missed beats as a
-// dead downloader.
+// A downloader refreshes its claim's heartbeat while bytes flow; waiters poll on the
+// same cadence and treat three missed beats as a dead downloader.
 const HEARTBEAT_MS = 10_000;
 const POLL_MS = 10_000;
 const STALE_MS = 3 * HEARTBEAT_MS;
 
-// Per cached file: either a live download claim (heartbeatAt advances while
-// bytes flow) or the cached timestamps pruning will need later.
 type ManifestEntry =
   | { status: "downloading"; heartbeatAt: string }
   | { status: "cached"; cachedAt: string; lastUsedAt: string };
@@ -47,8 +34,7 @@ export async function getIso(db: Db, name: string, who: Who): Promise<string> {
     } catch {
       throw new Error(`iso: not found: ${path}`);
     }
-    // The path for "--iso ~/isos" instead of the file inside it: QEMU's own
-    // complaint would land in stdio "ignore", so name the mistake here.
+    // QEMU's own complaint would land in stdio "ignore", so name a directory iso here.
     if (info.isDirectory()) {
       throw new Error(`iso: is a directory: ${path}`);
     }
@@ -56,9 +42,6 @@ export async function getIso(db: Db, name: string, who: Who): Promise<string> {
   }
 
   const file = cacheFileName(name);
-  // A fleet booting the same new iso means many concurrent /start calls;
-  // they collapse onto one download instead of one each (attributed to the
-  // session that got here first).
   const inflight = downloads.get(file);
   if (inflight !== undefined) {
     return inflight;
@@ -68,10 +51,6 @@ export async function getIso(db: Db, name: string, who: Who): Promise<string> {
   return promise;
 }
 
-// A cached iso is named by its url with ':' and '/' — and every other
-// character a file name cannot hold — replaced by '_'. Everything legal
-// stays, so the name remains recognizable:
-//   https://iso.omarchy.org/omarchy-3.0.iso -> https___iso.omarchy.org_omarchy-3.0.iso
 function cacheFileName(url: string): string {
   // oxlint-disable-next-line no-control-regex -- control chars are in the forbidden set
   return url.replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_");
@@ -84,11 +63,10 @@ async function downloadCached(db: Db, url: string, file: string, who: Who): Prom
   await mkdir(ISO_DIR, { recursive: true });
   let waitLogged = false;
   for (;;) {
-    // Another proxy mid-download shows up as a claim with a live heartbeat:
-    // wait for its rename instead of downloading the same iso twice. A stale
-    // heartbeat is a dead downloader and gets walked over. Two proxies
-    // claiming in the same instant both download — wasteful, still correct,
-    // since each streams its own partial and the rename is atomic.
+    // A live claim is another proxy mid-download: wait for its rename. A stale
+    // heartbeat is a dead downloader and gets walked over. Two proxies claiming in
+    // the same instant both download — wasteful, still correct, since each streams
+    // its own partial and the rename is atomic.
     const entry = (await readManifest())[file];
     if (entry?.status === "downloading" && Date.now() - Date.parse(entry.heartbeatAt) < STALE_MS) {
       if (!waitLogged) {
@@ -98,8 +76,8 @@ async function downloadCached(db: Db, url: string, file: string, who: Who): Prom
       await sleep(POLL_MS);
       continue;
     }
-    // The claim is checked before the file so a download that finishes
-    // between the two reads is still seen here and not downloaded again.
+    // The claim is checked before the file so a download that finishes between the
+    // two reads is still seen here and not downloaded again.
     const cached = await stat(path).then(
       () => true,
       () => false,
@@ -113,8 +91,8 @@ async function downloadCached(db: Db, url: string, file: string, who: Who): Prom
     try {
       await download(db, url, file, path, who);
     } catch (err) {
-      // Drop the claim so waiters take over right away; if even this write
-      // fails, they still recover once the heartbeat goes stale.
+      // Drop the claim so waiters take over right away; if even this write fails,
+      // they still recover once the heartbeat goes stale.
       await updateManifest(file, "removed").catch(() => {});
       throw err;
     }
@@ -129,22 +107,19 @@ async function download(db: Db, url: string, file: string, path: string, who: Wh
   if (!res.ok || res.body === null) {
     throw new Error(`iso: download failed: ${url}: HTTP ${res.status}`);
   }
-  // Written beside the final name and renamed into place on success, so a
-  // file under the cached name is always a complete download; the pid keeps
-  // two proxies on one machine out of each other's partials.
+  // Renamed into place on success, so a file under the cached name is always a
+  // complete download; the pid keeps two proxies on one machine out of each
+  // other's partials.
   const partial = `${path}.partial-${process.pid}`;
   const hash = createHash("sha256");
   let beatAt = Date.now();
   try {
     await pipeline(
       Readable.fromWeb(res.body),
-      // Hash the bytes on their way to disk; an iso runs to gigabytes and
-      // is not worth a second read.
       async function* (chunks: AsyncIterable<Buffer>) {
         for await (const chunk of chunks) {
           hash.update(chunk);
-          // Keep the claim's heartbeat fresh while bytes flow. A failed
-          // beat only risks a duplicate download elsewhere, never this one.
+          // A failed beat only risks a duplicate download elsewhere, never this one.
           if (Date.now() - beatAt >= HEARTBEAT_MS) {
             beatAt = Date.now();
             updateManifest(file, "downloading").catch((err: unknown) => {
@@ -171,10 +146,8 @@ async function download(db: Db, url: string, file: string, path: string, who: Wh
   }
 }
 
-// Publishers put a sha256sum-style sidecar ("<hex>  <name>") beside the iso
-// at <url>.sha256 — omarchy does. Its first token is the digest. An iso
-// without one gets no check: there is nothing to check against — and a 200
-// whose body is not a digest (a soft-404 page) counts as no sidecar too,
+// The sidecar at <url>.sha256 is sha256sum-style ("<hex>  <name>"); its first token is
+// the digest. A 200 whose body is not a digest (a soft-404 page) counts as no sidecar,
 // not as a mismatch.
 async function publishedSha256(url: string): Promise<string | undefined> {
   const res = await fetch(`${url}.sha256`);
@@ -189,7 +162,6 @@ async function readManifest(): Promise<Record<string, ManifestEntry>> {
   try {
     return JSON.parse(await readFile(MANIFEST_PATH, "utf8")) as Record<string, ManifestEntry>;
   } catch (err) {
-    // No manifest yet — the first cached iso creates it.
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
       throw err;
     }
@@ -197,9 +169,8 @@ async function readManifest(): Promise<Record<string, ManifestEntry>> {
   }
 }
 
-// Every manifest write is a read-modify-write of the whole file; the chain
-// keeps concurrent starts for different isos from interleaving and losing
-// an entry. A failed write must not wedge the writes after it.
+// Manifest writes are read-modify-write of the whole file; the chain keeps concurrent
+// writers from losing entries, and a failed write must not wedge the ones behind it.
 let manifestChain: Promise<unknown> = Promise.resolve();
 
 function updateManifest(file: string, state: "cached" | "downloading" | "removed"): Promise<void> {
@@ -212,14 +183,12 @@ function updateManifest(file: string, state: "cached" | "downloading" | "removed
     } else if (state === "downloading") {
       manifest[file] = { status: "downloading", heartbeatAt: now };
     } else {
-      // A fresh cache gets both stamps; a hit only moves lastUsedAt.
       manifest[file] = {
         status: "cached",
         cachedAt: entry?.status === "cached" ? entry.cachedAt : now,
         lastUsedAt: now,
       };
     }
-    // Temp-write and rename so a crash cannot leave a truncated manifest.
     const partial = `${MANIFEST_PATH}.partial-${process.pid}`;
     await writeFile(partial, `${JSON.stringify(manifest, null, 2)}\n`);
     await rename(partial, MANIFEST_PATH);

--- a/src/qemu/keys.ts
+++ b/src/qemu/keys.ts
@@ -1,6 +1,3 @@
-// Key-string parsing for the oligarchy encoding: literal characters plus
-// angle-bracket names and modifiers, e.g. "Hi<ENTER>" or "<C-S-c>".
-
 const NAMED: Record<string, string> = {
   ENTER: "ret",
   RETURN: "ret",
@@ -42,7 +39,6 @@ const NAMED: Record<string, string> = {
   META_L: "meta_l",
 };
 
-// Punctuation that needs shift on a US keyboard, mapped to the unshifted qcode.
 const SHIFTED: Record<string, string> = {
   "!": "1",
   "@": "2",
@@ -97,7 +93,6 @@ const MODIFIERS: Record<string, string> = {
   META: "meta_l",
 };
 
-/** Turns an encoded key string into send-key chords of QEMU qcodes. */
 export function parseKeys(s: string, encoding = "oligarchy"): string[][] {
   if (encoding !== "" && encoding.toLowerCase() !== "oligarchy") {
     throw new Error(`qemu: unknown key encoding "${encoding}"`);
@@ -119,7 +114,6 @@ export function parseKeys(s: string, encoding = "oligarchy"): string[][] {
   return out;
 }
 
-/** Parses the inside of <...>: optional dash-separated modifiers, then a key. */
 function angleChord(inner: string): string[] {
   if (inner === "") {
     throw new Error("qemu: empty key sequence");

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -1,45 +1,3 @@
-// The oligarchy proxy: a main file, not a library. It serves an HTTP control
-// plane that boots QEMU sessions and drives them by session uuid.
-//
-//   node --experimental-strip-types src/qemu/proxy.ts <iso>
-//
-// The default iso comes from argv or OLIGARCHY_ISO; the listen address from
-// OLIGARCHY_ADDR (default 127.0.0.1:42069). The control-plane database comes
-// from DATABASE_URL — a proxy that cannot record its sessions refuses to
-// boot, and every session, QMP exchange, image, and iso event is recorded
-// as it happens. Major actions also land in the logs table through log():
-// the lifecycle at info with how long each took, failed requests at error,
-// the death of the proxy at fatal (see field-guide/database.md). Error and
-// fatal lines also go to Sentry. 4xx request refusals stay in the logs
-// table and skip Sentry — they are the client's mistake.
-//
-//   POST /start      -> {"iso"?, "disk"?, "agent"}; boots a qemu, returns
-//                       {"id": uuid}; an http(s) iso is downloaded into
-//                       ~/.oligarchy/isos once (a start that finds a running
-//                       download waits for it) and reused from there on
-//                       later starts
-//   GET  /image?id=&agent= -> PNG of that session's guest display
-//   GET  /stats      -> qemu count + host memory + cpu percentiles (last 5m)
-//   POST /send-keys  -> {"id", "keys": "Hi<ENTER>", "encoding"?, "agent"}
-//   POST /stop       -> {"id", "status"?, "reason"?}; kills the qemu, removes
-//                       its session dir, and records the verdict (default
-//                       aborted)
-//
-// The HTTP layer is Effect (v4). Request shapes are Schema structs decoded
-// at the boundary — the one place input is validated — and the agent id is
-// required on every session-driving request. Each route is an Effect whose
-// error type names the operational errors it can answer with — the
-// ApiError union below — and the respond middleware is the one place that
-// turns each tag into the wire shape {"error": message}. The compiler
-// closes the loop: a route cannot fail with anything outside the union,
-// and the middleware cannot omit a tag. Anything else that goes wrong is a
-// defect — a bug — logged in full on stderr and shown to the client only
-// as a generic 500.
-// The subsystems the routes call (the qemu client, the iso cache, the db
-// ops) are still promise code, untouched by this spike; their failures are
-// mapped into the coarser tags at each call site, and sharpen into precise
-// ones only when those files move to Effect themselves.
-
 import { createServer } from "node:http";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -67,7 +25,6 @@ const SESSION_TIMEOUT_MS = 10 * 60 * 1000;
 const SESSION_TIMEOUT_CHECK_MS = 10_000;
 const SESSION_TIMEOUT_REASON = "no command received for 10 minutes";
 
-// A control plane that cannot record its sessions must not boot.
 const db = connectDatabase();
 
 type LiveSession = {
@@ -78,19 +35,12 @@ type LiveSession = {
 const sessions = new Map<string, LiveSession>();
 const cpuSampler = startCpuSampler();
 
-// Drizzle buries the reason (ECONNREFUSED etc.) in the cause; its own
-// message is the failed SQL and the params — noise in a log line.
+// Drizzle buries the reason (ECONNREFUSED etc.) in the cause; its own message is the failed SQL.
 function errorDetail(err: unknown): string {
   const e = err as Error;
   return e.cause instanceof Error ? e.cause.message : e.message;
 }
 
-// One action row per QMP exchange: opened as the command goes out, closed
-// with the outcome when the reply lands (see database.md). A close that
-// cannot be recorded is logged against its session before it surfaces —
-// the open row it leaves behind is the state database.md documents, and
-// the caller (client.ts) still decides whether the failure is swallowed
-// (after a failed exchange) or surfaced (after a completed one).
 function recorder(sessionId: string, agentId: string): QemuExchangeRecorder {
   return async (command) => {
     const id = await startAction(db, { sessionId, agentId, request: command });
@@ -105,15 +55,6 @@ function recorder(sessionId: string, agentId: string): QemuExchangeRecorder {
   };
 }
 
-// Every operational error a route can answer with, as plain tagged values
-// (no classes — AGENTS.md). BadRequest and UnknownSession are the client's
-// mistakes and carry their message onto the wire; StartFailed and
-// ExchangeFailed are operations that genuinely failed and whose message is
-// exactly what the driving agent needs to read; Internal is ours — the
-// cause is logged and the client learns nothing but "internal error".
-// Every tag carries the session and agent as far as its route knew them,
-// so the respond middleware's one error line per failed request lands
-// where a session inspection will find it.
 type ApiError =
   | { readonly _tag: "BadRequest"; readonly message: string; readonly sessionId?: string; readonly agentId?: string }
   | { readonly _tag: "UnknownSession"; readonly id: string; readonly agentId?: string }
@@ -125,8 +66,6 @@ function badRequest(message: string, who: { sessionId?: string; agentId?: string
   return { _tag: "BadRequest", message, ...who };
 }
 
-// The cast is the same contract the rest of the repo leans on: everything
-// the wrapped subsystems throw is an Error.
 function startFailed(err: unknown, who: { sessionId: string; agentId: string }): ApiError {
   return { _tag: "StartFailed", message: (err as Error).message, cause: err, ...who };
 }
@@ -147,25 +86,14 @@ function session(id: string, agentId?: string): Effect.Effect<Qemu, ApiError> {
   if (live === undefined) {
     return Effect.fail({ _tag: "UnknownSession", id, agentId });
   }
-  // A valid request for a live session is a command even when the QMP
-  // exchange it starts later fails.
+  // A valid request counts as activity even when the exchange it starts later fails.
   live.lastCommandAt = Date.now();
   return Effect.succeed(live.qemu);
 }
 
-// What each request must say, stated once as schemas: the schema is the
-// accepted input, and a request that does not match it is answered with
-// the decode error's own words. agent is required on every session-driving
-// request — this control plane is driven by agents, and a request that
-// names no agent has no business being sent (the CLI already refuses to).
-// The wire key is "agent"; its value is the agent's id, which the code and
-// the database call agentId — one value, two spellings. /stop stays
-// agentless by design: a stop exchanges nothing over QMP and is not an
-// action, it carries the session's verdict instead.
 const StartBody = Schema.Struct({
   iso: Schema.optionalKey(Schema.String),
   disk: Schema.optionalKey(Schema.String),
-  // Non-empty like the CLI's own --agent-id check: "" is not an agent.
   agent: Schema.NonEmptyString,
 });
 
@@ -181,18 +109,14 @@ const SendKeysBody = Schema.Struct({
   agent: Schema.NonEmptyString,
 });
 
-// The verdict rides the shape: a bad status never reaches the handler, so
-// it cannot kill the qemu and then fail to record the end.
+// /stop is agentless by design: it exchanges nothing over QMP and is not an action.
 const StopBody = Schema.Struct({
   id: Schema.String,
   status: Schema.optionalKey(Schema.Literals(["succeeded", "failed", "aborted"])),
   reason: Schema.optionalKey(Schema.String),
 });
 
-// The one decoded JSON body per POST route. A body that does not read as
-// JSON or does not match its schema is the client's mistake — answered
-// with JSON.parse's own message (it names the exact spot the body went
-// wrong; the platform's request.json hides it) or the decode error's.
+// JSON.parse instead of the platform's request.json: its error names the exact spot the body went wrong.
 function jsonBody<S extends Schema.Constraint>(
   schema: S,
 ): Effect.Effect<S["Type"], ApiError, HttpServerRequest.HttpServerRequest | S["DecodingServices"]> {
@@ -207,37 +131,21 @@ function jsonBody<S extends Schema.Constraint>(
   });
 }
 
-// The route contract, stated as a type so it is checked, not promised: a
-// route answers with a response or fails with an ApiError — nothing else.
-// Every handler below carries `satisfies RouteHandler`, so a new failure
-// sneaking into a route is a compile error at that route, not a mystery
-// 500 at runtime.
 type RouteHandler = Effect.Effect<HttpServerResponse.HttpServerResponse, ApiError, HttpRouter.Provided>;
 
-// The launch half of /start — still promise code end to end, because the
-// qemu client, iso cache, and db ops are out of this spike's scope.
 async function launchQemu(qemu: Qemu, cfg: { disk?: string; agent: string }, isoName: string): Promise<void> {
   try {
-    // Inside the try: a rejected registration (the agent already drives
-    // a session) must close this session as failed, not leave it open.
     await registerAgent(db, cfg.agent, qemu.id);
     const iso = await getIso(db, isoName, { sessionId: qemu.id, agentId: cfg.agent });
     if (cfg.disk === undefined) {
       await createDisk(qemu);
     } else {
-      // start() puts the firmware copy and the QMP socket in the session
-      // dir; with a caller-provided disk, createDisk never made it.
+      // start() expects the session dir; with a caller-provided disk, createDisk never made it.
       await mkdir(qemu.dir, { recursive: true, mode: 0o700 });
     }
     await start(qemu, { iso, disk: cfg.disk }, recorder(qemu.id, cfg.agent));
-    // Unconditional: the machine is up, so the row says running — no
-    // re-checking how the iso arrived. For a session that entered as
-    // "running" this update changes nothing.
     await sessionRunning(db, qemu.id);
   } catch (err) {
-    // The qemu must not outlive its failed start — a machine the map
-    // never held would be unreachable and unkillable through the API.
-    // The start error is the one worth seeing if cleanup fails too.
     await stop(qemu).catch(() => {});
     await endSession(db, qemu.id, "failed", (err as Error).message).catch((e: unknown) => {
       log(db, { level: "error", text: `db: recording a failed start failed too: ${(e as Error).message}`, sessionId: qemu.id, agentId: cfg.agent }, { cause: e });
@@ -246,18 +154,11 @@ async function launchQemu(qemu: Qemu, cfg: { disk?: string; agent: string }, iso
   }
 }
 
-// Everything /start does once its body is decoded: create the session
-// row, launch the machine, and only then let the sessions map hold it.
-// Returns the new session's id; fails with ApiError and nothing else.
-// started is the request's clock, ticking since before the body was read.
 function startSession(cfg: typeof StartBody.Type, started: number): Effect.Effect<string, ApiError> {
   return Effect.gen(function* () {
     const isoName = cfg.iso ?? defaultIso;
     const isUrl = isoName.startsWith("http://") || isoName.startsWith("https://");
     const qemu = createQemu();
-    // The session row exists before any start work, so iso events have a
-    // session to hang on: a url iso enters as "downloading", a local path
-    // goes straight to "running".
     yield* Effect.tryPromise({
       try: () => insertSession(db, qemu.id, { iso: isoName, disk: cfg.disk }, isUrl ? "downloading" : "running"),
       catch: (cause) => internal(cause, { sessionId: qemu.id, agentId: cfg.agent }),
@@ -272,19 +173,14 @@ function startSession(cfg: typeof StartBody.Type, started: number): Effect.Effec
       catch: (err) => startFailed(err, { sessionId: qemu.id, agentId: cfg.agent }),
     });
     sessions.set(qemu.id, { qemu, lastCommandAt: Date.now() });
-    // Wall time from request to a live QMP handshake, download included —
-    // per-exchange timing lives on the action rows.
     log(db, { text: `session ${qemu.id}: running; started in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: cfg.agent });
     return qemu.id;
   });
 }
 
-// The four session-driving routes are uninterruptible: the server
-// interrupts a request's fiber when the client disconnects, and a state
-// transition must not be torn in half by a vanished client — a booted
-// machine the map never received would be unreachable and unkillable, a
-// killed machine could go unrecorded. The old handler always ran to
-// completion; these keep doing so, and only the reply is lost.
+// The session-driving routes are uninterruptible: a client disconnect interrupts the
+// request's fiber, and a state transition torn in half leaves a machine the sessions
+// map never received — unreachable and unkillable — or a kill that went unrecorded.
 const routes = HttpRouter.use((router) =>
   Effect.gen(function* () {
     yield* router.add("POST", "/start", Effect.gen(function* () {
@@ -300,9 +196,8 @@ const routes = HttpRouter.use((router) =>
       const qemu = yield* session(params.id, params.agent);
       const agent = params.agent;
       const path = join(qemu.dir, `image-${process.hrtime.bigint()}.png`);
-      // The PNG is read back only after the exchange closes, and the images
-      // row must ride the same transaction that closes the action (they are
-      // 1:1) — so the recorder only stashes, and the route closes.
+      // The images row must ride the same transaction that closes the action (they are
+      // 1:1), so the recorder only stashes and the route closes.
       let opened: number | undefined;
       let outcome: QemuExchangeOutcome | undefined;
       const png = Effect.gen(function* () {
@@ -316,10 +211,8 @@ const routes = HttpRouter.use((router) =>
             }),
           catch: (err) => exchangeFailed(err, { sessionId: qemu.id, agentId: agent }),
         }).pipe(
-          // Only a failed exchange is closed without an image. A completed
-          // one whose image write failed stays open — the row state
-          // database.md documents as a completion that was never persisted;
-          // closing it imageless would break the 1:1 promise instead.
+          // Only a failed exchange is closed without an image; a completed one whose
+          // image write failed stays open rather than break the 1:1 promise.
           Effect.tapError(() =>
             Effect.promise(async () => {
               if (opened !== undefined && outcome !== undefined && outcome.state === "failed") {
@@ -352,7 +245,6 @@ const routes = HttpRouter.use((router) =>
       const qemu = yield* session(id);
       sessions.delete(qemu.id);
       yield* Effect.tryPromise({ try: () => stop(qemu), catch: (cause) => internal(cause, { sessionId: qemu.id }) });
-      // The stop ends the session; a stop without a verdict is an abort.
       yield* Effect.tryPromise({
         try: () => endSession(db, qemu.id, status ?? "aborted", reason ?? null),
         catch: (cause) => internal(cause, { sessionId: qemu.id }),
@@ -368,9 +260,6 @@ const routes = HttpRouter.use((router) =>
       const started = Date.now();
       const { id, keys, encoding, agent } = yield* jsonBody(SendKeysBody);
       const qemu = yield* session(id, agent);
-      // parseKeys throws only on bad input, so every failure is the
-      // client's — attributed, so the refused key string lands in the
-      // session's story beside the actions it never became.
       const chords = yield* Effect.try({
         try: () => parseKeys(keys, encoding),
         catch: (err) => badRequest((err as Error).message, { sessionId: qemu.id, agentId: agent }),
@@ -384,13 +273,10 @@ const routes = HttpRouter.use((router) =>
         },
         catch: (err) => exchangeFailed(err, { sessionId: qemu.id, agentId: agent }),
       });
-      // The request-level story; each chord is its own action row with its
-      // own timing.
       log(db, { text: `session ${qemu.id}: sent ${chords.length} chords in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: agent });
       return HttpServerResponse.jsonUnsafe({ ok: "true" });
     }) satisfies RouteHandler, { uninterruptible: true });
 
-    // The proxy's own 404, kept as JSON like every other reply.
     yield* router.add("*", "*", HttpServerResponse.jsonUnsafe({ error: "not found" }, { status: 404 }));
   })
 );
@@ -399,11 +285,6 @@ function errorBody(status: number, message: string): HttpServerResponse.HttpServ
   return HttpServerResponse.jsonUnsafe({ error: message }, { status });
 }
 
-// One error line per failed request — method, url, and what went wrong —
-// attributed as far as the route knew, then the wire answer. The log line
-// and the client's message differ only for Internal: the client gets no
-// internals. Sentry is fed from log(): 5xx send the cause, 4xx skip
-// (the client's mistake), and the defect arm below passes the defect.
 function answer(
   request: HttpServerRequest.HttpServerRequest,
   status: number,
@@ -426,11 +307,7 @@ function answer(
   });
 }
 
-// Every operational error, said once: this table is the whole client-facing
-// error contract. Its type is total over ApiError's tags — catchTags alone
-// would let an arm silently fall through to the platform's default 500, so
-// the table says every tag must have a row, and dropping one (or adding a
-// tag to ApiError without one) does not compile.
+// Total over ApiError's tags: dropping an arm, or adding a tag without one, does not compile.
 function respondTable(request: HttpServerRequest.HttpServerRequest): {
   readonly [K in ApiError["_tag"]]: (err: Extract<ApiError, { _tag: K }>) => Effect.Effect<HttpServerResponse.HttpServerResponse>;
 } {
@@ -438,10 +315,8 @@ function respondTable(request: HttpServerRequest.HttpServerRequest): {
     BadRequest: (err) => answer(request, 400, err.message, err),
     UnknownSession: (err) =>
       answer(request, 404, `unknown session "${err.id}"`, {
-        // logs.session_id is a uuid column, and logs has no foreign keys by
-        // design — so an id this server could have minted is attributed (an
-        // agent still driving a stopped session is history worth keeping),
-        // while garbage ids get the line without the attribution.
+        // logs.session_id is a uuid column: attribute ids this server could have
+        // minted, drop the attribution for garbage.
         sessionId: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(err.id) ? err.id : undefined,
         agentId: err.agentId,
       }),
@@ -457,9 +332,6 @@ const respond = HttpRouter.middleware<{ handles: ApiError }>()((handler) =>
       Effect.catchTags(respondTable(request)),
       Effect.catchDefect((defect) =>
         Effect.sync(() => {
-          // A defect is a bug: the stack names the spot, so it rides the
-          // line. A defect is also by definition not ours, so the boundary
-          // that keeps the process alive assumes nothing about its shape.
           log(
             db,
             {
@@ -474,9 +346,6 @@ const respond = HttpRouter.middleware<{ handles: ApiError }>()((handler) =>
     )
   ), { global: true });
 
-// Sessions nobody is driving are killed after ten minutes. The timer is
-// bounded by the sessions map, does not hold the server open, and catches
-// every tick so cleanup trouble cannot bring down the proxy.
 async function stopTimedOutSessions(): Promise<void> {
   const now = Date.now();
   const timedOut = [...sessions.values()].filter((live) => now - live.lastCommandAt >= SESSION_TIMEOUT_MS);
@@ -488,8 +357,7 @@ async function stopTimedOutSessions(): Promise<void> {
       try {
         await stop(qemu);
       } catch (err) {
-        // stop() has already destroyed the socket and signaled QEMU before
-        // removing the directory, so still close the database record.
+        // stop() already destroyed the socket and signaled QEMU, so still close the record.
         log(db, { level: "error", text: `session ${qemu.id}: timeout cleanup failed: ${errorDetail(err)}`, sessionId: qemu.id }, { cause: err });
       }
       await endSession(db, qemu.id, "timed_out", SESSION_TIMEOUT_REASON);
@@ -525,10 +393,6 @@ const sessionTimeoutTimer = setInterval(() => {
 }, SESSION_TIMEOUT_CHECK_MS);
 sessionTimeoutTimer.unref();
 
-// Settled, not raced: one session failing to stop or record must not cut
-// short the cleanup of the others. The finalizer runs when the server's
-// scope closes — a SIGINT/SIGTERM interrupts runMain's fiber and every
-// still-running session is stopped and recorded as aborted, like before.
 let shutdownFailed = false;
 const drainSessions = Layer.effectDiscard(
   Effect.addFinalizer(() =>
@@ -543,8 +407,6 @@ const drainSessions = Layer.effectDiscard(
             await endSession(db, qemu.id, "aborted", "proxy shutdown");
             log(db, { text: `session ${qemu.id}: stopped; aborted; proxy shutdown`, sessionId: qemu.id });
           } catch (err) {
-            // Logged here, where the session is known — the sessions that
-            // fail are the ones whose absence from the story matters most.
             log(db, { level: "error", text: `shutdown: session ${qemu.id}: ${(err as Error).message}`, sessionId: qemu.id }, { cause: err });
             throw err;
           }
@@ -555,13 +417,8 @@ const drainSessions = Layer.effectDiscard(
   ),
 );
 
-// serve's built-in request logger and listen line are off: the proxy keeps
-// its stderr contract — one boot line, error lines only. The boot line
-// goes through log() too: a proxy restart in the record explains sessions
-// that ended as "aborted, proxy shutdown". The platform guards only the
-// listen itself and drops its error listener once the server is up, so a
-// later server error (the acceptor breaking) gets the same death master
-// gave it: one fatal line, the flush, exit 1.
+// The platform drops its error listener once the server is up; a later server error
+// (the acceptor breaking) still needs the fatal line, the flush, and exit 1.
 const server = createServer();
 const main = Layer.effectDiscard(
   Effect.sync(() => {
@@ -576,16 +433,8 @@ const main = Layer.effectDiscard(
   Layer.provide(NodeHttpServer.layer(() => server, { host, port: Number(port) })),
 );
 
-// The exit contract is unchanged: a clean shutdown (signals included) exits
-// 0, a session whose cleanup failed makes it 1, and a server that could not
-// come up is a fatal line and exit 1. Every exit path flushes the log chain
-// and Sentry first — the last lines are the ones most worth having when the
-// proxy is gone — and runMain's own error report is off: the fatal line is
-// the story.
 NodeRuntime.runMain(
   Layer.launch(main).pipe(
-    // The platform's ServeError says nothing itself; the reason (the port
-    // is taken) is the cause underneath.
     Effect.tapError((err) => Effect.sync(() => log(db, { level: "fatal", text: `proxy: ${errorDetail(err)}` }, { cause: err }))),
   ),
   {

--- a/src/qemu/stats.ts
+++ b/src/qemu/stats.ts
@@ -1,11 +1,3 @@
-// Host stats for the proxy's GET /stats endpoint: how many qemu sessions the
-// proxy is running, how much memory the host has, and cpu utilization over
-// the last five minutes.
-//
-// A timer started with the server samples the busy share of cpu time every
-// tick into a rolling window; /stats reports the window's mean and
-// p10/p25/p75/p90 percentiles. The cpu fields are 0 until the first tick.
-
 import os from "node:os";
 import { capture } from "../sentry.ts";
 
@@ -20,7 +12,6 @@ type CpuTimes = {
 
 export type CpuSampler = {
   prev: CpuTimes;
-  /** Utilization percents, oldest first. */
   samples: number[];
 };
 
@@ -41,7 +32,6 @@ export type Stats = {
   };
 };
 
-/** Starts the sampling timer; unref keeps it from holding the process open. */
 export function startCpuSampler(): CpuSampler {
   const sampler: CpuSampler = { prev: cpuTimes(), samples: [] };
   setInterval(() => sampleCpu(sampler), SAMPLE_INTERVAL_MS).unref();

--- a/src/qmu.types.ts
+++ b/src/qmu.types.ts
@@ -43,8 +43,6 @@ declare global {
     data: string | number;
   };
 
-  // The commands this program sends: the exact JSON written to the QMP
-  // socket, one type per command in use.
   type QemuCapabilitiesCommand = {
     execute: "qmp_capabilities";
     arguments: Record<string, never>;
@@ -69,16 +67,14 @@ declare global {
     id: string;
   };
 
-  // How one QMP exchange ended. completed: QEMU's exact reply (the greeting
-  // for qmp_capabilities at boot). failed: QEMU's {error} reply, or this
-  // server's error message when the failure never reached QEMU.
+  // failed: QEMU's {error} reply, or this server's error message when the failure
+  // never reached QEMU (a timeout, a dead socket).
   type QemuExchangeOutcome =
     | { state: "completed"; response: QemuGreetingResponse | QemuSuccessResponse }
     | { state: "failed"; response: QemuErrorResponse | string };
 
-  // The proxy's hook into the wire: awaited with the exact command JSON
-  // before it goes out (a refused insert fails the exchange up front); the
-  // returned close lands the outcome when the reply arrives.
+  // Awaited with the exact command before it goes out (a refused insert fails the
+  // exchange up front); the returned close records the outcome when the reply lands.
   type QemuExchangeRecorder = (
     command: QemuCommand,
   ) => Promise<(outcome: QemuExchangeOutcome) => Promise<void>>;

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,11 +1,3 @@
-// Sentry for the proxy. The DSN is the Cloudflare project's — this process
-// is Node (QEMU cannot run on a worker), so the SDK is @sentry/node, and
-// Effect's respond middleware plus log() decide what is an event: 5xx and
-// operational failures, not 4xx. capture() is what log() calls for error
-// and fatal (and for the log-insert failure that cannot go through log()
-// again). flush() is for the process.exit paths so the last event is not
-// dropped.
-
 import * as Sentry from "@sentry/node";
 import { SENTRY_DSN } from "./sentry-dsn.ts";
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,6 @@
     {
       "binding": "HYPERDRIVE",
       "id": "da54bf43f004492996574a6db26d8895",
-      // Optional. Use this to connect to a local database during development.
       "localConnectionString": "postgresql://user:password@localhost:5432/databasename"
     }
   ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Removes ~450 lines of comments across `src/`, `wrangler.jsonc`, and `.github/workflows/migrations.yml`: every file header, doc comment, and line of narration that restated what the code or the field guide already says. Comments and whitespace only — no code change anywhere (`git diff -w` outside the comment lines is empty), and `drizzle/` is untouched per the append-only policy.

Adds a `## Comments` section to `AGENTS.md`: do not write comments, with the one exception of a genuinely tricky edge case whose intent cannot live in the code.

## What was kept (trimmed to one to four lines)

Only comments that name a constraint invisible in the code:

- **Upstream quirks**: the `sslrootcert=system` drop for node-postgres#3101 and the `URL.canParse` password-leak guard (`src/db/ops.ts`); drizzle and Node fetch burying the real error in `cause` (`src/db/log.ts`, `src/qemu/proxy.ts`, `src/qemu/cli.ts`); drizzle having no built-in `bytea` (`src/db/schema.ts`); oxlint's Sentry flush timeout rationale (`src/sentry.ts`); the Sentry DSN being public by design (`src/sentry-dsn.ts`).
- **Ordering and placement correctness depends on**: listen-before-spawn in the QMP handshake and the completed-close outside the `try` (`src/qemu/client.ts`); claim-checked-before-file and the recorder stash/close split for the images 1:1 transaction (`src/qemu/iso.ts`, `src/qemu/proxy.ts`); `now()` being transaction-start time (`src/db/ops.ts`).
- **Deliberate races and protocol rules** in the iso cache: heartbeat/stale-claim protocol, two simultaneous claimants both downloading (wasteful, still correct), partial-file pid suffixes, the manifest write chain, soft-404 sha256 sidecars (`src/qemu/iso.ts`).
- **Design decisions that look like mistakes**: uninterruptible session routes, agentless `/stop`, no foreign keys on `logs`, the agent-id primary key, the nullable historical `agent_id`, the uuid-regex attribution filter, `JSON.parse` over `request.json` (`src/qemu/proxy.ts`, `src/db/schema.ts`).
- **The philosophy.md canonical examples**: the cpu hotplug guard and `MAX_SAMPLES` window math (`src/qemu/stats.ts`), the omitted `disk` key (`src/qemu/cli.ts`), plus the `<GT>`/qcode-token special cases (`src/qemu/keys.ts`).

## Verification

- `npm run lint` clean, `npx tsc --noEmit` clean, 28/28 tests pass.
- `drizzle-kit check` and `npm run db:generate` confirm no schema drift from the comment-only `schema.ts` edit.
- GPT-5.6 Sol review pass done per AGENTS.md; its one finding (restore the close-placement constraint in `execute`) was accepted as a genuine ordering constraint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a053da-b509-78b7-b298-e1b6a5b0b06a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a053da-b509-78b7-b298-e1b6a5b0b06a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

