### PR TITLE
Serve the clicker app on clicker.oligarchy.trm.sh

### DIFF
--- a/src/clicker.ts
+++ b/src/clicker.ts
@@ -74,18 +74,14 @@ export const clickerPage = `<!doctype html>
       let grabY = 0;
       let dragging = false;
 
-      function contained() {
-        const r = red.getBoundingClientRect();
-        const t = target.getBoundingClientRect();
-        return r.left >= t.left && r.top >= t.top && r.right <= t.right && r.bottom <= t.bottom;
-      }
-
       function place(nextX, nextY) {
         x = Math.min(Math.max(0, nextX), innerWidth - size);
         y = Math.min(Math.max(0, nextY), innerHeight - size);
         red.style.left = x + "px";
         red.style.top = y + "px";
-        target.classList.toggle("in", contained());
+        const r = red.getBoundingClientRect();
+        const t = target.getBoundingClientRect();
+        target.classList.toggle("in", r.left >= t.left && r.top >= t.top && r.right <= t.right && r.bottom <= t.bottom);
       }
 
       blue.addEventListener("click", () => {

--- a/src/clicker.ts
+++ b/src/clicker.ts
@@ -1,0 +1,123 @@
+export const clickerPage = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>clicker</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        overflow: hidden;
+        user-select: none;
+      }
+      :root {
+        --size: 80px;
+      }
+      #blue {
+        position: absolute;
+        left: var(--size);
+        top: 0;
+        z-index: 1;
+        display: grid;
+        place-items: center;
+        width: var(--size);
+        height: var(--size);
+        background: blue;
+        color: #fff;
+        cursor: pointer;
+        font: 32px/1 sans-serif;
+      }
+      #red {
+        position: absolute;
+        left: 0;
+        top: 0;
+        z-index: 2;
+        width: var(--size);
+        height: var(--size);
+        background: red;
+        cursor: grab;
+        touch-action: none;
+      }
+      #red:active {
+        cursor: grabbing;
+      }
+      #target {
+        position: absolute;
+        right: 10px;
+        bottom: 10px;
+        z-index: 0;
+        box-sizing: border-box;
+        width: calc(var(--size) * 2);
+        height: calc(var(--size) * 2);
+        border: 2px dashed #000;
+      }
+      #target.in {
+        background: purple;
+        border-color: purple;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="blue">0</div>
+    <div id="target"></div>
+    <div id="red"></div>
+    <script>
+      const blue = document.getElementById("blue");
+      const red = document.getElementById("red");
+      const target = document.getElementById("target");
+      const size = red.offsetWidth;
+      let x = 0;
+      let y = 0;
+      let grabX = 0;
+      let grabY = 0;
+      let dragging = false;
+
+      function contained() {
+        const r = red.getBoundingClientRect();
+        const t = target.getBoundingClientRect();
+        return r.left >= t.left && r.top >= t.top && r.right <= t.right && r.bottom <= t.bottom;
+      }
+
+      function place(nextX, nextY) {
+        x = Math.min(Math.max(0, nextX), innerWidth - size);
+        y = Math.min(Math.max(0, nextY), innerHeight - size);
+        red.style.left = x + "px";
+        red.style.top = y + "px";
+        target.classList.toggle("in", contained());
+      }
+
+      blue.addEventListener("click", () => {
+        blue.textContent = String(Number(blue.textContent) + 1);
+      });
+
+      red.addEventListener("pointerdown", (event) => {
+        dragging = true;
+        red.setPointerCapture(event.pointerId);
+        grabX = event.clientX - x;
+        grabY = event.clientY - y;
+      });
+
+      red.addEventListener("pointermove", (event) => {
+        if (!dragging) {
+          return;
+        }
+        place(event.clientX - grabX, event.clientY - grabY);
+      });
+
+      red.addEventListener("pointerup", () => {
+        dragging = false;
+      });
+
+      red.addEventListener("pointercancel", () => {
+        dragging = false;
+      });
+
+      addEventListener("resize", () => {
+        place(x, y);
+      });
+    </script>
+  </body>
+</html>
+`;

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -278,9 +278,7 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 app.use(async (context, next) => {
   if (new URL(context.req.url).hostname === "clicker.oligarchy.trm.sh") {
-    return context.html(clickerPage, 200, {
-      "cache-control": "public, max-age=31536000, immutable",
-    });
+    return context.html(clickerPage);
   }
   await next();
 });

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -11,6 +11,7 @@ import {
   type TestBasePrompt,
   type TestDefinition,
 } from "./db/query.ts";
+import { clickerPage } from "./clicker.ts";
 import { SENTRY_DSN } from "./sentry-dsn.ts";
 
 const HTMX_URL = "https://cdn.jsdelivr.net/npm/htmx.org@4.0.0";
@@ -274,6 +275,15 @@ const Prompts: FC<PromptsProps> = ({ prompts }) => (
 );
 
 const app = new Hono<{ Bindings: Bindings }>();
+
+app.use(async (context, next) => {
+  if (new URL(context.req.url).hostname === "clicker.oligarchy.trm.sh") {
+    return context.html(clickerPage, 200, {
+      "cache-control": "public, max-age=31536000, immutable",
+    });
+  }
+  await next();
+});
 
 app.use(
   jsxRenderer(({ children }) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`clicker.oligarchy.trm.sh` was already a custom domain on the dashboard worker, so navigating there showed the Omarchy test-results app.

This routes that hostname to the click-and-drag test page (blue click counter, red draggable square, dashed target that turns purple when the square is fully inside). `oligarchy.trm.sh` is unchanged.

Deployed to the live worker. Verified:
- `https://clicker.oligarchy.trm.sh` returns the clicker page
- `https://oligarchy.trm.sh` still returns the Omarchy dashboard

[Clicker after ten clicks, red square in purple target](https://cursor.com/agents/bc-01a06432-d798-77cc-81aa-02843a7f758d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclicker_count_ten_target_purple.webp)
[Omarchy dashboard still on oligarchy.trm.sh](https://cursor.com/agents/bc-01a06432-d798-77cc-81aa-02843a7f758d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foligarchy_dashboard_still_test_results.webp)
[clicker_full_page_count_and_drag.mp4](https://cursor.com/agents/bc-01a06432-d798-77cc-81aa-02843a7f758d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclicker_full_page_count_and_drag.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06432-d798-77cc-81aa-02843a7f758d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06432-d798-77cc-81aa-02843a7f758d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

