### PR TITLE
Address Sentry timeline review findings

### DIFF
--- a/src/qemu/client.test.ts
+++ b/src/qemu/client.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import type { Socket } from "node:net";
 import { describe, it } from "node:test";
-import { createQemu, sendKey } from "./client.ts";
+import { createQemu, sendKey, start, stop } from "./client.ts";
 
 const keys = [{ type: "qcode", data: "a" }] satisfies QemuKeyValue[];
 
@@ -65,6 +65,18 @@ describe("sendKey recorder unhappy path", () => {
     assert.deepEqual(outcome, {
       state: "failed",
       response: "qemu: closed",
+    });
+  });
+});
+
+describe("stopped QEMU", () => {
+  it("cannot start again", async () => {
+    const qemu = createQemu();
+
+    await stop(qemu);
+
+    await assert.rejects(() => start(qemu, { iso: "missing.iso" }), {
+      message: "qemu: closed",
     });
   });
 });

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -34,7 +34,7 @@ type LiveSession = {
   lastCommandAt: number;
   span: QemuSpan;
   intent?: QemuSpan;
-  actions: Set<Promise<void>>;
+  actionSpans: Set<QemuSpan>;
 };
 
 function finishOpenIntent(live: LiveSession, status: "completed" | "cancelled"): void {
@@ -49,6 +49,26 @@ const sessions = new Map<string, LiveSession>();
 const openSessions = new Set<LiveSession>();
 const cpuSampler = startCpuSampler();
 
+function finishLiveActionSpan(
+  live: LiveSession,
+  span: QemuSpan,
+  state: QemuExchangeOutcome["state"],
+): void {
+  if (!live.actionSpans.delete(span)) {
+    return;
+  }
+  finishQemuActionSpan(span, state);
+}
+
+function finishLiveSession(live: LiveSession, status: SessionEndStatus): void {
+  openSessions.delete(live);
+  for (const span of live.actionSpans) {
+    finishLiveActionSpan(live, span, "failed");
+  }
+  finishOpenIntent(live, "cancelled");
+  finishQemuSpan(live.span, status);
+}
+
 // Drizzle buries the reason (ECONNREFUSED etc.) in the cause; its own message is the failed SQL.
 function errorDetail(err: unknown): string {
   const e = err as Error;
@@ -57,35 +77,24 @@ function errorDetail(err: unknown): string {
 
 function recorder(live: LiveSession): QemuExchangeRecorder {
   return async (command) => {
-    let finishTracking!: () => void;
-    const active = new Promise<void>((resolve) => {
-      finishTracking = resolve;
-    });
-    live.actions.add(active);
     const sessionId = live.qemu.id;
     const agentId = live.agent;
     const span = startQemuActionSpan(live.intent ?? live.span, sessionId, agentId, command.execute);
+    live.actionSpans.add(span);
     let id: number;
     try {
       id = await startAction(db, { sessionId, agentId, request: command });
     } catch (err) {
-      finishQemuActionSpan(span, "failed");
-      live.actions.delete(active);
-      finishTracking();
+      finishLiveActionSpan(live, span, "failed");
       throw err;
     }
     return async (outcome) => {
-      let state = outcome.state;
+      finishLiveActionSpan(live, span, outcome.state);
       try {
         await finishAction(db, id, outcome);
       } catch (err) {
-        state = "failed";
         log(db, { level: "error", text: `db: closing action ${id} failed: ${errorDetail(err)}`, sessionId, agentId }, { cause: err });
         throw err;
-      } finally {
-        finishQemuActionSpan(span, state);
-        live.actions.delete(active);
-        finishTracking();
       }
     };
   };
@@ -217,7 +226,6 @@ async function launchQemu(
     await sessionRunning(db, qemu.id);
   } catch (err) {
     await stop(qemu).catch(() => {});
-    await Promise.all(live.actions);
     await endSession(db, qemu.id, "failed", (err as Error).message).catch((e: unknown) => {
       log(db, { level: "error", text: `db: recording a failed start failed too: ${(e as Error).message}`, sessionId: qemu.id, agentId: cfg.agent }, { cause: e });
     });
@@ -230,15 +238,12 @@ function startSession(cfg: typeof StartBody.Type, started: number, display: Qemu
     const isUrl = cfg.iso.startsWith("http://") || cfg.iso.startsWith("https://");
     const qemu = createQemu({ display, automation });
     const span = startQemuSpan(qemu.id, cfg.agent);
-    const actions = new Set<Promise<void>>();
-    const live = { qemu, agent: cfg.agent, lastCommandAt: Date.now(), span, actions };
+    const live = { qemu, agent: cfg.agent, lastCommandAt: Date.now(), span, actionSpans: new Set<QemuSpan>() };
     openSessions.add(live);
     yield* Effect.tryPromise({
       try: () => insertSession(db, qemu.id, { iso: cfg.iso, disk: cfg.disk }, isUrl ? "downloading" : "running"),
       catch: (cause) => {
-        if (openSessions.delete(live)) {
-          finishQemuSpan(span, "failed");
-        }
+        finishLiveSession(live, "failed");
         return internal(cause, { sessionId: qemu.id, agentId: cfg.agent });
       },
     });
@@ -250,9 +255,7 @@ function startSession(cfg: typeof StartBody.Type, started: number, display: Qemu
     yield* Effect.tryPromise({
       try: () => launchQemu(live, cfg),
       catch: (err) => {
-        if (openSessions.delete(live)) {
-          finishQemuSpan(span, "failed");
-        }
+        finishLiveSession(live, "failed");
         return startFailed(err, { sessionId: qemu.id, agentId: cfg.agent });
       },
     });
@@ -287,27 +290,21 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
       let opened: number | undefined;
       let outcome: QemuExchangeOutcome | undefined;
       let actionSpan: QemuSpan | undefined;
-      let activeAction: Promise<void> | undefined;
-      let finishTracking: (() => void) | undefined;
       const png = Effect.gen(function* () {
         yield* Effect.tryPromise({
           try: () =>
             screendump(qemu, path, "png", async (command) => {
-              activeAction = new Promise<void>((resolve) => {
-                finishTracking = resolve;
-              });
-              live.actions.add(activeAction);
               actionSpan = startQemuActionSpan(live.intent ?? live.span, qemu.id, agent, command.execute);
+              live.actionSpans.add(actionSpan);
               try {
                 opened = await startAction(db, { sessionId: qemu.id, agentId: agent, request: command });
               } catch (err) {
-                finishQemuActionSpan(actionSpan, "failed");
-                live.actions.delete(activeAction);
-                finishTracking!();
+                finishLiveActionSpan(live, actionSpan, "failed");
                 throw err;
               }
               return async (result) => {
                 outcome = result;
+                finishLiveActionSpan(live, actionSpan!, result.state);
               };
             }),
           catch: (err) => exchangeFailed(err, { sessionId: qemu.id, agentId: agent }),
@@ -320,9 +317,6 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
                 await finishAction(db, opened, outcome).catch((e: unknown) => {
                   log(db, { level: "error", text: `db: recording a failed screendump failed too: ${(e as Error).message}`, sessionId: qemu.id, agentId: agent }, { cause: e });
                 });
-                finishQemuActionSpan(actionSpan!, "failed");
-                live.actions.delete(activeAction!);
-                finishTracking!();
               }
             })
           ),
@@ -332,15 +326,9 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
             const data = await readFile(path);
             // screendump resolved, so the recorder ran: opened and outcome are set.
             await finishAction(db, opened!, outcome!, data);
-            finishQemuActionSpan(actionSpan!, outcome!.state);
-            live.actions.delete(activeAction!);
-            finishTracking!();
             return data;
           },
           catch: (cause) => {
-            finishQemuActionSpan(actionSpan!, "failed");
-            live.actions.delete(activeAction!);
-            finishTracking!();
             return internal(cause, { sessionId: qemu.id, agentId: agent });
           },
         });
@@ -371,37 +359,20 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
       const finalStatus = status ?? "aborted";
       sessions.delete(qemu.id);
       yield* Effect.tryPromise({
-        try: async () => {
-          try {
-            await stop(qemu);
-          } catch (cause) {
-            await Promise.all(live.actions);
-            throw cause;
-          }
-          await Promise.all(live.actions);
-        },
+        try: () => stop(qemu),
         catch: (cause) => {
-          if (openSessions.delete(live)) {
-            finishOpenIntent(live, "cancelled");
-            finishQemuSpan(live.span, "failed");
-          }
+          finishLiveSession(live, "failed");
           return internal(cause, { sessionId: qemu.id, agentId: agent });
         },
       });
       yield* Effect.tryPromise({
         try: () => endSession(db, qemu.id, finalStatus, reason ?? null),
         catch: (cause) => {
-          if (openSessions.delete(live)) {
-            finishOpenIntent(live, "cancelled");
-            finishQemuSpan(live.span, "failed");
-          }
+          finishLiveSession(live, finalStatus);
           return internal(cause, { sessionId: qemu.id, agentId: agent });
         },
       });
-      if (openSessions.delete(live)) {
-        finishOpenIntent(live, "cancelled");
-        finishQemuSpan(live.span, finalStatus);
-      }
+      finishLiveSession(live, finalStatus);
       log(db, {
         text: `session ${qemu.id}: stopped; ${finalStatus}${reason === undefined ? "" : `; ${reason}`}`,
         sessionId: qemu.id,
@@ -555,22 +526,18 @@ async function stopTimedOutSessions(): Promise<void> {
   }
   const results = await Promise.allSettled(
     timedOut.map(async (live) => {
-      const { qemu, span, actions } = live;
+      const { qemu } = live;
       try {
         await stop(qemu);
       } catch (err) {
         // stop() already destroyed the socket and signaled QEMU, so still close the record.
         log(db, { level: "error", text: `session ${qemu.id}: timeout cleanup failed: ${errorDetail(err)}`, sessionId: qemu.id }, { cause: err });
       }
-      await Promise.all(actions);
       try {
         await endSession(db, qemu.id, "timed_out", SESSION_TIMEOUT_REASON);
         log(db, { text: `session ${qemu.id}: timed out; ${SESSION_TIMEOUT_REASON}`, sessionId: qemu.id });
       } finally {
-        if (openSessions.delete(live)) {
-          finishOpenIntent(live, "cancelled");
-          finishQemuSpan(span, "timed_out");
-        }
+        finishLiveSession(live, "timed_out");
       }
     }),
   );
@@ -612,24 +579,18 @@ const drainSessions = Layer.effectDiscard(
       log(db, `proxy: shutting down; stopping ${sessions.size} sessions`);
       const results = await Promise.allSettled(
         [...sessions.values()].map(async (live) => {
-          const { qemu, span, actions } = live;
+          const { qemu } = live;
+          let status: SessionEndStatus = "failed";
           try {
             await stop(qemu);
-            await Promise.all(actions);
+            status = "aborted";
             await endSession(db, qemu.id, "aborted", "proxy shutdown");
-            if (openSessions.delete(live)) {
-              finishOpenIntent(live, "cancelled");
-              finishQemuSpan(span, "aborted");
-            }
             log(db, { text: `session ${qemu.id}: stopped; aborted; proxy shutdown`, sessionId: qemu.id });
           } catch (err) {
-            await Promise.all(actions);
-            if (openSessions.delete(live)) {
-              finishOpenIntent(live, "cancelled");
-              finishQemuSpan(span, "failed");
-            }
             log(db, { level: "error", text: `shutdown: session ${qemu.id}: ${(err as Error).message}`, sessionId: qemu.id }, { cause: err });
             throw err;
+          } finally {
+            finishLiveSession(live, status);
           }
         }),
       );
@@ -646,6 +607,7 @@ const main = (display: QemuDisplay, automation: boolean) => Layer.effectDiscard(
   Effect.sync(() => {
     log(db, `oligarchy proxy listening on ${addr}; display ${display}${automation ? "; automation" : ""}`);
     server.on("error", (err) => {
+      // Later accept errors must not exit before the first fatal flush finishes.
       if (serverFailing) {
         return;
       }
@@ -655,15 +617,11 @@ const main = (display: QemuDisplay, automation: boolean) => Layer.effectDiscard(
       const open = [...openSessions];
       openSessions.clear();
       sessions.clear();
-      void Promise.allSettled(
-        open.map(async (live) => {
-          const { qemu, span, actions } = live;
-          await stop(qemu).catch(() => {});
-          await Promise.all(actions);
-          finishOpenIntent(live, "cancelled");
-          finishQemuSpan(span, "failed");
-        }),
-      ).then(flushLogs).then(flushSentry).then(() => process.exit(1));
+      const stops = open.map((live) => stop(live.qemu).catch(() => {}));
+      for (const live of open) {
+        finishLiveSession(live, "failed");
+      }
+      void Promise.all(stops).then(flushLogs).then(flushSentry).then(() => process.exit(1));
     });
   }),
 ).pipe(

--- a/src/sentry.test.ts
+++ b/src/sentry.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
+import { once } from "node:events";
+import { createServer } from "node:http";
 import { afterEach, describe, it } from "node:test";
 import * as Sentry from "@sentry/node";
 import {
   finishQemuActionSpan,
   finishQemuSpan,
+  initSentry,
   startQemuActionSpan,
   startQemuSpan,
 } from "./sentry.ts";
@@ -51,6 +54,39 @@ function captureSpans(): { spans: () => Promise<StreamedSpan[]> } {
 
 afterEach(async () => {
   await Sentry.close(1_000);
+});
+
+describe("initSentry", () => {
+  it("does not trace proxy HTTP requests or fetches", async () => {
+    initSentry();
+    const client = Sentry.getClient();
+    assert.ok(client !== undefined);
+    Object.assign(client, {
+      _transport: {
+        send: async () => ({}),
+        flush: async () => true,
+      },
+    });
+    let started = 0;
+    client.on("spanStart", () => {
+      started++;
+    });
+    const server = createServer((_request, response) => {
+      response.end("ok");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    assert.ok(address !== null && typeof address !== "string");
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${address.port}/test`);
+      assert.equal(await response.text(), "ok");
+      assert.equal(started, 0);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
 });
 
 describe("QEMU spans happy path", () => {
@@ -115,5 +151,29 @@ describe("QEMU spans unhappy path", () => {
     assert.equal(spans.length, 1);
     assert.equal(spans[0].status, "error");
     assert.equal(spans[0].attributes.session_status.value, "failed");
+  });
+
+  it("marks an aborted session as an error", async () => {
+    const captured = captureSpans();
+    const session = startQemuSpan("session-4", "agent-4");
+
+    finishQemuSpan(session, "aborted");
+
+    const spans = await captured.spans();
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0].status, "error");
+    assert.equal(spans[0].attributes.session_status.value, "aborted");
+  });
+
+  it("marks a timed-out session as an error", async () => {
+    const captured = captureSpans();
+    const session = startQemuSpan("session-5", "agent-5");
+
+    finishQemuSpan(session, "timed_out");
+
+    const spans = await captured.spans();
+    assert.equal(spans.length, 1);
+    assert.equal(spans[0].status, "error");
+    assert.equal(spans[0].attributes.session_status.value, "timed_out");
   });
 });

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -6,10 +6,14 @@ export function initSentry(): void {
     dsn: SENTRY_DSN,
     tracesSampleRate: 1,
     traceLifecycle: "stream",
+    integrations: [
+      Sentry.httpIntegration({ spans: false }),
+      Sentry.nativeNodeFetchIntegration({ spans: false }),
+    ],
   });
 }
 
-export type QemuSpan = ReturnType<typeof Sentry.startInactiveSpan>;
+export type QemuSpan = Sentry.Span;
 
 export function startQemuSpan(sessionId: string, agentId: string): QemuSpan {
   return Sentry.startInactiveSpan({
@@ -30,7 +34,7 @@ export function finishQemuSpan(span: QemuSpan, status: SessionEndStatus): void {
   } else if (status === "timed_out") {
     span.setStatus({ code: 2, message: "deadline_exceeded" });
   } else if (status === "aborted") {
-    span.setStatus({ code: 2, message: "cancelled" });
+    span.setStatus({ code: 2, message: "aborted" });
   } else {
     span.setStatus({ code: 2, message: "internal_error" });
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- disable automatic HTTP and fetch spans so tracing stays focused on QEMU sessions, intents, and actions
- report aborted sessions as errors and close action spans with the observed QMP outcome
- replace action-drain promises with direct active-span ownership while preserving fatal QEMU teardown
- cover tracing scope, session end statuses, and stopped-QEMU behavior

## Testing
- `npm test` (55 tests)
- `npm run lint`
- `tsc --noEmit`
- final GPT-5.6 Sol review: no findings
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18901741-4cd9-467d-be93-16e7d4da5fcc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18901741-4cd9-467d-be93-16e7d4da5fcc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

