### PR TITLE
Assign live session log colors from the Rose Pine palette

### DIFF
--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -24,13 +24,6 @@ const ROSE_PINE_MAIN = {
   text: "#e0def4",
   subtle: "#908caa",
   muted: "#6e6a86",
-  highlightHigh: "#524f67",
-  highlightMed: "#403d52",
-  overlay: "#26233a",
-  highlightLow: "#21202e",
-  surface: "#1f1d2e",
-  base: "#191724",
-  nc: "#16141f",
 } as const;
 
 const AGENT_COLORS: readonly string[] = Object.values(ROSE_PINE_MAIN);
@@ -67,6 +60,7 @@ function paint(hex: string, text: string): string {
   if (process.stdout.isTTY !== true && process.env.FORCE_COLOR === undefined) {
     return text;
   }
+  // 16, not 24-bit: tmux and FORCE_COLOR=1 report 256/16 and still render 38;2.
   if (!WriteStream.prototype.hasColors.call(process.stdout, 16)) {
     return text;
   }

--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -12,36 +12,79 @@ export type LogEntry = {
   agentId?: string;
 };
 
-const AGENT_COLORS = [
-  "cyan",
-  "green",
-  "yellow",
-  "magenta",
-  "blue",
-  "cyanBright",
-  "greenBright",
-  "yellowBright",
-  "magentaBright",
-  "blueBright",
-] as const;
+const ROSE_PINE_MAIN = {
+  love: "#eb6f92",
+  gold: "#f6c177",
+  rose: "#ebbcba",
+  pine: "#31748f",
+  foam: "#9ccfd8",
+  iris: "#c4a7e7",
+  leaf: "#95b1ac",
+  text: "#e0def4",
+  subtle: "#908caa",
+  muted: "#6e6a86",
+  highlightHigh: "#524f67",
+  highlightMed: "#403d52",
+  overlay: "#26233a",
+  highlightLow: "#21202e",
+  surface: "#1f1d2e",
+  base: "#191724",
+  nc: "#16141f",
+} as const;
+
+const AGENT_COLORS: readonly string[] = Object.values(ROSE_PINE_MAIN);
+
+const assigned = new Map<string, string>();
+let next = 0;
 
 // Inserts are chained so rows land in call order; a failed insert reports itself to
 // stdout and never fails the caller or the lines behind it.
 let chain: Promise<void> = Promise.resolve();
 
-function colorFor(agentId: string): (typeof AGENT_COLORS)[number] {
-  let hash = 0;
-  for (let i = 0; i < agentId.length; i++) {
-    hash = (hash * 31 + agentId.charCodeAt(i)) >>> 0;
+function colorFor(agentId: string): string {
+  const have = assigned.get(agentId);
+  if (have !== undefined) {
+    return have;
   }
-  return AGENT_COLORS[hash % AGENT_COLORS.length];
+  const taken = new Set(assigned.values());
+  let pick = next;
+  for (let i = 0; i < AGENT_COLORS.length; i++) {
+    const idx = (next + i) % AGENT_COLORS.length;
+    if (!taken.has(AGENT_COLORS[idx])) {
+      pick = idx;
+      break;
+    }
+  }
+  const color = AGENT_COLORS[pick];
+  next = (pick + 1) % AGENT_COLORS.length;
+  assigned.set(agentId, color);
+  return color;
+}
+
+export function releaseAgentColor(agentId: string): void {
+  assigned.delete(agentId);
+}
+
+function paint(hex: string, text: string): string {
+  if (!process.stdout.hasColors(2 ** 24)) {
+    return text;
+  }
+  const n = Number.parseInt(hex.slice(1), 16);
+  const r = (n >> 16) & 255;
+  const g = (n >> 8) & 255;
+  const b = n & 255;
+  return `\x1b[38;2;${r};${g};${b}m${text}\x1b[39m`;
 }
 
 function write(line: LogEntry): void {
   const tag = line.agentId ?? "global";
   const text = line.level === undefined || line.level === "info" ? line.text : `${line.level}: ${line.text}`;
-  const color = line.agentId === undefined ? "gray" : colorFor(line.agentId);
-  console.log(styleText(color, `[${tag}] ${text}`, { stream: process.stdout }));
+  const rendered = `[${tag}] ${text}`;
+  if (line.agentId === undefined) {
+    console.log(styleText("gray", rendered, { stream: process.stdout }));
+    return;
+  }
+  console.log(paint(colorFor(line.agentId), rendered));
 }
 
 export function log(

--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -35,23 +35,18 @@ const ROSE_PINE_MAIN = {
 
 const AGENT_COLORS: readonly string[] = Object.values(ROSE_PINE_MAIN);
 
-const assigned = new Map<string, string>();
-const live = new Set<string>();
+const colors = new Map<string, string>();
 let next = 0;
 
 // Inserts are chained so rows land in call order; a failed insert reports itself to
 // stdout and never fails the caller or the lines behind it.
 let chain: Promise<void> = Promise.resolve();
 
-function colorFor(agentId: string): string {
-  const have = assigned.get(agentId);
-  if (have !== undefined) {
-    return have;
+export function acquireAgentColor(agentId: string): void {
+  if (colors.has(agentId)) {
+    return;
   }
-  const taken = new Set<string>();
-  for (const id of live) {
-    taken.add(assigned.get(id)!);
-  }
+  const taken = new Set(colors.values());
   let pick = next;
   for (let i = 0; i < AGENT_COLORS.length; i++) {
     const idx = (next + i) % AGENT_COLORS.length;
@@ -60,25 +55,19 @@ function colorFor(agentId: string): string {
       break;
     }
   }
-  const color = AGENT_COLORS[pick];
+  colors.set(agentId, AGENT_COLORS[pick]);
   next = (pick + 1) % AGENT_COLORS.length;
-  assigned.set(agentId, color);
-  return color;
-}
-
-export function acquireAgentColor(agentId: string): void {
-  colorFor(agentId);
-  live.add(agentId);
 }
 
 export function releaseAgentColor(agentId: string): void {
-  live.delete(agentId);
-  assigned.delete(agentId);
+  colors.delete(agentId);
 }
 
 function paint(hex: string, text: string): string {
-  // Piped stdout is a Socket and has no hasColors; the TTY method still honors FORCE_COLOR.
-  if (!WriteStream.prototype.hasColors.call(process.stdout, 2 ** 24)) {
+  if (process.stdout.isTTY !== true && process.env.FORCE_COLOR === undefined) {
+    return text;
+  }
+  if (!WriteStream.prototype.hasColors.call(process.stdout, 16)) {
     return text;
   }
   const n = Number.parseInt(hex.slice(1), 16);
@@ -92,11 +81,12 @@ function write(line: LogEntry): void {
   const tag = line.agentId ?? "global";
   const text = line.level === undefined || line.level === "info" ? line.text : `${line.level}: ${line.text}`;
   const rendered = `[${tag}] ${text}`;
-  if (line.agentId === undefined) {
+  const hex = line.agentId === undefined ? undefined : colors.get(line.agentId);
+  if (hex === undefined) {
     console.log(styleText("gray", rendered, { stream: process.stdout }));
     return;
   }
-  console.log(paint(colorFor(line.agentId), rendered));
+  console.log(paint(hex, rendered));
 }
 
 export function log(

--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -1,3 +1,4 @@
+import { WriteStream } from "node:tty";
 import { styleText } from "node:util";
 import { capture } from "../sentry.ts";
 import type { Db } from "./ops.ts";
@@ -35,6 +36,7 @@ const ROSE_PINE_MAIN = {
 const AGENT_COLORS: readonly string[] = Object.values(ROSE_PINE_MAIN);
 
 const assigned = new Map<string, string>();
+const live = new Set<string>();
 let next = 0;
 
 // Inserts are chained so rows land in call order; a failed insert reports itself to
@@ -46,7 +48,10 @@ function colorFor(agentId: string): string {
   if (have !== undefined) {
     return have;
   }
-  const taken = new Set(assigned.values());
+  const taken = new Set<string>();
+  for (const id of live) {
+    taken.add(assigned.get(id)!);
+  }
   let pick = next;
   for (let i = 0; i < AGENT_COLORS.length; i++) {
     const idx = (next + i) % AGENT_COLORS.length;
@@ -61,12 +66,19 @@ function colorFor(agentId: string): string {
   return color;
 }
 
+export function acquireAgentColor(agentId: string): void {
+  colorFor(agentId);
+  live.add(agentId);
+}
+
 export function releaseAgentColor(agentId: string): void {
+  live.delete(agentId);
   assigned.delete(agentId);
 }
 
 function paint(hex: string, text: string): string {
-  if (!process.stdout.hasColors(2 ** 24)) {
+  // Piped stdout is a Socket and has no hasColors; the TTY method still honors FORCE_COLOR.
+  if (!WriteStream.prototype.hasColors.call(process.stdout, 2 ** 24)) {
     return text;
   }
   const n = Number.parseInt(hex.slice(1), 16);

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -8,7 +8,7 @@ import { Cause, Effect, Exit, Layer, Option, Schema } from "effect";
 import { CliError, Command, Flag } from "effect/unstable/cli";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
-import { flushLogs, log, releaseAgentColor } from "../db/log.ts";
+import { acquireAgentColor, flushLogs, log, releaseAgentColor } from "../db/log.ts";
 import { connectDatabase, endSession, finishAction, getImage, insertSession, pingDatabase, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
 import { finishIntentSpan, finishQemuActionSpan, finishQemuSpan, flushSentry, initSentry, startIntentSpan, startQemuActionSpan, startQemuSpan, type QemuSpan } from "../sentry.ts";
 import { QEMU_DISPLAYS, createDisk, createQemu, missingHostRequirements, screendump, sendKeys, sendMouse, start, stop, type Qemu, type QemuDisplay } from "./client.ts";
@@ -272,6 +272,7 @@ function startSession(cfg: typeof StartBody.Type, started: number, display: Qemu
     const span = startQemuSpan(qemu.id, cfg.agent);
     const live = { qemu, agent: cfg.agent, lastCommandAt: Date.now(), span, actionSpans: new Set<QemuSpan>() };
     openSessions.add(live);
+    acquireAgentColor(cfg.agent);
     yield* Effect.tryPromise({
       try: () => insertSession(db, qemu.id, { iso: cfg.iso, disk: cfg.disk }, isUrl ? "downloading" : "running"),
       catch: (cause) => {

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -429,6 +429,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
           return internal(cause, { sessionId: qemu.id, agentId: agent });
         },
       });
+      // Color is released in finishLiveSession; log first so the stopped line keeps it.
       log(db, {
         text: `session ${qemu.id}: stopped; ${finalStatus}${reason === undefined ? "" : `; ${reason}`}`,
         sessionId: qemu.id,

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -8,7 +8,7 @@ import { Cause, Effect, Exit, Layer, Option, Schema } from "effect";
 import { CliError, Command, Flag } from "effect/unstable/cli";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
-import { flushLogs, log } from "../db/log.ts";
+import { flushLogs, log, releaseAgentColor } from "../db/log.ts";
 import { connectDatabase, endSession, finishAction, getImage, insertSession, pingDatabase, registerAgent, sessionRunning, startAction } from "../db/ops.ts";
 import { finishIntentSpan, finishQemuActionSpan, finishQemuSpan, flushSentry, initSentry, startIntentSpan, startQemuActionSpan, startQemuSpan, type QemuSpan } from "../sentry.ts";
 import { QEMU_DISPLAYS, createDisk, createQemu, missingHostRequirements, screendump, sendKeys, sendMouse, start, stop, type Qemu, type QemuDisplay } from "./client.ts";
@@ -81,6 +81,7 @@ function finishLiveActionSpan(
 
 function finishLiveSession(live: LiveSession, status: SessionEndStatus): void {
   openSessions.delete(live);
+  releaseAgentColor(live.agent);
   for (const span of live.actionSpans) {
     finishLiveActionSpan(live, span, "failed");
   }
@@ -427,12 +428,12 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
           return internal(cause, { sessionId: qemu.id, agentId: agent });
         },
       });
-      finishLiveSession(live, finalStatus);
       log(db, {
         text: `session ${qemu.id}: stopped; ${finalStatus}${reason === undefined ? "" : `; ${reason}`}`,
         sessionId: qemu.id,
         agentId: agent,
       });
+      finishLiveSession(live, finalStatus);
       return HttpServerResponse.jsonUnsafe({ ok: "true" });
     }) satisfies RouteHandler, { uninterruptible: true });
 

--- a/src/test-results.ts
+++ b/src/test-results.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { loadEnvFile } from "node:process";
 import { eq, sql } from "drizzle-orm";
 import { closeDatabase, connectDatabase } from "./db/ops.ts";
-import { flushLogs, log } from "./db/log.ts";
+import { acquireAgentColor, flushLogs, log } from "./db/log.ts";
 import { agentRuns, testResults } from "./db/schema.ts";
 
 export async function runTestResults(input: {
@@ -34,6 +34,7 @@ export async function runTestResults(input: {
     if (row === undefined) {
       throw new Error(`test-results: result ${input.id} not found`);
     }
+    acquireAgentColor(input.agentId);
     log(db, {
       text: `test result ${input.id}: ${input.status}${input.reason === undefined ? "" : `; ${input.reason}`}`,
       agentId: input.agentId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hashing agent ids into a short ANSI list made `prime` and `prime2` share a color. Session prefixes now take the next free Rose Pine foreground color (love, gold, rose, pine, foam, iris, leaf, text, subtle, muted). A color is released when the session ends, so two live sessions collide only after every slot is taken.

Background roles (`highlight_*`, overlay, surface, base, `_nc`) are omitted: they are near-black as log text, and the ring would walk them even with one live session.

## Changes
- Replace the hashed ANSI list in `src/db/log.ts` with the main Rose Pine foreground palette and a ring of free slots
- `acquireAgentColor` is the only writer; leftover logs after a session ends stay gray and do not pin a slot
- Paint agent prefixes with 24-bit ANSI when stdout would also color `styleText` (TTY or `FORCE_COLOR`, including tmux)
- Release the color from `finishLiveSession`; log `/stop` before that so the last line keeps the session color

## Verification
- Typecheck passes
- Existing unit tests pass (84/84)
- Disposable harness: `prime`/`prime2`/`prime3` get love/gold/rose; the ring keeps walking after a release; a freed slot is reused before wrapping; overflow collides only when every slot is live; leftover logs are gray
- Failed `/start` leftover + retry does not steal another live session's color

[prime and prime2 no longer share a color](https://cursor.com/agents/bc-394c200a-01ce-49f8-9ffa-265890046692/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_log_colors.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-394c200a-01ce-49f8-9ffa-265890046692?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-394c200a-01ce-49f8-9ffa-265890046692&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

