### PR TITLE
Remove the agent rule that commits straight to master

### DIFF
--- a/development.md
+++ b/development.md
@@ -4,7 +4,7 @@ Check the field guide: [field-guide/index.md](field-guide/index.md).
 
 ## Branches
 
-- All development happens on `master`. Do not create feature branches, `cursor/*` branches, or pull requests. Work on `master`, commit to `master`, push `master`.
+- Never commit or push to `master`. Create a feature branch, push that branch, and open a pull request.
 
 ## Host
 

--- a/development.md
+++ b/development.md
@@ -2,10 +2,6 @@
 
 Check the field guide: [field-guide/index.md](field-guide/index.md).
 
-## Branches
-
-- Never commit or push to `master`. Create a feature branch, push that branch, and open a pull request.
-
 ## Host
 
 The proxy needs `qemu-system-x86_64`, `qemu-img`, and OVMF at `/usr/share/edk2/x64/OVMF_CODE.4m.fd` and `OVMF_VARS.4m.fd`. `--display gtk` also needs `DISPLAY` and a QEMU build that lists gtk; `egl-headless` needs a DRM render node under `/dev/dri`. The proxy checks what it is about to use at startup and exits 1 with the missing list. There is no setup script.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the Branches section from `development.md`. That section told agents to work only on `master` and skip feature branches and pull requests.

The section is gone. There is no replacement rule.

`AGENTS.md` is unchanged: it still just points agents at `development.md` and `client.md`.

## Testing

Docs-only. Confirmed the old sentence is deleted and that nothing else in the repo still tells agents to commit to `master`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ace2d24d-9a1f-4370-8639-798ebbbada75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ace2d24d-9a1f-4370-8639-798ebbbada75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

