### PR TITLE
Add Cloud Agent development environment setup

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,11 @@
+{
+  "name": "oligarchy",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "proxy",
+      "command": "DATABASE_URL=\"postgresql://oligarchy:oligarchy@127.0.0.1:5432/oligarchy\" ./server 42069 --automation"
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  qemu-system-x86 qemu-utils ovmf postgresql postgresql-client
+
+# The proxy reads OVMF from /usr/share/edk2/x64; Ubuntu ships it under /usr/share/OVMF.
+sudo mkdir -p /usr/share/edk2/x64
+sudo ln -sf /usr/share/OVMF/OVMF_CODE_4M.fd /usr/share/edk2/x64/OVMF_CODE.4m.fd
+sudo ln -sf /usr/share/OVMF/OVMF_VARS_4M.fd /usr/share/edk2/x64/OVMF_VARS.4m.fd
+
+PG_VER="$(ls /usr/lib/postgresql/ | sort -n | tail -1)"
+if ! pg_isready -q; then
+  sudo pg_ctlcluster "$PG_VER" main start
+fi
+sudo -u postgres psql -v ON_ERROR_STOP=1 -c \
+  "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='oligarchy') THEN CREATE ROLE oligarchy LOGIN PASSWORD 'oligarchy'; END IF; END \$\$;"
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='oligarchy'" | grep -q 1 \
+  || sudo -u postgres createdb -O oligarchy oligarchy
+
+npm ci
+
+# Node's loadEnvFile() does not override an already-set DATABASE_URL, so any injected
+# production secret still wins over this file; the dev commands set the local url inline.
+if [ ! -f .env ]; then
+  echo 'DATABASE_URL=postgresql://oligarchy:oligarchy@127.0.0.1:5432/oligarchy' > .env
+fi
+
+DATABASE_URL='postgresql://oligarchy:oligarchy@127.0.0.1:5432/oligarchy' npm run db:migrate

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PG_VER="$(ls /usr/lib/postgresql/ | sort -n | tail -1)"
+if ! pg_isready -q; then
+  sudo pg_ctlcluster "$PG_VER" main start
+fi
+
+# The proxy runs QEMU as the agent user; open /dev/kvm when the host exposes it.
+if [ -e /dev/kvm ]; then
+  sudo chmod 666 /dev/kvm
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `.cursor/` development-environment configuration so a Cursor Cloud Agent (or any fresh machine) can build, run, and drive the oligarchy control plane end to end.

- **`.cursor/install.sh`** (idempotent bootstrap)
  - `apt-get install` `qemu-system-x86`, `qemu-utils`, `ovmf`, `postgresql`, `postgresql-client` — the host requirements the proxy checks for at startup.
  - Symlinks Ubuntu's OVMF (`/usr/share/OVMF/OVMF_CODE_4M.fd`, `OVMF_VARS_4M.fd`) to the `/usr/share/edk2/x64/OVMF_CODE.4m.fd` / `OVMF_VARS.4m.fd` paths hardcoded in `src/qemu/client.ts`.
  - Provisions a local Postgres role/db (`oligarchy`), runs `npm ci`, writes a fallback `.env`, and applies migrations with `npm run db:migrate`.
- **`.cursor/start.sh`** (per-boot): brings the Postgres cluster up (gated on `pg_isready`) and opens `/dev/kvm` when the host exposes it.
- **`.cursor/environment.json`**: wires `install`/`start` and launches the proxy (`./server 42069 --automation`) as a terminal against the local database.

## Why local Postgres

The proxy requires `DATABASE_URL` at startup. Node's `loadEnvFile()` does not override an already-set variable, so a local Postgres keeps development isolated and works even when no `DATABASE_URL` secret is injected. The env-provided entrypoints (the proxy terminal and the install migrate step) set the local URL inline.

## Verified end to end

On this VM: `npm ci`, `npm run db:migrate` (9 tables created), `npm test` (46/46 pass), and `npm run lint` (clean) all succeed; the proxy comes up under `--automation` and serves `/stats`. Driving the real Omarchy 4.0.2 ISO through the client (`start` → `get-image` → `send-keys` → `send-mouse` → `get-serial` → `stop`) boots the Omarchy installer and records the full session (sessions/agent_runs/actions/images) in Postgres via Drizzle.

## Known blocker (infrastructure, not code)

This VM's nested KVM cannot create vCPUs — QEMU hangs right after the QMP greeting and `dmesg` shows `kvm_spurious_fault` inside `KVM_CREATE_VCPU`. Since the proxy hardcodes `accel=kvm`, guest boots require a host with functioning nested virtualization. The end-to-end demo above used a temporary, uncommitted `accel=tcg` override to prove the pipeline; the committed code is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b4ba7ed-5b82-46db-a489-3bc138e1aae9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b4ba7ed-5b82-46db-a489-3bc138e1aae9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

