### PR TITLE
Add send-mouse for QEMU tablet input

### DIFF
--- a/field-guide/cli.md
+++ b/field-guide/cli.md
@@ -6,6 +6,7 @@ The TypeScript client for the oligarchy control plane. It sends HTTP requests to
 node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> start [--iso <path>] [--disk <path>]
 node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> get-image <id> [-o file]
 node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-keys <id> <keys> [encoding]
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-mouse <id> <x> <y> [button [clicks]]
 ```
 
 The server address comes from `OLIGARCHY_ADDR`, default `127.0.0.1:42069`.
@@ -35,6 +36,13 @@ Types a key string into the session.
 
 - `send-keys <id> <keys> [encoding]`; the encoding defaults to `oligarchy` and is passed through untouched — the server does the parsing. The encoding itself (literal characters, `<ENTER>`, `<C-c>`, ...) is documented in [how-to.md](how-to.md) and implemented server-side in `src/qemu/keys.ts`.
 - Wire call: `POST /send-keys` with `{"id", "keys", "encoding", "agent"}` → `{"ok": "true"}`.
+
+## send-mouse
+
+Moves the pointer, and optionally clicks or scrolls, at a point on the screenshot.
+
+- `send-mouse <id> <x> <y> [button [clicks]]`. `x` and `y` are fractions of the screenshot, `0..1` from the top-left; the CLI rejects anything else before calling the server. Omit `button` to move only. `button` is `left`, `middle`, `right`, `wheel-up`, or `wheel-down`; `clicks` defaults to 1 and is a pulse count (a double-click is `left 2`, three wheel ticks is `wheel-down 3`).
+- Wire call: `POST /send-mouse` with `{"id", "x", "y", "button"?, "clicks"?, "agent"}` → `{"ok": "true"}`.
 
 ## Errors and exit codes
 

--- a/field-guide/database.md
+++ b/field-guide/database.md
@@ -1,6 +1,6 @@
 # The control-plane database
 
-One PlanetScale Postgres database holds the record of everything the proxy does. `src/db/schema.ts` defines the five tables (sessions, agent_runs, actions, images, logs); `src/db/ops.ts` writes the control-plane record, `src/db/log.ts` writes its attributed log lines, and `src/db/query.ts` reads recent sessions for the dashboard. Every path uses Drizzle; node-postgres is only the transport. The proxy records through this interface as it runs: the session row lands before any start work (`downloading` for a url iso), every QMP exchange opens and closes an action row via the recorder hook threaded into the qemu client, a get-image's PNG rides the closing transaction, `/stop` closes the session with its verdict, and ten minutes without a command closes it as `timed_out` with the reason. Alongside those rows, every major action narrates itself through `log()` — starting, running, image served, chords sent, stopped, timed out, shutdown, iso cache traffic — with how long the work took, and every refused or failed request is one error line attributed as far as the handler knew, so the logs alone tell the session's story, refusals included, and the state tables carry the exact records.
+One PlanetScale Postgres database holds the record of everything the proxy does. `src/db/schema.ts` defines the five tables (sessions, agent_runs, actions, images, logs); `src/db/ops.ts` writes the control-plane record, `src/db/log.ts` writes its attributed log lines, and `src/db/query.ts` reads recent sessions for the dashboard. Every path uses Drizzle; node-postgres is only the transport. The proxy records through this interface as it runs: the session row lands before any start work (`downloading` for a url iso), every QMP exchange opens and closes an action row via the recorder hook threaded into the qemu client, a get-image's PNG rides the closing transaction, `/stop` closes the session with its verdict, and ten minutes without a command closes it as `timed_out` with the reason. Alongside those rows, every major action narrates itself through `log()` — starting, running, image served, chords sent, mouse sent, stopped, timed out, shutdown, iso cache traffic — with how long the work took, and every refused or failed request is one error line attributed as far as the handler knew, so the logs alone tell the session's story, refusals included, and the state tables carry the exact records.
 
 ## The state that threads through
 
@@ -20,7 +20,7 @@ One PlanetScale Postgres database holds the record of everything the proxy does.
 
 ## The shape of an action
 
-An action is one QMP exchange, opened then closed, its id relating the two. `startAction` inserts the row with the exact command JSON sent to QEMU (`QemuCommand` — `qmp_capabilities`, `send-key`, `screendump`; the `execute` field names the command, so there is no separate kind column). `finishAction` closes it by id in one of the only two states an exchange can finish in:
+An action is one QMP exchange, opened then closed, its id relating the two. `startAction` inserts the row with the exact command JSON sent to QEMU (`QemuCommand` — `qmp_capabilities`, `send-key`, `screendump`, `input-send-event`; the `execute` field names the command, so there is no separate kind column). `finishAction` closes it by id in one of the only two states an exchange can finish in:
 
 - **`completed`** — the response is QEMU's exact reply: the greeting for the boot handshake, the `{return}` reply otherwise. A get-image's PNG is what QEMU wrote into the session dir and the server read back; the raw bytes ride the closing update into `images`, 1:1 by action id.
 - **`failed`** — the response is the error: QEMU's `{error}` reply when it answered, or this server's error message when the failure never reached QEMU (a timeout, a dead socket). There is no separate error column.
@@ -31,7 +31,7 @@ A still-running exchange has no state yet: `state`, `response`, and `finished_at
 
 `log()` writes one line twice — to stderr, and as a logs row — in call order behind a chain; a failed insert reports itself to stderr and never fails the caller. The stamp is the database's, taken at the insert: a stalled database lands queued lines late, and id, not `created_at`, is the truth of their order. Every line carries a level, the `log_level` enum, declared in ascending severity so `WHERE level >= 'error'` reads the scary lines:
 
-- **info** — the default, and the normal story: the proxy listening, a session starting / running / stopped, an image served, chords sent, iso cache hits and downloads.
+- **info** — the default, and the normal story: the proxy listening, a session starting / running / stopped, an image served, chords sent, mouse sent, iso cache hits and downloads.
 - **warning** — something was off but the operation went on: a download heartbeat that failed to write, an iso with no published sha256 to check against.
 - **error** — an operation failed: one line per failed request from the HTTP boundary (a refused request is a failed request, so a bad key string or an unknown session id lands here too, attributed when the id is one this server could have minted), an action close that could not be recorded, a session that would not stop or record at shutdown, and a defect — a bug behind the client's generic 500 — with its stack.
 - **fatal** — the proxy is going down, written right before the exit: the listen failing at boot (the port is taken).
@@ -44,7 +44,7 @@ Paths that end in `process.exit` — shutdown, a fatal — await `flushLogs()` t
 
 ## Timing
 
-Two clocks, each for what it is good at. Action rows are stamped by the database — `finished_at - created_at` is per-exchange handling time with no cross-clock arithmetic. The proxy's log lines carry request-level wall time measured at the server — `running; started in 45123ms`, `image; 48213 bytes in 87ms`, `sent 6 chords in 412ms` — the numbers the action rows cannot give, because a request spans many exchanges (send-keys) or work that is no exchange at all (a download, a disk create, the boot handshake).
+Two clocks, each for what it is good at. Action rows are stamped by the database — `finished_at - created_at` is per-exchange handling time with no cross-clock arithmetic. The proxy's log lines carry request-level wall time measured at the server — `running; started in 45123ms`, `image; 48213 bytes in 87ms`, `sent 6 chords in 412ms`, `mouse 0.5 0.5 left in 12ms` — the numbers the action rows cannot give, because a request spans many exchanges (send-keys, a multi-click send-mouse) or work that is no exchange at all (a download, a disk create, the boot handshake).
 
 ## Replaying a session
 

--- a/field-guide/driving.md
+++ b/field-guide/driving.md
@@ -1,20 +1,21 @@
 # Driving a guest
 
-How to operate a session over the control plane: send keys, look, decide.
-Everything here was learned driving a full Omarchy install to the desktop.
+How to operate a session over the control plane: send keys, move the mouse,
+look, decide. Everything here was learned driving a full Omarchy install to
+the desktop.
 
 ## The loop
 
-Send keys, wait about three seconds, take an image, read it, decide. That is
-the whole method. Never sleep more than ten seconds between actions — things
-happen quickly, and a long blind wait is how a session gets away from you.
-When something genuinely slow is running (an installer's progress bar, a
+Send keys or mouse, wait about three seconds, take an image, read it, decide.
+That is the whole method. Never sleep more than ten seconds between actions —
+things happen quickly, and a long blind wait is how a session gets away from
+you. When something genuinely slow is running (an installer's progress bar, a
 reboot, a first boot), the loop does not change: keep taking images and
 reading them instead of trusting a long sleep.
 
-Every send-keys chord and every image is recorded as an action in the
-database, so the loop leaves a complete flight recorder behind — replaying
-what you did is `actions WHERE session_id ORDER BY created_at, id`.
+Every send-keys chord, every send-mouse, and every image is recorded as an
+action in the database, so the loop leaves a complete flight recorder behind
+— replaying what you did is `actions WHERE session_id ORDER BY created_at, id`.
 
 ## Look before you type
 
@@ -33,10 +34,13 @@ re-sending: double-typed input is worse than late input.
 
 ## Focus is mouse-shaped
 
-The control plane has no mouse, and Hyprland as Omarchy ships it focuses the
-window under the pointer. Window-manager chords (`<M-Enter>`, `<M-2>`,
-`<M-w>`) land no matter what has focus; plain text lands wherever the pointer
-says. When a desktop plays focus games, switch to a TTY with `<C-A-F3>` — a
+Hyprland as Omarchy ships it focuses the window under the pointer. Move the
+pointer onto the window you mean to type into (`send-mouse <id> x y`), then
+send keys. Window-manager chords (`<M-Enter>`, `<M-2>`, `<M-w>`) land no
+matter what has focus; plain text lands wherever the pointer says. A greeter
+or installer button is a left click at that point (`send-mouse <id> x y left`);
+a double-click launches, a right-click opens a menu, `wheel-down` scrolls.
+When a desktop still plays focus games, switch to a TTY with `<C-A-F3>` — a
 text console is focus-proof, and a username/password login there is the
 cleanest proof of a working system.
 
@@ -46,8 +50,10 @@ TUI pickers may not filter when you type — letters can reset the selection
 instead. Navigate with batched arrows (`<Down>` repeated in one send-keys),
 then an image to verify the cursor position before `<Enter>`.
 
-## The keys you will actually use
+## The keys and clicks you will actually use
 
 The full encoding is in [how-to.md](how-to.md). The drive used little beyond:
 literal text, `<Enter>`, `<Esc>`, `<Tab>`, `<Down>`, `<M-...>` for Super
-chords, `<C-A-F3>` for TTY switching, and a bare `<META_L>` tap.
+chords, `<C-A-F3>` for TTY switching, and a bare `<META_L>` tap. On a
+desktop, add `send-mouse` at the button or window you can see: a move to
+focus, a left click to sign in, a double-click to launch.

--- a/field-guide/how-to.md
+++ b/field-guide/how-to.md
@@ -48,3 +48,26 @@ node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-keys <id
 - `<` and `>` as characters: `<LT>` and `<GT>`.
 
 Quote the key string so the shell does not eat `<`, `>`, or spaces.
+
+## Send mouse
+
+Coordinates are fractions of the last screenshot: `0` is the top or left edge, `1` is the bottom or right. From a pixel `(px, py)` on a `W×H` image, `x = px / (W - 1)` and `y = py / (H - 1)`.
+
+```bash
+# move the pointer (Hyprland focuses the window under it)
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-mouse <id> 0.5 0.5
+
+# left click
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-mouse <id> 0.5 0.5 left
+
+# double-click
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-mouse <id> 0.3 0.2 left 2
+
+# right-click
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-mouse <id> 0.8 0.1 right
+
+# scroll three ticks
+node --experimental-strip-types src/qemu/cli.ts --agent-id <agent> send-mouse <id> 0.5 0.5 wheel-down 3
+```
+
+Omit the button to move only. `button` is `left`, `middle`, `right`, `wheel-up`, or `wheel-down`. `clicks` is how many times that button is pulsed.

--- a/field-guide/http-api.md
+++ b/field-guide/http-api.md
@@ -4,7 +4,7 @@ The control plane spoken between the CLI and the proxy (`src/qemu/proxy.ts`).
 
 The proxy defaults to `127.0.0.1:42069`. Bodies are JSON except the PNG. Errors are `4xx`/`5xx` with `{"error": "<message>"}`.
 
-Session-driving requests (`/start`, `/image`, `/send-keys`) carry the calling agent's id — `agent` in the POST body, a query param on the GET — so the server attributes the session's [actions](database.md) to that agent. The agent id is required: this control plane is driven by agents, and a request that names none is refused with a 400. `/stop` carries none because a stop exchanges nothing over QMP and is not an action — it carries the session's verdict instead; `/stats` has no session at all.
+Session-driving requests (`/start`, `/image`, `/send-keys`, `/send-mouse`) carry the calling agent's id — `agent` in the POST body, a query param on the GET — so the server attributes the session's [actions](database.md) to that agent. The agent id is required: this control plane is driven by agents, and a request that names none is refused with a 400. `/stop` carries none because a stop exchanges nothing over QMP and is not an action — it carries the session's verdict instead; `/stats` has no session at all.
 
 ## POST /start
 
@@ -44,8 +44,12 @@ Stats for the machine the proxy runs on, plus how many sessions it is running:
 
 Body `{"id", "keys", "encoding"?, "agent"}`. The server parses the key string (`encoding` defaults to `oligarchy`, see [how-to.md](how-to.md)) and types it into the guest via QMP `send-key`. Returns `{"ok": "true"}`.
 
+## POST /send-mouse
+
+Body `{"id", "x", "y", "button"?, "clicks"?, "agent"}`. Moves the pointer to `(x, y)` — each a number in `0..1`, the fraction of the screenshot from the top-left — via QMP `input-send-event`. With no `button`, that is the whole command: a move, so Hyprland focus can follow the pointer. With `button` (`left`, `middle`, `right`, `wheel-up`, `wheel-down`), the server then pulses that button `clicks` times (`clicks` defaults to 1). Returns `{"ok": "true"}`.
+
 ## POST /stop
 
 Body `{"id", "status"?, "reason"?}`; kills the QEMU and removes its session directory, then closes the session row with the verdict — `succeeded`, `failed`, or `aborted` — and the optional reason. A stop without a verdict is an abort: a machine killed with nothing to say for itself. Returns `{"ok": "true"}`.
 
-Once a session is running, each `/image` or `/send-keys` request for it restarts a ten-minute inactivity window. If no command arrives before that window expires, the proxy removes and kills the session automatically, closes it with status `timed_out` and reason `no command received for 10 minutes`, and writes the same event to the session log. `timed_out` is proxy-owned and is not an accepted `/stop` verdict.
+Once a session is running, each `/image`, `/send-keys`, or `/send-mouse` request for it restarts a ten-minute inactivity window. If no command arrives before that window expires, the proxy removes and kills the session automatically, closes it with status `timed_out` and reason `no command received for 10 minutes`, and writes the same event to the session log. `timed_out` is proxy-owned and is not an accepted `/stop` verdict.

--- a/field-guide/index.md
+++ b/field-guide/index.md
@@ -3,9 +3,9 @@
 The entry point for working on this repo. Start here, then follow the link you need.
 
 - [Philosophy](philosophy.md) — how code is written here: simple, small surface, every real error handled, no unneeded guards.
-- [Driving a guest](driving.md) — the operating loop: send keys, wait three seconds, image, decide.
+- [Driving a guest](driving.md) — the operating loop: send keys or mouse, wait three seconds, image, decide.
 - [The CLI](cli.md) — what `src/qemu/cli.ts` does and why, command by command.
 - [The HTTP API](http-api.md) — the control-plane contract between the CLI and the proxy.
 - [The database](database.md) — the PlanetScale Postgres record of every session, and the `src/db/ops.ts` interface to it.
-- [Key encoding how-to](how-to.md) — the `oligarchy` key-string encoding used by `send-keys`.
+- [How-to](how-to.md) — the `oligarchy` key-string encoding and send-mouse coordinates.
 - [Agent rules](../AGENTS.md) — vocabulary and hard TypeScript rules.

--- a/src/qemu/cli.ts
+++ b/src/qemu/cli.ts
@@ -23,6 +23,9 @@ async function main(args: string[]): Promise<void> {
       case "send-keys":
         await cmdSendKeys(agent, args.slice(3));
         break;
+      case "send-mouse":
+        await cmdSendMouse(agent, args.slice(3));
+        break;
       default:
         usage();
         process.exitCode = 2;
@@ -40,6 +43,7 @@ Usage:
   oligarchy --agent-id <agent> start [--iso <path>] [--disk <path>]
   oligarchy --agent-id <agent> get-image <id> [-o file]
   oligarchy --agent-id <agent> send-keys <id> <keys> [encoding]
+  oligarchy --agent-id <agent> send-mouse <id> <x> <y> [button [clicks]]
 `);
 }
 
@@ -116,6 +120,34 @@ async function cmdSendKeys(agent: string, args: string[]): Promise<void> {
   }
   const encoding = args.length === 3 ? args[2] : DEFAULT_ENCODING;
   await postJSON("/send-keys", { id: args[0], keys: args[1], encoding, agent });
+}
+
+async function cmdSendMouse(agent: string, args: string[]): Promise<void> {
+  if (args.length < 3 || args.length > 5) {
+    throw new Error("usage: oligarchy --agent-id <agent> send-mouse <id> <x> <y> [button [clicks]]");
+  }
+  const x = Number(args[1]);
+  const y = Number(args[2]);
+  if (!Number.isFinite(x) || !Number.isFinite(y) || x < 0 || x > 1 || y < 0 || y > 1) {
+    throw new Error("mouse: x and y must be in 0..1");
+  }
+  const body: { id: string; x: number; y: number; agent: string; button?: string; clicks?: number } = {
+    id: args[0],
+    x,
+    y,
+    agent,
+  };
+  if (args.length >= 4) {
+    body.button = args[3];
+  }
+  if (args.length === 5) {
+    const clicks = Number(args[4]);
+    if (!Number.isInteger(clicks) || clicks < 1) {
+      throw new Error("usage: oligarchy --agent-id <agent> send-mouse <id> <x> <y> [button [clicks]]");
+    }
+    body.clicks = clicks;
+  }
+  await postJSON("/send-mouse", body);
 }
 
 async function postJSON(path: string, body: unknown): Promise<string> {

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -199,6 +199,46 @@ export async function sendKey(qemu: Qemu, keys: QemuKeyValue[], record?: QemuExc
   await execute(qemu, "send-key", { keys }, record);
 }
 
+// QEMU INPUT_EVENT_ABS_MAX: tablet axes are 0..0x7fff.
+const TABLET_AXIS_MAX = 0x7fff;
+// Two down/up pairs in one events list look like one click to the guest.
+const MULTI_CLICK_GAP_MS = 50;
+
+export async function sendMouse(
+  qemu: Qemu,
+  x: number,
+  y: number,
+  button?: QemuInputButton,
+  clicks = 1,
+  record?: QemuExchangeRecorder,
+): Promise<void> {
+  const abs: QemuInputEvent[] = [
+    { type: "abs", data: { axis: "x", value: Math.round(x * TABLET_AXIS_MAX) } },
+    { type: "abs", data: { axis: "y", value: Math.round(y * TABLET_AXIS_MAX) } },
+  ];
+  if (button === undefined) {
+    await execute(qemu, "input-send-event", { events: abs }, record);
+    return;
+  }
+  for (let i = 0; i < clicks; i++) {
+    await execute(
+      qemu,
+      "input-send-event",
+      {
+        events: [
+          ...abs,
+          { type: "btn", data: { button, down: true } },
+          { type: "btn", data: { button, down: false } },
+        ],
+      },
+      record,
+    );
+    if (i + 1 < clicks) {
+      await new Promise<void>((resolve) => setTimeout(resolve, MULTI_CLICK_GAP_MS));
+    }
+  }
+}
+
 export async function screendump(
   qemu: Qemu,
   filename: string,
@@ -232,6 +272,11 @@ function qemuArgs(opts: {
     `if=pflash,format=raw,file=${opts.varsPath}`,
     "-display",
     "gtk",
+    // usb-tablet is the absolute pointer; without it, input-send-event abs has no handler.
+    "-device",
+    "qemu-xhci",
+    "-device",
+    "usb-tablet",
     "-chardev",
     `socket,id=qmp,path=${opts.sockPath}`,
     "-mon",

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -223,18 +223,21 @@ export async function sendMouse(
   // usb-tablet applies the event list then syncs once: down and up in the same
   // list leave the button unchanged, so the guest never sees a click.
   for (let i = 0; i < clicks; i++) {
-    await execute(
-      qemu,
-      "input-send-event",
-      { events: [...abs, { type: "btn", data: { button, down: true } }] },
-      record,
-    );
-    await execute(
-      qemu,
-      "input-send-event",
-      { events: [{ type: "btn", data: { button, down: false } }] },
-      record,
-    );
+    try {
+      await execute(
+        qemu,
+        "input-send-event",
+        { events: [...abs, { type: "btn", data: { button, down: true } }] },
+        record,
+      );
+    } finally {
+      await execute(
+        qemu,
+        "input-send-event",
+        { events: [{ type: "btn", data: { button, down: false } }] },
+        record,
+      );
+    }
     if (i + 1 < clicks) {
       await new Promise<void>((resolve) => setTimeout(resolve, MULTI_CLICK_GAP_MS));
     }

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -201,7 +201,7 @@ export async function sendKey(qemu: Qemu, keys: QemuKeyValue[], record?: QemuExc
 
 // QEMU INPUT_EVENT_ABS_MAX: tablet axes are 0..0x7fff.
 const TABLET_AXIS_MAX = 0x7fff;
-// Two down/up pairs in one events list look like one click to the guest.
+// guest double-click detection needs a gap between successive press/release pairs
 const MULTI_CLICK_GAP_MS = 50;
 
 export async function sendMouse(
@@ -220,17 +220,19 @@ export async function sendMouse(
     await execute(qemu, "input-send-event", { events: abs }, record);
     return;
   }
+  // usb-tablet applies the event list then syncs once: down and up in the same
+  // list leave the button unchanged, so the guest never sees a click.
   for (let i = 0; i < clicks; i++) {
     await execute(
       qemu,
       "input-send-event",
-      {
-        events: [
-          ...abs,
-          { type: "btn", data: { button, down: true } },
-          { type: "btn", data: { button, down: false } },
-        ],
-      },
+      { events: [...abs, { type: "btn", data: { button, down: true } }] },
+      record,
+    );
+    await execute(
+      qemu,
+      "input-send-event",
+      { events: [{ type: "btn", data: { button, down: false } }] },
       record,
     );
     if (i + 1 < clicks) {

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -7,7 +7,7 @@ import { NodeHttpServer, NodeRuntime } from "@effect/platform-node";
 import { flushLogs, log } from "../db/log.ts";
 import { connectDatabase, endSession, finishAction, insertSession, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
 import { flushSentry, initSentry } from "../sentry.ts";
-import { createDisk, createQemu, screendump, sendKey, start, stop, type Qemu } from "./client.ts";
+import { createDisk, createQemu, screendump, sendKey, sendMouse, start, stop, type Qemu } from "./client.ts";
 import { getIso } from "./iso.ts";
 import { parseKeys } from "./keys.ts";
 import { collectStats, startCpuSampler } from "./stats.ts";
@@ -106,6 +106,15 @@ const SendKeysBody = Schema.Struct({
   id: Schema.String,
   keys: Schema.String,
   encoding: Schema.optionalKey(Schema.String),
+  agent: Schema.NonEmptyString,
+});
+
+const SendMouseBody = Schema.Struct({
+  id: Schema.String,
+  x: Schema.Number,
+  y: Schema.Number,
+  button: Schema.optionalKey(Schema.Literals(["left", "middle", "right", "wheel-up", "wheel-down"])),
+  clicks: Schema.optionalKey(Schema.Number),
   agent: Schema.NonEmptyString,
 });
 
@@ -274,6 +283,28 @@ const routes = HttpRouter.use((router) =>
         catch: (err) => exchangeFailed(err, { sessionId: qemu.id, agentId: agent }),
       });
       log(db, { text: `session ${qemu.id}: sent ${chords.length} chords in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: agent });
+      return HttpServerResponse.jsonUnsafe({ ok: "true" });
+    }) satisfies RouteHandler, { uninterruptible: true });
+
+    yield* router.add("POST", "/send-mouse", Effect.gen(function* () {
+      const started = Date.now();
+      const { id, x, y, button, clicks, agent } = yield* jsonBody(SendMouseBody);
+      const qemu = yield* session(id, agent);
+      if (!(x >= 0 && x <= 1 && y >= 0 && y <= 1)) {
+        return yield* Effect.fail(badRequest("mouse: x and y must be in 0..1", { sessionId: qemu.id, agentId: agent }));
+      }
+      if (clicks !== undefined && (!Number.isInteger(clicks) || clicks < 1)) {
+        return yield* Effect.fail(badRequest("mouse: clicks must be a positive integer", { sessionId: qemu.id, agentId: agent }));
+      }
+      yield* Effect.tryPromise({
+        try: () => sendMouse(qemu, x, y, button, clicks, recorder(qemu.id, agent)),
+        catch: (err) => exchangeFailed(err, { sessionId: qemu.id, agentId: agent }),
+      });
+      log(db, {
+        text: `session ${qemu.id}: mouse ${x} ${y}${button === undefined ? "" : ` ${button}${clicks === undefined || clicks === 1 ? "" : ` ×${clicks}`}`} in ${Date.now() - started}ms`,
+        sessionId: qemu.id,
+        agentId: agent,
+      });
       return HttpServerResponse.jsonUnsafe({ ok: "true" });
     }) satisfies RouteHandler, { uninterruptible: true });
 

--- a/src/qmu.types.ts
+++ b/src/qmu.types.ts
@@ -61,7 +61,23 @@ declare global {
     id: number;
   };
 
-  type QemuCommand = QemuCapabilitiesCommand | QemuSendKeyCommand | QemuScreendumpCommand;
+  type QemuInputButton = "left" | "middle" | "right" | "wheel-up" | "wheel-down";
+
+  type QemuInputEvent =
+    | { type: "abs"; data: { axis: "x" | "y"; value: number } }
+    | { type: "btn"; data: { button: QemuInputButton; down: boolean } };
+
+  type QemuInputSendEventCommand = {
+    execute: "input-send-event";
+    arguments: { events: QemuInputEvent[] };
+    id: number;
+  };
+
+  type QemuCommand =
+    | QemuCapabilitiesCommand
+    | QemuSendKeyCommand
+    | QemuScreendumpCommand
+    | QemuInputSendEventCommand;
 
   type QemuStartResult = {
     id: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The control plane could type but not point. Hyprland focuses the window under the pointer, and a greeter or installer is a click, so a session could not sign in or use the desktop from the screenshot.

## QEMU mouse inventory

Walked the current QMP UI schema (`qapi/ui.json`). What actually involves the mouse:

| Item | What it does | Useful here? |
| --- | --- | --- |
| `input-send-event` + `abs` | Absolute pointer position, range `0..0x7fff` | Yes — click what you see on the screenshot |
| `input-send-event` + `btn` | `left` / `middle` / `right` / `wheel-up` / `wheel-down` / `side` / `extra` / `wheel-left` / `wheel-right` / `touch` | Yes — left, right, middle, and the two wheel ticks. The rest is extra buttons and touch. |
| `input-send-event` + `rel` | Relative motion | No — we never know where the pointer already is |
| `input-send-event` + `mtt` | Multi-touch | No |
| `input-send-event` + `key` | Keyboard via the same command | No — we already have `send-key` |
| `query-mice` | Lists pointer devices (`name`, `index`, `current`, `absolute`) | No — diagnostic only |
| HMP `mouse_move` / `mouse_button` / `mouse_set` | Legacy monitor | No — not QMP |
| `usb-tablet` / `virtio-tablet-pci` | Guest device that accepts `abs` | Yes — without one, `abs` fails with "Input handler not found" |
| `usb-mouse` / `virtio-mouse-pci` | Relative-only pointers | No |

`usb-tablet` (via `qemu-xhci`) is the device that works from firmware through the greeter. `virtio-tablet-pci` needs a guest driver; the installer and OVMF setup would not see it.

What is useful for signing in and using the desktop:

- **Move** so Hyprland focuses the window under the pointer, then type
- **Left click** a user, a password field, a login or installer button
- **Double-click** to launch
- **Right-click** a context menu
- **Scroll** a list or settings page

Relative motion, extra/side buttons, multi-touch, and `query-mice` stay unexposed.

## Surface

One command, same shape as `send-keys`, through the QEMU client, the proxy, and the CLI.

```
oligarchy --agent-id <agent> send-mouse <id> <x> <y> [button [clicks]]
POST /send-mouse  {"id", "x", "y", "button"?, "clicks"?, "agent"}
```

`x` and `y` are fractions of the screenshot (`0` is top/left, `1` is bottom/right). From a pixel `(px, py)` on a `W×H` image: `x = px / (W - 1)`, `y = py / (H - 1)`. Omit `button` to move only. `button` is `left`, `middle`, `right`, `wheel-up`, or `wheel-down`. `clicks` defaults to 1.

Each QMP `input-send-event` is one action row. A click is two exchanges (button down, then button up) because `usb-tablet` syncs once per command — a press and release in the same list leave the button unchanged. A double-click is two of those pairs with a 50ms gap.

## Live proof (Omarchy 4.0.1)

Booted the latest ISO, created user `demo`, installed, reached the Hyprland desktop, launched Chromium, opened Cookie Clicker, and clicked the cookie with `send-mouse`. The in-game counter went from 0 to 4 cookies; the last frame shows the hand cursor on the cookie and a `+1` pop.

[Omarchy desktop after install and login](https://cursor.com/agents/bc-01a05443-fe80-7861-be58-13d5af3fdbe2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fomarchy_desktop.png)

[Cookie Clicker after send-mouse clicks, score 4](https://cursor.com/agents/bc-01a05443-fe80-7861-be58-13d5af3fdbe2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcookie_clicker_after.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05443-fe80-7861-be58-13d5af3fdbe2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05443-fe80-7861-be58-13d5af3fdbe2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

