### PR TITLE
Stop writing a local .env during Cursor install

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -23,10 +23,4 @@ sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='oligarchy'"
 
 npm ci
 
-# Node's loadEnvFile() does not override an already-set DATABASE_URL, so any injected
-# production secret still wins over this file; the dev commands set the local url inline.
-if [ ! -f .env ]; then
-  echo 'DATABASE_URL=postgresql://oligarchy:oligarchy@127.0.0.1:5432/oligarchy' > .env
-fi
-
 DATABASE_URL='postgresql://oligarchy:oligarchy@127.0.0.1:5432/oligarchy' npm run db:migrate

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,9 +1,12 @@
+import { existsSync } from "node:fs";
 import { loadEnvFile } from "node:process";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
 import { closeDatabase, connectDatabase } from "./ops.ts";
 
 async function main(): Promise<void> {
-  loadEnvFile();
+  if (existsSync(".env")) {
+    loadEnvFile();
+  }
   const db = connectDatabase();
   try {
     await migrate(db, { migrationsFolder: "drizzle" });

--- a/src/experiment.ts
+++ b/src/experiment.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { loadEnvFile } from "node:process";
 import { Effect, Schema } from "effect";
 import { CliError, Command, Flag } from "effect/unstable/cli";
@@ -305,7 +306,9 @@ export async function createExperiment(
 }
 
 export async function newExperiment(input: { iso: string; serverUrl: string; version: string }): Promise<void> {
-  loadEnvFile();
+  if (existsSync(".env")) {
+    loadEnvFile();
+  }
 
   const token = process.env.LINEAR_API_TOKEN;
   if (token === undefined || token === "") {

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -1,4 +1,5 @@
 import { createServer } from "node:http";
+import { existsSync } from "node:fs";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { loadEnvFile } from "node:process";
@@ -14,7 +15,9 @@ import { getIso } from "./iso.ts";
 import { parseKeys } from "./keys.ts";
 import { collectStats, startCpuSampler } from "./stats.ts";
 
-loadEnvFile();
+if (existsSync(".env")) {
+  loadEnvFile();
+}
 initSentry();
 
 const addr = process.env.OLIGARCHY_ADDR ?? "127.0.0.1:42069";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`.cursor/install.sh` created a local `.env` with `DATABASE_URL=postgresql://oligarchy:oligarchy@127.0.0.1:5432/oligarchy` when the file was missing.

That write should not exist. Cloud Agent environments already inject the PlanetScale `DATABASE_URL` (and `LINEAR_API_TOKEN`). Creating a local `.env` hid that the real secrets were coming through.

This PR:
- Removes the `.env` write from `.cursor/install.sh`
- Loads `.env` only when the file exists (`migrate`, proxy, `experiment new`). Node's `loadEnvFile()` throws `ENOENT` when the file is missing, even if `DATABASE_URL` is already in the environment.

Install still stands up a local Postgres cluster and migrates it with an inline `DATABASE_URL`. `.cursor/environment.json` still starts the proxy with the same local URL hardcoded — that is a separate override, not a `.env` write.

## Testing
- Grep: no remaining `> .env` writes
- `bash -n .cursor/install.sh` parses
- Node `loadEnvFile()` throws `ENOENT` when `.env` is absent
- With leftover `.env` moved aside, `connectDatabase()` used the injected PlanetScale URL (`pg.psdb.cloud`, `sslmode=verify-full`) and queried successfully; `LINEAR_API_TOKEN` stayed set
- `npm run db:migrate` against local Postgres with no `.env` applied migrations
- `npm test`: 51 passed, 0 failed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d12fb4fd-28f1-4d1e-82f2-bdbd2d72baf1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d12fb4fd-28f1-4d1e-82f2-bdbd2d72baf1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

