### PR TITLE
Return 500 when starting an intent while one is already open

### DIFF
--- a/client.md
+++ b/client.md
@@ -123,7 +123,7 @@ Moves the pointer, and optionally clicks or scrolls, at a point on the screensho
 
 ## intent
 
-Declares what you are about to do on the session, before you do it. Required around every action: start an intent, run the commands that fulfill it, end it. One intent may cover many commands, sleeps, and images. One intent is active at a time: a second start while one is open fails, and so does an end with none open. End the open intent before `stop`.
+Declares what you are about to do on the session, before you do it. Required around every action: start an intent, run the commands that fulfill it, end it. One intent may cover many commands, sleeps, and images. One intent is active at a time: a second start while one is open fails with `Cannot start one intent when one's already running. Please end your previous intent.`, and so does an end with none open. End the open intent before `stop`.
 
 ```bash
 ./client --agent-id <agent> intent start --session_id <id> --test_result_id <result> --message "wait for the boot menu"

--- a/field-guide/http-api.md
+++ b/field-guide/http-api.md
@@ -58,7 +58,7 @@ Body `{"id", "x", "y", "button"?, "clicks"?, "agent"}`. Moves the pointer to `(x
 
 ## POST /intent/start
 
-Body `{"id", "agent", "test_result_id", "message"}`. Opens the session's one intent span (name is `message`, `op` is `agent.intent`) as a child of the QEMU session span. A second start while one is still open is a 400. Returns `{"ok": "true"}`.
+Body `{"id", "agent", "test_result_id", "message"}`. Opens the session's one intent span (name is `message`, `op` is `agent.intent`) as a child of the QEMU session span. A second start while one is still open is a 500: `Cannot start one intent when one's already running. Please end your previous intent.` Returns `{"ok": "true"}`.
 
 ## POST /intent/end
 

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -97,10 +97,15 @@ type ApiError =
   | { readonly _tag: "Forbidden"; readonly message: string; readonly sessionId: string; readonly agentId: string }
   | { readonly _tag: "StartFailed"; readonly message: string; readonly cause: unknown; readonly sessionId: string; readonly agentId: string }
   | { readonly _tag: "ExchangeFailed"; readonly message: string; readonly cause: unknown; readonly sessionId: string; readonly agentId: string }
-  | { readonly _tag: "Internal"; readonly cause: unknown; readonly sessionId: string; readonly agentId?: string };
+  | { readonly _tag: "Internal"; readonly cause: unknown; readonly sessionId: string; readonly agentId?: string }
+  | { readonly _tag: "Failed"; readonly message: string; readonly sessionId: string; readonly agentId: string };
 
 function badRequest(message: string, who: { sessionId?: string; agentId?: string } = {}): ApiError {
   return { _tag: "BadRequest", message, ...who };
+}
+
+function failed(message: string, who: { sessionId: string; agentId: string }): ApiError {
+  return { _tag: "Failed", message, ...who };
 }
 
 function startFailed(err: unknown, who: { sessionId: string; agentId: string }): ApiError {
@@ -459,7 +464,10 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
       const { id, agent, test_result_id, message } = yield* jsonBody(IntentStartBody);
       const live = yield* session(id, agent);
       if (live.intent !== undefined) {
-        return yield* Effect.fail(badRequest("intent already active", { sessionId: live.qemu.id, agentId: agent }));
+        return yield* Effect.fail(failed(
+          "Cannot start one intent when one's already running. Please end your previous intent.",
+          { sessionId: live.qemu.id, agentId: agent },
+        ));
       }
       live.intent = startIntentSpan(live.span, live.qemu.id, agent, test_result_id, message);
       log(db, { text: `session ${live.qemu.id}: intent start; ${message}`, sessionId: live.qemu.id, agentId: agent });
@@ -513,6 +521,7 @@ function respondTable(request: HttpServerRequest.HttpServerRequest): {
 } {
   return {
     BadRequest: (err) => answer(request, 400, err.message, err),
+    Failed: (err) => answer(request, 500, err.message, err),
     Forbidden: (err) => answer(request, 403, err.message, err),
     UnknownSession: (err) =>
       answer(request, 404, `unknown session "${err.id}"`, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A second `POST /intent/start` while a session already has an active intent now fails with HTTP 500 and:

`Cannot start one intent when one's already running. Please end your previous intent.`

Previously this was a 400 with `intent already active`.

`client.md` and the HTTP API field guide match the new status and message.

Verified against a live proxy: first start succeeds, second start is 500 with that message (HTTP and `./client`), and start works again after `intent end`.

[intent_already_running_500.log](https://cursor.com/agents/bc-0d330b53-fc73-471c-ab5a-8a6ed72cf39d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fintent_already_running_500.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d330b53-fc73-471c-ab5a-8a6ed72cf39d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d330b53-fc73-471c-ab5a-8a6ed72cf39d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

