### PR TITLE
Fix bugs found in the client/proxy QEMU control plane

### DIFF
--- a/field-guide/http-api.md
+++ b/field-guide/http-api.md
@@ -50,11 +50,11 @@ Stats for the machine the proxy runs on, plus how many sessions it is running:
 
 ## POST /send-keys
 
-Body `{"id", "keys", "encoding"?, "agent"}`. The server parses the key string (`encoding` defaults to `oligarchy`, see [how-to.md](how-to.md)) and types it into the guest via QMP `send-key`. Returns `{"ok": "true"}`.
+Body `{"id", "keys", "encoding"?, "agent"}`. The server parses the key string (`encoding` defaults to `oligarchy`, see [how-to.md](how-to.md)) and types it into the guest via QMP `send-key`, pacing the chords so QEMU's keyboard queue does not overflow and drop keys. At most 1000 keys are accepted per request; more is a 400. Returns `{"ok": "true"}`.
 
 ## POST /send-mouse
 
-Body `{"id", "x", "y", "button"?, "clicks"?, "agent"}`. Moves the pointer to `(x, y)` — each a number in `0..1`, the fraction of the screenshot from the top-left — via QMP `input-send-event`. With no `button`, that is the whole command: a move, so Hyprland focus can follow the pointer. With `button` (`left`, `middle`, `right`, `wheel-up`, `wheel-down`), the server then pulses that button `clicks` times (`clicks` defaults to 1). Returns `{"ok": "true"}`.
+Body `{"id", "x", "y", "button"?, "clicks"?, "agent"}`. Moves the pointer to `(x, y)` — each a number in `0..1`, the fraction of the screenshot from the top-left — via QMP `input-send-event`. With no `button`, that is the whole command: a move, so Hyprland focus can follow the pointer. With `button` (`left`, `middle`, `right`, `wheel-up`, `wheel-down`), the server then pulses that button `clicks` times (`clicks` defaults to 1, and must be an integer in `1..100`). Returns `{"ok": "true"}`.
 
 ## POST /intent/start
 

--- a/src/db/ops.ts
+++ b/src/db/ops.ts
@@ -32,6 +32,10 @@ export async function closeDatabase(db: Db): Promise<void> {
   await db.$client.end();
 }
 
+export async function pingDatabase(db: Db): Promise<void> {
+  await db.execute(sql`select 1`);
+}
+
 export async function insertSession(db: Db, id: string, config: SessionConfig, status: SessionStartStatus): Promise<void> {
   await db.insert(sessions).values({ id, config, status });
 }

--- a/src/db/query.ts
+++ b/src/db/query.ts
@@ -1,5 +1,5 @@
 import { desc, eq, sql } from "drizzle-orm";
-import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
+import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import { actions, images, sessions, testBasePrompts, testDefinitions } from "./schema.ts";
 
@@ -11,80 +11,75 @@ export type Session = typeof sessions.$inferSelect & {
 export type TestDefinition = typeof testDefinitions.$inferSelect;
 export type TestBasePrompt = typeof testBasePrompts.$inferSelect;
 
-// One connection per request, always closed: a worker invocation that leaves the
-// client open leaks a Hyperdrive pooled connection until the pool is exhausted.
-async function withDb<T>(connectionString: string, run: (db: NodePgDatabase) => Promise<T>): Promise<T> {
+async function connectDatabase(connectionString: string) {
   const client = new Client({ connectionString });
   await client.connect();
-  try {
-    return await run(drizzle(client));
-  } finally {
-    await client.end();
-  }
+  return drizzle(client);
 }
 
 export async function listSessions(connectionString: string): Promise<Session[]> {
-  return withDb(connectionString, async (db) => {
-    const recentSessions = db
-      .select({
-        id: sessions.id,
-        config: sessions.config,
-        status: sessions.status,
-        reason: sessions.reason,
-        startedAt: sessions.startedAt,
-        endedAt: sessions.endedAt,
-      })
-      .from(sessions)
-      .orderBy(desc(sessions.startedAt))
-      .limit(50)
-      .as("recent_sessions");
-    const latestImage = db
-      .select({ actionId: images.actionId })
-      .from(images)
-      .innerJoin(actions, eq(actions.id, images.actionId))
-      .where(eq(actions.sessionId, recentSessions.id))
-      .orderBy(desc(actions.id))
-      .limit(1)
-      .as("latest_image");
+  const db = await connectDatabase(connectionString);
+  const recentSessions = db
+    .select({
+      id: sessions.id,
+      config: sessions.config,
+      status: sessions.status,
+      reason: sessions.reason,
+      startedAt: sessions.startedAt,
+      endedAt: sessions.endedAt,
+    })
+    .from(sessions)
+    .orderBy(desc(sessions.startedAt))
+    .limit(50)
+    .as("recent_sessions");
+  const latestImage = db
+    .select({ actionId: images.actionId })
+    .from(images)
+    .innerJoin(actions, eq(actions.id, images.actionId))
+    .where(eq(actions.sessionId, recentSessions.id))
+    .orderBy(desc(actions.id))
+    .limit(1)
+    .as("latest_image");
 
-    // The database timestamp shown by the UI also keeps status reads out of Hyperdrive's query cache.
-    return db
-      .select({
-        id: recentSessions.id,
-        config: recentSessions.config,
-        status: recentSessions.status,
-        reason: recentSessions.reason,
-        startedAt: recentSessions.startedAt,
-        endedAt: recentSessions.endedAt,
-        imageActionId: latestImage.actionId,
-        queriedAt: sql<Date>`CURRENT_TIMESTAMP`.mapWith(recentSessions.startedAt),
-      })
-      .from(recentSessions)
-      .leftJoinLateral(latestImage, sql`true`)
-      .orderBy(desc(recentSessions.startedAt));
-  });
+  // The database timestamp shown by the UI also keeps status reads out of Hyperdrive's query cache.
+  const rows = await db
+    .select({
+      id: recentSessions.id,
+      config: recentSessions.config,
+      status: recentSessions.status,
+      reason: recentSessions.reason,
+      startedAt: recentSessions.startedAt,
+      endedAt: recentSessions.endedAt,
+      imageActionId: latestImage.actionId,
+      queriedAt: sql<Date>`CURRENT_TIMESTAMP`.mapWith(recentSessions.startedAt),
+    })
+    .from(recentSessions)
+    .leftJoinLateral(latestImage, sql`true`)
+    .orderBy(desc(recentSessions.startedAt));
+  return rows;
 }
 
 export async function getSessionImage(connectionString: string, sessionId: string): Promise<Buffer | undefined> {
-  return withDb(connectionString, async (db) => {
-    const [row] = await db
-      .select({
-        data: images.data,
-        queriedAt: sql`CURRENT_TIMESTAMP`,
-      })
-      .from(images)
-      .innerJoin(actions, eq(actions.id, images.actionId))
-      .where(eq(actions.sessionId, sessionId))
-      .orderBy(desc(actions.id))
-      .limit(1);
-    return row?.data;
-  });
+  const db = await connectDatabase(connectionString);
+  const [row] = await db
+    .select({
+      data: images.data,
+      queriedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .from(images)
+    .innerJoin(actions, eq(actions.id, images.actionId))
+    .where(eq(actions.sessionId, sessionId))
+    .orderBy(desc(actions.id))
+    .limit(1);
+  return row?.data;
 }
 
 export async function listTestDefinitions(connectionString: string): Promise<TestDefinition[]> {
-  return withDb(connectionString, async (db) => db.select().from(testDefinitions).orderBy(testDefinitions.name));
+  const db = await connectDatabase(connectionString);
+  return db.select().from(testDefinitions).orderBy(testDefinitions.name);
 }
 
 export async function listTestBasePrompts(connectionString: string): Promise<TestBasePrompt[]> {
-  return withDb(connectionString, async (db) => db.select().from(testBasePrompts).orderBy(testBasePrompts.name));
+  const db = await connectDatabase(connectionString);
+  return db.select().from(testBasePrompts).orderBy(testBasePrompts.name);
 }

--- a/src/db/query.ts
+++ b/src/db/query.ts
@@ -1,5 +1,5 @@
 import { desc, eq, sql } from "drizzle-orm";
-import { drizzle } from "drizzle-orm/node-postgres";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import { actions, images, sessions, testBasePrompts, testDefinitions } from "./schema.ts";
 
@@ -11,75 +11,80 @@ export type Session = typeof sessions.$inferSelect & {
 export type TestDefinition = typeof testDefinitions.$inferSelect;
 export type TestBasePrompt = typeof testBasePrompts.$inferSelect;
 
-async function connectDatabase(connectionString: string) {
+// One connection per request, always closed: a worker invocation that leaves the
+// client open leaks a Hyperdrive pooled connection until the pool is exhausted.
+async function withDb<T>(connectionString: string, run: (db: NodePgDatabase) => Promise<T>): Promise<T> {
   const client = new Client({ connectionString });
   await client.connect();
-  return drizzle(client);
+  try {
+    return await run(drizzle(client));
+  } finally {
+    await client.end();
+  }
 }
 
 export async function listSessions(connectionString: string): Promise<Session[]> {
-  const db = await connectDatabase(connectionString);
-  const recentSessions = db
-    .select({
-      id: sessions.id,
-      config: sessions.config,
-      status: sessions.status,
-      reason: sessions.reason,
-      startedAt: sessions.startedAt,
-      endedAt: sessions.endedAt,
-    })
-    .from(sessions)
-    .orderBy(desc(sessions.startedAt))
-    .limit(50)
-    .as("recent_sessions");
-  const latestImage = db
-    .select({ actionId: images.actionId })
-    .from(images)
-    .innerJoin(actions, eq(actions.id, images.actionId))
-    .where(eq(actions.sessionId, recentSessions.id))
-    .orderBy(desc(actions.id))
-    .limit(1)
-    .as("latest_image");
+  return withDb(connectionString, async (db) => {
+    const recentSessions = db
+      .select({
+        id: sessions.id,
+        config: sessions.config,
+        status: sessions.status,
+        reason: sessions.reason,
+        startedAt: sessions.startedAt,
+        endedAt: sessions.endedAt,
+      })
+      .from(sessions)
+      .orderBy(desc(sessions.startedAt))
+      .limit(50)
+      .as("recent_sessions");
+    const latestImage = db
+      .select({ actionId: images.actionId })
+      .from(images)
+      .innerJoin(actions, eq(actions.id, images.actionId))
+      .where(eq(actions.sessionId, recentSessions.id))
+      .orderBy(desc(actions.id))
+      .limit(1)
+      .as("latest_image");
 
-  // The database timestamp shown by the UI also keeps status reads out of Hyperdrive's query cache.
-  const rows = await db
-    .select({
-      id: recentSessions.id,
-      config: recentSessions.config,
-      status: recentSessions.status,
-      reason: recentSessions.reason,
-      startedAt: recentSessions.startedAt,
-      endedAt: recentSessions.endedAt,
-      imageActionId: latestImage.actionId,
-      queriedAt: sql<Date>`CURRENT_TIMESTAMP`.mapWith(recentSessions.startedAt),
-    })
-    .from(recentSessions)
-    .leftJoinLateral(latestImage, sql`true`)
-    .orderBy(desc(recentSessions.startedAt));
-  return rows;
+    // The database timestamp shown by the UI also keeps status reads out of Hyperdrive's query cache.
+    return db
+      .select({
+        id: recentSessions.id,
+        config: recentSessions.config,
+        status: recentSessions.status,
+        reason: recentSessions.reason,
+        startedAt: recentSessions.startedAt,
+        endedAt: recentSessions.endedAt,
+        imageActionId: latestImage.actionId,
+        queriedAt: sql<Date>`CURRENT_TIMESTAMP`.mapWith(recentSessions.startedAt),
+      })
+      .from(recentSessions)
+      .leftJoinLateral(latestImage, sql`true`)
+      .orderBy(desc(recentSessions.startedAt));
+  });
 }
 
 export async function getSessionImage(connectionString: string, sessionId: string): Promise<Buffer | undefined> {
-  const db = await connectDatabase(connectionString);
-  const [row] = await db
-    .select({
-      data: images.data,
-      queriedAt: sql`CURRENT_TIMESTAMP`,
-    })
-    .from(images)
-    .innerJoin(actions, eq(actions.id, images.actionId))
-    .where(eq(actions.sessionId, sessionId))
-    .orderBy(desc(actions.id))
-    .limit(1);
-  return row?.data;
+  return withDb(connectionString, async (db) => {
+    const [row] = await db
+      .select({
+        data: images.data,
+        queriedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .from(images)
+      .innerJoin(actions, eq(actions.id, images.actionId))
+      .where(eq(actions.sessionId, sessionId))
+      .orderBy(desc(actions.id))
+      .limit(1);
+    return row?.data;
+  });
 }
 
 export async function listTestDefinitions(connectionString: string): Promise<TestDefinition[]> {
-  const db = await connectDatabase(connectionString);
-  return db.select().from(testDefinitions).orderBy(testDefinitions.name);
+  return withDb(connectionString, async (db) => db.select().from(testDefinitions).orderBy(testDefinitions.name));
 }
 
 export async function listTestBasePrompts(connectionString: string): Promise<TestBasePrompt[]> {
-  const db = await connectDatabase(connectionString);
-  return db.select().from(testBasePrompts).orderBy(testBasePrompts.name);
+  return withDb(connectionString, async (db) => db.select().from(testBasePrompts).orderBy(testBasePrompts.name));
 }

--- a/src/qemu/cli.ts
+++ b/src/qemu/cli.ts
@@ -193,7 +193,9 @@ const sendMouse = Command.make(
     y: Argument.float("y").pipe(Argument.withSchema(UnitInterval)),
     button: Argument.choice("button", ["left", "middle", "right", "wheel-up", "wheel-down"]).pipe(Argument.optional),
     clicks: Argument.integer("clicks").pipe(
-      Argument.withSchema(Schema.Number.check(Schema.isGreaterThanOrEqualTo(1))),
+      Argument.withSchema(
+        Schema.Number.check(Schema.isGreaterThanOrEqualTo(1), Schema.isLessThanOrEqualTo(100)),
+      ),
       Argument.optional,
     ),
   },

--- a/src/qemu/cli.ts
+++ b/src/qemu/cli.ts
@@ -4,12 +4,25 @@ import { resolve } from "node:path";
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Console, Effect, Option, Schema } from "effect";
 import { Argument, CliError, Command, Flag } from "effect/unstable/cli";
+import { Agent } from "undici";
 import { experimentCommand } from "../experiment.ts";
 import { runTestResults } from "../test-results.ts";
 
 const DEFAULT_SERVER_URL = "http://127.0.0.1:42069";
 const DEFAULT_ISO = "omarchy.iso";
 const DEFAULT_ENCODING = "oligarchy";
+
+// /start blocks until the ISO is fetched and QEMU boots; a first-time URL download
+// can outlast undici's 300s default header timeout, so give that one call a long
+// ceiling instead of letting the client give up on a server that is still working.
+const START_TIMEOUT_MS = 45 * 60 * 1000;
+type FetchInit = NonNullable<Parameters<typeof fetch>[1]>;
+// undici's Agent and node's bundled undici-types Dispatcher are separate declarations;
+// the cast pins it to exactly what this runtime's fetch accepts.
+const startDispatcher = new Agent({
+  headersTimeout: START_TIMEOUT_MS,
+  bodyTimeout: START_TIMEOUT_MS,
+}) as unknown as FetchInit["dispatcher"];
 
 const UnitInterval = Schema.Number.check(
   Schema.isBetween({ minimum: 0, maximum: 1 }, { message: "mouse: x and y must be in 0..1" }),
@@ -74,7 +87,7 @@ const start = Command.make(
             // An undefined disk is left out of the JSON, so the server creates one.
             disk: Option.isNone(disk) ? undefined : resolve(disk.value),
             agent,
-          }),
+          }, startDispatcher),
         catch: fail,
       }),
     ) as QemuStartResult;
@@ -318,11 +331,12 @@ const app = client.pipe(
   Command.withSubcommands([experimentCommand, testResults, start, getImage, getSerial, sendKeys, sendMouse, stop, intent]),
 );
 
-async function postJSON(serverUrl: string, path: string, body: unknown): Promise<string> {
+async function postJSON(serverUrl: string, path: string, body: unknown, dispatcher?: FetchInit["dispatcher"]): Promise<string> {
   const res = await fetch(`${serverUrl}${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    dispatcher,
   });
   if (res.status < 200 || res.status >= 300) {
     throw new Error(await readAPIError(res));

--- a/src/qemu/cli.ts
+++ b/src/qemu/cli.ts
@@ -354,8 +354,11 @@ function postStart(serverUrl: string, body: unknown): Promise<string> {
         res.on("data", (chunk) => {
           data += chunk;
         });
+        // A reset mid-body emits res error but never end, so without this the promise
+        // (and its timeout, gone with the destroyed socket) would hang forever.
+        res.on("error", reject);
         res.on("end", () => {
-          const status = res.statusCode ?? 0;
+          const status = res.statusCode!;
           if (status >= 200 && status < 300) {
             resolve(data);
           } else {

--- a/src/qemu/cli.ts
+++ b/src/qemu/cli.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env -S node --experimental-strip-types
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { stat, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Console, Effect, Option, Schema } from "effect";
 import { Argument, CliError, Command, Flag } from "effect/unstable/cli";
-import { Agent } from "undici";
 import { experimentCommand } from "../experiment.ts";
 import { runTestResults } from "../test-results.ts";
 
@@ -12,17 +13,10 @@ const DEFAULT_SERVER_URL = "http://127.0.0.1:42069";
 const DEFAULT_ISO = "omarchy.iso";
 const DEFAULT_ENCODING = "oligarchy";
 
-// /start blocks until the ISO is fetched and QEMU boots; a first-time URL download
-// can outlast undici's 300s default header timeout, so give that one call a long
-// ceiling instead of letting the client give up on a server that is still working.
+// /start blocks until the ISO is fetched and QEMU boots; a first-time URL download can
+// outlast fetch's 300s header timeout, which fetch does not let a caller raise per
+// request. So /start goes through node:http (postStart) with this idle ceiling instead.
 const START_TIMEOUT_MS = 45 * 60 * 1000;
-type FetchInit = NonNullable<Parameters<typeof fetch>[1]>;
-// undici's Agent and node's bundled undici-types Dispatcher are separate declarations;
-// the cast pins it to exactly what this runtime's fetch accepts.
-const startDispatcher = new Agent({
-  headersTimeout: START_TIMEOUT_MS,
-  bodyTimeout: START_TIMEOUT_MS,
-}) as unknown as FetchInit["dispatcher"];
 
 const UnitInterval = Schema.Number.check(
   Schema.isBetween({ minimum: 0, maximum: 1 }, { message: "mouse: x and y must be in 0..1" }),
@@ -82,12 +76,12 @@ const start = Command.make(
     const out = JSON.parse(
       yield* Effect.tryPromise({
         try: () =>
-          postJSON(serverUrl, "/start", {
+          postStart(serverUrl, {
             iso: image,
             // An undefined disk is left out of the JSON, so the server creates one.
             disk: Option.isNone(disk) ? undefined : resolve(disk.value),
             agent,
-          }, startDispatcher),
+          }),
         catch: fail,
       }),
     ) as QemuStartResult;
@@ -331,12 +325,11 @@ const app = client.pipe(
   Command.withSubcommands([experimentCommand, testResults, start, getImage, getSerial, sendKeys, sendMouse, stop, intent]),
 );
 
-async function postJSON(serverUrl: string, path: string, body: unknown, dispatcher?: FetchInit["dispatcher"]): Promise<string> {
+async function postJSON(serverUrl: string, path: string, body: unknown): Promise<string> {
   const res = await fetch(`${serverUrl}${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
-    dispatcher,
   });
   if (res.status < 200 || res.status >= 300) {
     throw new Error(await readAPIError(res));
@@ -344,8 +337,44 @@ async function postJSON(serverUrl: string, path: string, body: unknown, dispatch
   return res.text();
 }
 
+// /start alone can outlast fetch's fixed 300s header timeout, so it uses node:http,
+// whose idle timeout is the only ceiling — the connection sits quiet while the server
+// downloads the ISO and boots, then the reply arrives in one short burst.
+function postStart(serverUrl: string, body: unknown): Promise<string> {
+  const url = new URL(`${serverUrl}/start`);
+  const send = url.protocol === "https:" ? httpsRequest : httpRequest;
+  const payload = JSON.stringify(body);
+  return new Promise<string>((resolve, reject) => {
+    const req = send(
+      url,
+      { method: "POST", headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } },
+      (res) => {
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+        res.on("end", () => {
+          const status = res.statusCode ?? 0;
+          if (status >= 200 && status < 300) {
+            resolve(data);
+          } else {
+            reject(new Error(apiError(data)));
+          }
+        });
+      },
+    );
+    req.setTimeout(START_TIMEOUT_MS, () => req.destroy(new Error("start: no response within timeout")));
+    req.on("error", reject);
+    req.end(payload);
+  });
+}
+
 async function readAPIError(res: Response): Promise<string> {
-  const data = await res.text();
+  return apiError(await res.text());
+}
+
+function apiError(data: string): string {
   try {
     return (JSON.parse(data) as { error: string }).error;
   } catch {

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -16,6 +16,9 @@ const DEFAULT_SMP = 2;
 const DEFAULT_MACHINE = "q35,accel=kvm";
 const DEFAULT_CPU = "host";
 const HANDSHAKE_MS = 10_000;
+// A QMP reply is near-instant; anything this long means QEMU is wedged with its
+// socket still open (so the close teardown never fires). Fail the command instead.
+const COMMAND_TIMEOUT_MS = 30_000;
 // `-display help` minus curses, which needs QEMU's stdio and the proxy detaches it.
 export const QEMU_DISPLAYS = ["none", "gtk", "sdl", "egl-headless", "spice-app", "dbus"] as const;
 export type QemuDisplay = (typeof QEMU_DISPLAYS)[number];
@@ -342,7 +345,21 @@ async function execute(qemu: Qemu, name: string, args: unknown, record?: QemuExc
       throw new Error("qemu: closed");
     }
     response = (await new Promise<unknown>((resolve, reject) => {
-      qemu.pending.set(id, { resolve, reject });
+      const timer = setTimeout(() => {
+        qemu.pending.delete(id);
+        reject(new Error(`qemu: ${name} timed out`));
+      }, COMMAND_TIMEOUT_MS);
+      timer.unref();
+      qemu.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
       socket.write(`${JSON.stringify(command)}\n`);
     })) as QemuSuccessResponse;
   } catch (err) {

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -234,6 +234,25 @@ export async function sendKey(qemu: Qemu, keys: QemuKeyValue[], record?: QemuExc
   await execute(qemu, "send-key", { keys }, record);
 }
 
+// QEMU's keyboard queue holds ~1024 input events and silently drops the rest.
+// send-key acks immediately but the guest drains slowly, so a long string sent as
+// fast as QMP acks overflows the queue and loses keys. Pace chords under the drain
+// rate; measured against real QEMU, 60ms/chord keeps a 1000-char string lossless.
+const KEY_CHORD_GAP_MS = 60;
+
+export async function sendKeys(
+  qemu: Qemu,
+  chords: string[][],
+  record?: QemuExchangeRecorder,
+): Promise<void> {
+  for (let i = 0; i < chords.length; i++) {
+    await sendKey(qemu, chords[i].map((code): QemuKeyValue => ({ type: "qcode", data: code })), record);
+    if (i + 1 < chords.length) {
+      await new Promise<void>((resolve) => setTimeout(resolve, KEY_CHORD_GAP_MS));
+    }
+  }
+}
+
 // QEMU INPUT_EVENT_ABS_MAX: tablet axes are 0..0x7fff.
 const TABLET_AXIS_MAX = 0x7fff;
 // guest double-click detection needs a gap between successive press/release pairs

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -149,11 +149,12 @@ export async function start(
         }
         const proc = spawn(QEMU_BIN, args, { stdio: ["ignore", "ignore", "pipe"] });
         qemu.proc = proc;
-        proc.stderr?.on("data", (chunk) => {
+        proc.stderr!.on("data", (chunk) => {
           stderr = (stderr + String(chunk)).slice(-4096);
         });
         proc.once("error", (err) => reject(new Error(`qemu: ${err.message}`)));
-        proc.once("exit", (code) =>
+        // close, not exit: exit can fire before the piped stderr is fully drained.
+        proc.once("close", (code) =>
           reject(new Error(withStderr(`qemu: exited ${code} before QMP connect`))),
         );
       });
@@ -196,12 +197,11 @@ export async function start(
         socket.destroy();
       }
     });
-    // A socket error or close after the handshake means QEMU is gone. Tear the
-    // session down so qemu.socket is cleared: otherwise execute() writes to a
-    // dead socket, Node drops the write silently, and the command hangs forever.
+    // A socket error or close after the handshake means QEMU is gone (its exit closes
+    // this socket). Tear the session down so qemu.socket is cleared: otherwise execute()
+    // writes to a dead socket, Node drops the write silently, and the command hangs.
     socket.on("error", (err) => teardown(qemu, err));
     socket.on("close", () => teardown(qemu, new Error("qemu: socket closed")));
-    qemu.proc?.once("exit", () => teardown(qemu, new Error("qemu: exited")));
 
     const greetingMsg = (await Promise.race([greeting, timeout])) as QemuGreetingResponse;
     // The greeting is the recorded reply for the boot's qmp_capabilities: its own {return} is empty.

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { copyFile, mkdir, readdir, rm, stat } from "node:fs/promises";
+import { constants } from "node:fs";
+import { access, copyFile, mkdir, readdir, rm, stat } from "node:fs/promises";
 import { createServer, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -124,9 +125,15 @@ export async function start(
     automation: qemu.options.automation === true,
   });
 
+  // QEMU's stdio is otherwise discarded, so a boot failure (bad KVM, a rejected
+  // arg) would reach us as a bare timeout. Keep the tail of stderr to name it.
+  let stderr = "";
+  const withStderr = (message: string): string =>
+    stderr === "" ? message : `${message}: ${stderr.trim()}`;
+
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error("qemu: handshake timeout")), HANDSHAKE_MS);
+    timer = setTimeout(() => reject(new Error(withStderr("qemu: handshake timeout"))), HANDSHAKE_MS);
   });
 
   // QEMU connects to us: listen on the session socket, then spawn.
@@ -140,11 +147,14 @@ export async function start(
           reject(new Error("qemu: closed"));
           return;
         }
-        const proc = spawn(QEMU_BIN, args, { stdio: "ignore" });
+        const proc = spawn(QEMU_BIN, args, { stdio: ["ignore", "ignore", "pipe"] });
         qemu.proc = proc;
+        proc.stderr?.on("data", (chunk) => {
+          stderr = (stderr + String(chunk)).slice(-4096);
+        });
         proc.once("error", (err) => reject(new Error(`qemu: ${err.message}`)));
         proc.once("exit", (code) =>
-          reject(new Error(`qemu: exited ${code} before QMP connect`)),
+          reject(new Error(withStderr(`qemu: exited ${code} before QMP connect`))),
         );
       });
     });
@@ -423,6 +433,12 @@ export async function missingHostRequirements(display: QemuDisplay): Promise<str
       missing.push(`${label} not found: ${path}`);
     }
   }
+  // Every session boots with accel=kvm, so the device must be usable by this process.
+  try {
+    await access("/dev/kvm", constants.R_OK | constants.W_OK);
+  } catch {
+    missing.push("/dev/kvm is not readable and writable (needed for accel=kvm)");
+  }
   if (display === "gtk" && (process.env.DISPLAY === undefined || process.env.DISPLAY === "")) {
     missing.push("DISPLAY is not set (needed for --display gtk)");
   }
@@ -447,7 +463,8 @@ export async function missingHostRequirements(display: QemuDisplay): Promise<str
         out += String(chunk);
       });
       child.once("error", reject);
-      child.once("exit", () => resolve(out));
+      // close, not exit: exit can fire before the piped stdout is fully read.
+      child.once("close", () => resolve(out));
     });
     if (!help.split("\n").map((line) => line.trim()).includes(display)) {
       missing.push(`${QEMU_BIN} was built without display backend ${display}`);

--- a/src/qemu/client.ts
+++ b/src/qemu/client.ts
@@ -183,8 +183,12 @@ export async function start(
         socket.destroy();
       }
     });
-    socket.on("error", (err) => failAll(qemu, err));
-    socket.on("close", () => failAll(qemu, new Error("qemu: socket closed")));
+    // A socket error or close after the handshake means QEMU is gone. Tear the
+    // session down so qemu.socket is cleared: otherwise execute() writes to a
+    // dead socket, Node drops the write silently, and the command hangs forever.
+    socket.on("error", (err) => teardown(qemu, err));
+    socket.on("close", () => teardown(qemu, new Error("qemu: socket closed")));
+    qemu.proc?.once("exit", () => teardown(qemu, new Error("qemu: exited")));
 
     const greetingMsg = (await Promise.race([greeting, timeout])) as QemuGreetingResponse;
     // The greeting is the recorded reply for the boot's qmp_capabilities: its own {return} is empty.

--- a/src/qemu/iso.ts
+++ b/src/qemu/iso.ts
@@ -150,12 +150,18 @@ async function download(db: Db, url: string, file: string, path: string, who: Wh
 // the digest. A 200 whose body is not a digest (a soft-404 page) counts as no sidecar,
 // not as a mismatch.
 async function publishedSha256(url: string): Promise<string | undefined> {
-  const res = await fetch(`${url}.sha256`);
-  if (!res.ok) {
+  // The sidecar is optional, so a fetch failure counts as "none published" — it must
+  // not discard an already-complete download by rejecting the whole start.
+  try {
+    const res = await fetch(`${url}.sha256`);
+    if (!res.ok) {
+      return undefined;
+    }
+    const token = (await res.text()).trim().split(/\s+/)[0].toLowerCase();
+    return /^[0-9a-f]{64}$/.test(token) ? token : undefined;
+  } catch {
     return undefined;
   }
-  const token = (await res.text()).trim().split(/\s+/)[0].toLowerCase();
-  return /^[0-9a-f]{64}$/.test(token) ? token : undefined;
 }
 
 async function readManifest(): Promise<Record<string, ManifestEntry>> {

--- a/src/qemu/keys.test.ts
+++ b/src/qemu/keys.test.ts
@@ -59,6 +59,7 @@ describe("parseKeys happy path", () => {
     assert.deepEqual(parseKeys("<F13>"), [["f13"]]);
     assert.deepEqual(parseKeys("<kp_enter>"), [["kp_enter"]]);
     assert.deepEqual(parseKeys("<caps_lock>"), [["caps_lock"]]);
+    assert.deepEqual(parseKeys("<unmapped>"), [["unmapped"]]);
   });
 
   it("keeps literal and angle chords in input order", () => {
@@ -100,6 +101,18 @@ describe("parseKeys unhappy path", () => {
   it("throws on an unknown modifier", () => {
     assert.throws(() => parseKeys("<X-c>"), {
       message: 'qemu: unknown modifier "X"',
+    });
+  });
+
+  it("throws on a raw token carrying non-qcode characters", () => {
+    assert.throws(() => parseKeys("<f}>"), {
+      message: 'qemu: unknown key "f}"',
+    });
+    assert.throws(() => parseKeys("<f{>"), {
+      message: 'qemu: unknown key "f{"',
+    });
+    assert.throws(() => parseKeys("<foo bar>"), {
+      message: 'qemu: unknown key "foo bar"',
     });
   });
 

--- a/src/qemu/keys.ts
+++ b/src/qemu/keys.ts
@@ -25,7 +25,6 @@ const NAMED: Record<string, string> = {
   PGDN: "pgdn",
   PAGEDOWN: "pgdn",
   LT: "less",
-  GT: "dot",
   MENU: "menu",
   CAPSLOCK: "caps_lock",
   NUMLOCK: "num_lock",
@@ -144,9 +143,10 @@ function keyName(name: string): string[] {
     return charChord(name);
   }
   // Accept any documented qcode token (f1..f24, kp_*, caps_lock, ...)
-  // rather than maintain the full list here.
+  // rather than maintain the full list here. Qcodes are lowercase [a-z0-9_];
+  // rejecting anything else keeps a stray "f}" out of the QMP stream.
   const lower = name.toLowerCase();
-  if (lower === "unmapped" || lower.includes("_") || lower.startsWith("f")) {
+  if (/^[a-z0-9_]+$/.test(lower) && (lower === "unmapped" || lower.includes("_") || lower.startsWith("f"))) {
     return [lower];
   }
   throw new Error(`qemu: unknown key "${name}"`);

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -10,7 +10,7 @@ import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node
 import { flushLogs, log } from "../db/log.ts";
 import { connectDatabase, endSession, finishAction, insertSession, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
 import { finishIntentSpan, finishQemuActionSpan, finishQemuSpan, flushSentry, initSentry, startIntentSpan, startQemuActionSpan, startQemuSpan, type QemuSpan } from "../sentry.ts";
-import { QEMU_DISPLAYS, createDisk, createQemu, missingHostRequirements, screendump, sendKey, sendMouse, start, stop, type Qemu, type QemuDisplay } from "./client.ts";
+import { QEMU_DISPLAYS, createDisk, createQemu, missingHostRequirements, screendump, sendKeys, sendMouse, start, stop, type Qemu, type QemuDisplay } from "./client.ts";
 import { getIso } from "./iso.ts";
 import { parseKeys } from "./keys.ts";
 import { collectStats, startCpuSampler } from "./stats.ts";
@@ -397,11 +397,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
       });
       const record = recorder(live);
       yield* Effect.tryPromise({
-        try: async () => {
-          for (const chord of chords) {
-            await sendKey(qemu, chord.map((code): QemuKeyValue => ({ type: "qcode", data: code })), record);
-          }
-        },
+        try: () => sendKeys(qemu, chords, record),
         catch: (err) => exchangeFailed(err, { sessionId: qemu.id, agentId: agent }),
       });
       log(db, { text: `session ${qemu.id}: sent ${chords.length} chords in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: agent });

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -25,6 +25,9 @@ const [host, port] = addr.split(":");
 const SESSION_TIMEOUT_MS = 10 * 60 * 1000;
 const SESSION_TIMEOUT_CHECK_MS = 10_000;
 const SESSION_TIMEOUT_REASON = "no command received for 10 minutes";
+// A click is two QMP exchanges and two action rows; cap the pulse count so one
+// request cannot enqueue an unbounded amount of work.
+const MAX_CLICKS = 100;
 
 const db = connectDatabase();
 
@@ -417,8 +420,8 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
       if (!(x >= 0 && x <= 1 && y >= 0 && y <= 1)) {
         return yield* Effect.fail(badRequest("mouse: x and y must be in 0..1", { sessionId: qemu.id, agentId: agent }));
       }
-      if (clicks !== undefined && (!Number.isInteger(clicks) || clicks < 1)) {
-        return yield* Effect.fail(badRequest("mouse: clicks must be a positive integer", { sessionId: qemu.id, agentId: agent }));
+      if (clicks !== undefined && (!Number.isInteger(clicks) || clicks < 1 || clicks > MAX_CLICKS)) {
+        return yield* Effect.fail(badRequest(`mouse: clicks must be an integer in 1..${MAX_CLICKS}`, { sessionId: qemu.id, agentId: agent }));
       }
       yield* Effect.tryPromise({
         try: () => sendMouse(qemu, x, y, button, clicks, recorder(live)),
@@ -673,10 +676,13 @@ const proxy = Command.make(
     return Effect.gen(function* () {
       const missing = yield* Effect.promise(() => missingHostRequirements(resolved));
       if (missing.length > 0) {
-        const text = `missing host requirements:\n${missing.join("\n")}`;
-        console.error(`proxy: ${text}`);
-        return yield* Effect.fail(new Error(text));
+        return yield* Effect.fail(new Error(`missing host requirements:\n${missing.join("\n")}`));
       }
+      // Fail at startup, not on the first request, if the control-plane DB is unreachable.
+      yield* Effect.tryPromise({
+        try: () => db.$client.query("select 1"),
+        catch: (cause) => new Error(`database unreachable: ${errorDetail(cause)}`),
+      });
       return yield* Layer.launch(main(resolved, automation));
     }).pipe(
       Effect.tapError((err) => Effect.sync(() => log(db, { level: "fatal", text: `proxy: ${errorDetail(err)}` }, { cause: err }))),

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -8,7 +8,7 @@ import { CliError, Command, Flag } from "effect/unstable/cli";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
 import { flushLogs, log } from "../db/log.ts";
-import { connectDatabase, endSession, finishAction, insertSession, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
+import { connectDatabase, endSession, finishAction, insertSession, pingDatabase, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
 import { finishIntentSpan, finishQemuActionSpan, finishQemuSpan, flushSentry, initSentry, startIntentSpan, startQemuActionSpan, startQemuSpan, type QemuSpan } from "../sentry.ts";
 import { QEMU_DISPLAYS, createDisk, createQemu, missingHostRequirements, screendump, sendKeys, sendMouse, start, stop, type Qemu, type QemuDisplay } from "./client.ts";
 import { getIso } from "./iso.ts";
@@ -680,7 +680,7 @@ const proxy = Command.make(
       }
       // Fail at startup, not on the first request, if the control-plane DB is unreachable.
       yield* Effect.tryPromise({
-        try: () => db.$client.query("select 1"),
+        try: () => pingDatabase(db),
         catch: (cause) => new Error(`database unreachable: ${errorDetail(cause)}`),
       });
       return yield* Layer.launch(main(resolved, automation));

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -363,12 +363,14 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
       const qemu = live.qemu;
       const finalStatus = status ?? "aborted";
       sessions.delete(qemu.id);
-      yield* Effect.tryPromise({
-        try: () => stop(qemu),
-        catch: (cause) => {
-          finishLiveSession(live, "failed");
-          return internal(cause, { sessionId: qemu.id, agentId: agent });
-        },
+      // stop() destroys the socket and signals QEMU before it removes the dir, so
+      // a cleanup failure still leaves a dead machine: log it, but close the record.
+      yield* Effect.promise(async () => {
+        try {
+          await stop(qemu);
+        } catch (err) {
+          log(db, { level: "error", text: `session ${qemu.id}: stop cleanup failed: ${errorDetail(err)}`, sessionId: qemu.id, agentId: agent }, { cause: err });
+        }
       });
       yield* Effect.tryPromise({
         try: () => endSession(db, qemu.id, finalStatus, reason ?? null),
@@ -622,11 +624,22 @@ const main = (display: QemuDisplay, automation: boolean) => Layer.effectDiscard(
       const open = [...openSessions];
       openSessions.clear();
       sessions.clear();
-      const stops = open.map((live) => stop(live.qemu).catch(() => {}));
-      for (const live of open) {
-        finishLiveSession(live, "failed");
-      }
-      void Promise.all(stops).then(flushLogs).then(flushSentry).then(() => process.exit(1));
+      // The acceptor is gone, not the database: still close each open session's row
+      // so a proxy crash does not leave sessions stuck 'running' forever.
+      const cleanup = open.map(async (live) => {
+        try {
+          await stop(live.qemu);
+        } catch {
+          // already going down; the row close below is what matters
+        }
+        try {
+          await endSession(db, live.qemu.id, "aborted", `proxy error: ${err.message}`);
+        } catch (e) {
+          log(db, { level: "error", text: `shutdown: session ${live.qemu.id}: ${errorDetail(e)}`, sessionId: live.qemu.id }, { cause: e });
+        }
+        finishLiveSession(live, "aborted");
+      });
+      void Promise.allSettled(cleanup).then(flushLogs).then(flushSentry).then(() => process.exit(1));
     });
   }),
 ).pipe(

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -219,7 +219,6 @@ async function launchQemu(
 ): Promise<void> {
   const qemu = live.qemu;
   try {
-    await registerAgent(db, cfg.agent, qemu.id);
     const iso = await getIso(db, cfg.iso, { sessionId: qemu.id, agentId: cfg.agent });
     if (cfg.disk === undefined) {
       await createDisk(qemu);
@@ -227,6 +226,10 @@ async function launchQemu(
       // start() expects the session dir; with a caller-provided disk, createDisk never made it.
       await mkdir(qemu.dir, { recursive: true, mode: 0o700 });
     }
+    // Register right before boot: the handshake records an action that references
+    // agent_runs, so this must precede start(), but a failed download or disk
+    // create before here must not burn the agent id on its one-registration key.
+    await registerAgent(db, cfg.agent, qemu.id);
     await start(qemu, { iso, disk: cfg.disk }, recorder(live));
     await sessionRunning(db, qemu.id);
   } catch (err) {

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -28,6 +28,9 @@ const SESSION_TIMEOUT_REASON = "no command received for 10 minutes";
 // A click is two QMP exchanges and two action rows; cap the pulse count so one
 // request cannot enqueue an unbounded amount of work.
 const MAX_CLICKS = 100;
+// Each chord is a QMP exchange and an action row, paced ~60ms apart; cap the count so
+// one request cannot run for many minutes or write thousands of rows.
+const MAX_KEYS = 1000;
 
 const db = connectDatabase();
 
@@ -403,6 +406,9 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
         try: () => parseKeys(keys, encoding),
         catch: (err) => badRequest((err as Error).message, { sessionId: qemu.id, agentId: agent }),
       });
+      if (chords.length > MAX_KEYS) {
+        return yield* Effect.fail(badRequest(`send-keys: at most ${MAX_KEYS} keys per request`, { sessionId: qemu.id, agentId: agent }));
+      }
       const record = recorder(live);
       yield* Effect.tryPromise({
         try: () => sendKeys(qemu, chords, record),

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -118,11 +118,11 @@ function failed(message: string, who: { sessionId: string; agentId: string }): A
 }
 
 function startFailed(err: unknown, who: { sessionId: string; agentId: string }): ApiError {
-  return { _tag: "StartFailed", message: (err as Error).message, cause: err, ...who };
+  return { _tag: "StartFailed", message: errorDetail(err), cause: err, ...who };
 }
 
 function exchangeFailed(err: unknown, who: { sessionId: string; agentId: string }): ApiError {
-  return { _tag: "ExchangeFailed", message: (err as Error).message, cause: err, ...who };
+  return { _tag: "ExchangeFailed", message: errorDetail(err), cause: err, ...who };
 }
 
 function internal(cause: unknown, who: { sessionId: string; agentId?: string }): ApiError {
@@ -234,7 +234,7 @@ async function launchQemu(
     await sessionRunning(db, qemu.id);
   } catch (err) {
     await stop(qemu).catch(() => {});
-    await endSession(db, qemu.id, "failed", (err as Error).message).catch((e: unknown) => {
+    await endSession(db, qemu.id, "failed", errorDetail(err)).catch((e: unknown) => {
       log(db, { level: "error", text: `db: recording a failed start failed too: ${(e as Error).message}`, sessionId: qemu.id, agentId: cfg.agent }, { cause: e });
     });
     throw err;

--- a/src/qmp/json-stream.test.ts
+++ b/src/qmp/json-stream.test.ts
@@ -94,6 +94,22 @@ describe("JSONStreamParser happy path", () => {
     parser.push('{"foo":1}');
     assert.deepEqual(parser.pull(), { foo: 1 });
   });
+
+  it("frames an object with braces inside a string value", () => {
+    const parser = new JSONStreamParser();
+    parser.push('{"error":{"class":"GenericError","desc":"value \'f}\'"},"id":2}');
+    assert.deepEqual(parser.pull(), {
+      error: { class: "GenericError", desc: "value 'f}'" },
+      id: 2,
+    });
+    assert.equal(parser.pull(), undefined);
+  });
+
+  it("frames a string containing an escaped quote before a brace", () => {
+    const parser = new JSONStreamParser();
+    parser.push('{"desc":"a \\" b }","id":7}');
+    assert.deepEqual(parser.pull(), { desc: 'a " b }', id: 7 });
+  });
 });
 
 describe("JSONStreamParser unhappy path", () => {
@@ -116,5 +132,13 @@ describe("JSONStreamParser unhappy path", () => {
     const numbers = new JSONStreamParser();
     numbers.push("42");
     assert.equal(numbers.pull(), undefined);
+  });
+
+  it("keeps an object with an unterminated string incomplete", () => {
+    const parser = new JSONStreamParser();
+    parser.push('{"desc":"unterminated } ');
+    assert.equal(parser.pull(), undefined);
+    parser.push('more"}');
+    assert.deepEqual(parser.pull(), { desc: "unterminated } more" });
   });
 });

--- a/src/qmp/json-stream.ts
+++ b/src/qmp/json-stream.ts
@@ -19,10 +19,27 @@ export class JSONStreamParser {
       return undefined;
     }
     let depth = 0;
+    // Braces inside JSON string values must not move the depth, or a QMP error
+    // whose desc quotes a brace (e.g. a rejected key token) mis-frames the reply.
+    let inString = false;
+    let escaped = false;
     for (let i = start; i < this.buf.length; i++) {
-      if (this.buf[i] === "{") {
+      const ch = this.buf[i];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch === "\\") {
+          escaped = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (ch === '"') {
+        inString = true;
+      } else if (ch === "{") {
         depth++;
-      } else if (this.buf[i] === "}") {
+      } else if (ch === "}") {
         depth--;
         if (depth === 0) {
           const substr = this.buf.slice(start, i + 1);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the bugs found during a full read of the TypeScript, one logical commit each, plus two rounds of `gpt-5.6-sol-max` review. Every behavioral fix was verified against real QEMU or a throwaway local Postgres (never the production database). Final review verdict: **APPROVE**.

## Fixes

1. **Dead-QEMU hang** (`src/qemu/client.ts`) — socket error/close run `teardown()`, clearing `qemu.socket` so a command after QEMU exits fails fast with `qemu: closed` instead of writing to a destroyed socket and hanging forever.
2. **Silent key loss** (`src/qemu/client.ts`, `src/qemu/proxy.ts`) — a paced `sendKeys()` spaces chords 60ms apart so QEMU's ~1024-event keyboard queue no longer overflows; unpaced, a string lost ~30% of its keys past ~170 chars while still reporting success. Server caps input at 1000 keys/request.
3. **QMP mis-framing** (`src/qmp/json-stream.ts`, `src/qemu/keys.ts`) — the stream scanner ignores braces inside JSON strings, and raw key tokens are constrained to the `[a-z0-9_]` qcode charset so a token like `<f}>` can't corrupt the reply stream.
4. **`/start` abandoned early** (`src/qemu/cli.ts`) — the one long call goes through `node:http` (with a 45-minute idle ceiling and response-error handling) instead of `fetch`'s non-raisable 300s header timeout; no extra dependency.
5. **Session row left `running`** (`src/qemu/proxy.ts`) — `/stop` and the fatal acceptor path log a cleanup failure but still close the row with a verdict.
6. **Agent id burned on a failed start** (`src/qemu/proxy.ts`) — `registerAgent` moved after the download/disk step (still before boot, which the handshake action's FK requires).
7. **Drizzle SQL leaked in errors** (`src/qemu/proxy.ts`) — `StartFailed`/`ExchangeFailed` and the failed-start reason unwrap the cause via `errorDetail`.
8. ~~Dashboard connection leak~~ — **reverted after review**: Cloudflare Hyperdrive auto-closes request-scoped clients, so the original code was correct and this was a misdiagnosis.
9. **Sidecar fetch discards a good download** (`src/qemu/iso.ts`) — a network error on the optional `<url>.sha256` is treated as "no sidecar", not a failure.
10. **Opaque startup failures** (`src/qemu/client.ts`) — QEMU stderr is captured into the exit/timeout errors (read on `close`), and `/dev/kvm` readability is a startup check.
11. **No per-command QMP timeout** (`src/qemu/client.ts`) — `execute()` rejects after 30s if a reply never arrives.
12. **Unbounded `send-mouse` clicks** (`src/qemu/proxy.ts`, `src/qemu/cli.ts`) — capped at 100 on both sides.
13. Folded into 10. **14** removed the dead `NAMED.GT` entry. **15** pings the DB via Drizzle (`db.execute(sql\`select 1\`)`) at startup and drops a duplicate startup error print.

## Review rounds (gpt-5.6-sol-max)

- **Round 1** (REQUEST CHANGES): reverted 8; reworked 4 to `node:http` (the suggested `@effect/platform-node` undici is 8.x and is incompatible with Node's built-in `fetch` — `invalid onRequestStart method`); switched the 15 ping to Drizzle; dropped a redundant proc-exit teardown and read the pre-QMP failure on `close`; added the 1000-key cap; documented input caps.
- **Round 2** (REQUEST CHANGES → APPROVE): the reviewer found `postStart()` would hang on a truncated response (socket reset after headers, before the body); reproduced it, added `res.on("error", reject)` and asserted `res.statusCode`. Re-review: **APPROVE**, all blockers resolved.

## Verification

- Unit: `json-stream.test.ts` and `keys.test.ts` extended (both paths); full suite 59/59, `tsc` and `oxlint --type-aware` clean.
- Real QEMU: fast-fail after death (1); paced send-keys lossless to 1000 chars vs 30% unpaced (2); stderr surfaced in startup errors (10); command timeout fires (11); full start→screendump→send-keys→stop lifecycle.
- Local throwaway Postgres: migrations apply; Drizzle startup ping passes and a bad DB URL exits 1 (15); a pre-boot failure leaves `agent_runs` empty (6); errors store the unwrapped cause (7); a reset sidecar keeps the download (9).
- `node:http` `/start`: returns the id on 200, surfaces the server error on non-2xx, times out on a silent server, and now rejects (~0.9s) on a truncated response instead of hanging (4).

Screendump captured through the patched image pipeline (TianoCore/OVMF frame):

[QEMU screendump via patched image pipeline](https://cursor.com/agents/bc-01a06430-2c09-75f2-9e93-d1fae9350274/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqemu-screendump.png)

## Known limitations (not regressions)

- A QMP command that hits the 30s timeout may still be processed by QEMU later, so a client retry can double a keystroke/click. Inherent to any client-side timeout (QMP has no cancel).
- On unexpected QEMU death, commands fail fast, but the proxy still counts the session as running until `/stop` or the 10-minute inactivity sweep reclaims it (fail-fast, not eager reap).
- A legitimate `/start` silent for >45 minutes leaves the server operation running after the CLI exits — an explicit operational ceiling.
- `oxlint.config.ts` needs Node ≥ 22.18 to load (this VM has 22.14), so lint was run with an equivalent JSON config.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06430-2c09-75f2-9e93-d1fae9350274?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06430-2c09-75f2-9e93-d1fae9350274&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

