### PR TITLE
Add clicker.oligarchy.trm.sh test page

### DIFF
--- a/src/clicker.ts
+++ b/src/clicker.ts
@@ -1,0 +1,123 @@
+export const clickerPage = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>clicker</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        user-select: none;
+      }
+      :root {
+        --size: 80px;
+      }
+      #blue {
+        position: absolute;
+        left: var(--size);
+        top: 0;
+        z-index: 1;
+        display: grid;
+        place-items: center;
+        width: var(--size);
+        height: var(--size);
+        background: blue;
+        color: #fff;
+        cursor: pointer;
+        font: 32px/1 sans-serif;
+      }
+      #red {
+        position: absolute;
+        left: 0;
+        top: 0;
+        z-index: 2;
+        width: var(--size);
+        height: var(--size);
+        background: red;
+        cursor: grab;
+        touch-action: none;
+      }
+      #red:active {
+        cursor: grabbing;
+      }
+      #target {
+        position: absolute;
+        right: 10px;
+        bottom: 10px;
+        z-index: 0;
+        box-sizing: border-box;
+        width: calc(var(--size) * 2);
+        height: calc(var(--size) * 2);
+        border: 2px dashed #000;
+      }
+      #target.in {
+        background: purple;
+        border-color: purple;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="blue">0</div>
+    <div id="target"></div>
+    <div id="red"></div>
+    <script>
+      const blue = document.getElementById("blue");
+      const red = document.getElementById("red");
+      const target = document.getElementById("target");
+      const size = red.offsetWidth;
+      let x = 0;
+      let y = 0;
+      let grabX = 0;
+      let grabY = 0;
+      let dragging = false;
+
+      function contained() {
+        const r = red.getBoundingClientRect();
+        const t = target.getBoundingClientRect();
+        return r.left >= t.left && r.top >= t.top && r.right <= t.right && r.bottom <= t.bottom;
+      }
+
+      function place(nextX, nextY) {
+        x = Math.min(Math.max(0, nextX), innerWidth - size);
+        y = Math.min(Math.max(0, nextY), innerHeight - size);
+        red.style.left = x + "px";
+        red.style.top = y + "px";
+        target.classList.toggle("in", contained());
+      }
+
+      blue.addEventListener("click", () => {
+        blue.textContent = String(Number(blue.textContent) + 1);
+      });
+
+      red.addEventListener("pointerdown", (event) => {
+        dragging = true;
+        red.setPointerCapture(event.pointerId);
+        grabX = event.clientX - x;
+        grabY = event.clientY - y;
+      });
+
+      red.addEventListener("pointermove", (event) => {
+        if (!dragging) {
+          return;
+        }
+        place(event.clientX - grabX, event.clientY - grabY);
+      });
+
+      red.addEventListener("pointerup", () => {
+        dragging = false;
+      });
+
+      red.addEventListener("pointercancel", () => {
+        dragging = false;
+      });
+
+      addEventListener("resize", () => {
+        place(x, y);
+      });
+    </script>
+  </body>
+</html>
+`;

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/cloudflare";
 import { Hono } from "hono";
 import type { FC } from "hono/jsx";
 import { jsxRenderer } from "hono/jsx-renderer";
+import { clickerPage } from "./clicker.ts";
 import { getSessionImage, listSessions, type Session } from "./db/query.ts";
 import { SENTRY_DSN } from "./sentry-dsn.ts";
 
@@ -143,6 +144,13 @@ const Home: FC<HomeProps> = ({ sessions }) => (
 );
 
 const app = new Hono<{ Bindings: Bindings }>();
+
+app.use(async (context, next) => {
+  if (new URL(context.req.url).hostname === "clicker.oligarchy.trm.sh") {
+    return context.html(clickerPage);
+  }
+  await next();
+});
 
 app.use(
   jsxRenderer(({ children }) => (

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -147,7 +147,9 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 app.use(async (context, next) => {
   if (new URL(context.req.url).hostname === "clicker.oligarchy.trm.sh") {
-    return context.html(clickerPage);
+    return context.html(clickerPage, 200, {
+      "cache-control": "public, max-age=31536000, immutable",
+    });
   }
   await next();
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -5,6 +5,10 @@
   "assets": {
     "directory": "./public"
   },
+  "routes": [
+    { "pattern": "oligarchy.trm.sh", "custom_domain": true },
+    { "pattern": "clicker.oligarchy.trm.sh", "custom_domain": true }
+  ],
   "compatibility_date": "2026-08-30",
   "compatibility_flags": [
     "nodejs_compat"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a hostname on the dashboard worker for guest-driving tests.

`clicker.oligarchy.trm.sh` serves a page with no narrative:

- A blue square that starts at `0` and increments on each click
- A red square that starts at the top-left and can be dragged, clamped to the viewport
- A dashed square twice the red square's size, 10px from the bottom-right edges; it turns purple when the red square is fully inside it
- The HTML is served with `cache-control: public, max-age=31536000, immutable`

The existing `oligarchy.trm.sh` dashboard is unchanged. Both hostnames are declared as custom domains on `oligarchy-dashboard`. This is already deployed.

[Clicker page at 0 with red square top-left and dashed target bottom-right](https://cursor.com/agents/bc-01a05474-e7eb-7b46-9964-18b076abe3b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fclicker_initial_zero.png)

[Blue counter at 3 after clicks](https://cursor.com/agents/bc-01a05474-e7eb-7b46-9964-18b076abe3b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fclicker_count_three.png)

[Red square inside the target, which has turned purple](https://cursor.com/agents/bc-01a05474-e7eb-7b46-9964-18b076abe3b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fclicker_red_in_purple_target.png)

[clicker_full_page_count_and_drop.mp4](https://cursor.com/agents/bc-01a05474-e7eb-7b46-9964-18b076abe3b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclicker_full_page_count_and_drop.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05474-e7eb-7b46-9964-18b076abe3b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05474-e7eb-7b46-9964-18b076abe3b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

