### PR TITLE
Add interactive client runner with session tracking and inline images

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "client": "node --experimental-strip-types src/qemu/cli.ts",
+    "runner": "node --experimental-strip-types src/qemu/runner.ts",
     "dev": "wrangler dev --remote",
     "test": "node --test --experimental-strip-types src/client.test.ts src/cursor-agent/client.test.ts src/experiment.test.ts src/qmp/json-stream.test.ts src/qemu/client.test.ts src/qemu/keys.test.ts src/sentry.test.ts src/test-def.test.ts",
     "lint": "oxlint --type-aware --type-check",

--- a/runner
+++ b/runner
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node --experimental-strip-types "$(dirname "$0")/src/qemu/runner.ts" "$@"

--- a/src/qemu/runner.ts
+++ b/src/qemu/runner.ts
@@ -60,10 +60,13 @@ type ClientResult = { code: number; stdout: Buffer; stderr: string };
 
 function runClient(args: string[]): Promise<ClientResult> {
   return new Promise((resolve, reject) => {
+    // Own process group: a terminal hangup or Ctrl-C reaches the whole foreground group,
+    // and a start killed mid-boot still boots on the proxy. Detached, the child survives to
+    // hand back its session id so shutdown can stop it instead of orphaning the QEMU.
     const child = spawn(
       process.execPath,
       ["--experimental-strip-types", "--disable-warning=ExperimentalWarning", cliPath, "--agent-id", agentId, "--server-url", serverUrl, ...args],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], detached: true },
     );
     const out: Buffer[] = [];
     const err: Buffer[] = [];

--- a/src/qemu/runner.ts
+++ b/src/qemu/runner.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S node --experimental-strip-types
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import { loadEnvFile } from "node:process";
@@ -22,12 +22,14 @@ if (process.argv.length > 3 || process.argv[2]?.startsWith("-") === true) {
 }
 
 const serverUrl = process.argv[2] ?? "http://127.0.0.1:42069";
-const agentId = `runner-${randomUUID().slice(0, 8)}`;
 const cliPath = fileURLToPath(new URL("./cli.ts", import.meta.url));
 
+// The proxy keys one session per agent id (agent_runs primary key), so every start
+// mints a fresh id; later commands and the stop must use the id that booted the session.
+let agentId = `runner-${randomUUID()}`;
 let sessionId: string | undefined;
 let intentOpen = false;
-let running: ChildProcess | undefined;
+let startInFlight: Promise<ClientResult> | undefined;
 let shuttingDown = false;
 
 const COMMANDS = ["start", "get-image", "get-serial", "send-keys", "send-mouse", "intent", "stop", "status", "help", "exit", "quit"];
@@ -52,35 +54,7 @@ function completer(line: string): [string[], string] {
 const rl = createInterface({ input: process.stdin, output: process.stdout, completer });
 rl.on("SIGINT", () => void shutdown());
 process.on("SIGTERM", () => void shutdown());
-
-const pending: string[] = [];
-let closed = false;
-let notify: (() => void) | undefined;
-rl.on("line", (line) => {
-  pending.push(line);
-  notify?.();
-});
-rl.on("close", () => {
-  closed = true;
-  notify?.();
-});
-
-// Piped input can close stdin while lines are still queued; drain them before shutting down.
-async function nextLine(): Promise<string | undefined> {
-  for (;;) {
-    const line = pending.shift();
-    if (line !== undefined) {
-      return line;
-    }
-    if (closed) {
-      return undefined;
-    }
-    await new Promise<void>((resolve) => {
-      notify = resolve;
-    });
-    notify = undefined;
-  }
-}
+process.on("SIGHUP", () => void shutdown());
 
 type ClientResult = { code: number; stdout: Buffer; stderr: string };
 
@@ -91,17 +65,12 @@ function runClient(args: string[]): Promise<ClientResult> {
       ["--experimental-strip-types", "--disable-warning=ExperimentalWarning", cliPath, "--agent-id", agentId, "--server-url", serverUrl, ...args],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
-    running = child;
     const out: Buffer[] = [];
     const err: Buffer[] = [];
     child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
     child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
-    child.on("error", (cause) => {
-      running = undefined;
-      reject(cause);
-    });
+    child.on("error", reject);
     child.on("close", (code) => {
-      running = undefined;
       resolve({ code: code ?? 1, stdout: Buffer.concat(out), stderr: Buffer.concat(err).toString("utf8").trim() });
     });
   });
@@ -112,19 +81,6 @@ function requireSession(): string | undefined {
     console.log("no session. run start first.");
   }
   return sessionId;
-}
-
-function unquote(text: string): string {
-  if (text.length >= 2 && text.startsWith('"') && text.endsWith('"')) {
-    return text.slice(1, -1);
-  }
-  return text;
-}
-
-function errorMessage(cause: unknown): string {
-  const error = cause as Error;
-  // Node's fetch and spawn bury the useful detail in the cause.
-  return error.cause instanceof Error ? `${error.message}: ${error.cause.message}` : error.message;
 }
 
 const imageProtocol = (() => {
@@ -152,7 +108,7 @@ function renderImage(png: Buffer): void {
     return;
   }
   if (imageProtocol === "iterm") {
-    process.stdout.write(`\x1b]1337;File=inline=1;size=${png.length};width=100%;preserveAspectRatio=1:${png.toString("base64")}\x07\n`);
+    process.stdout.write(`\x1b]1337;File=inline=1;size=${png.length};width=100%:${png.toString("base64")}\x07\n`);
     return;
   }
   const image = decodePng(png);
@@ -176,22 +132,17 @@ function renderImage(png: Buffer): void {
   process.stdout.write(text);
 }
 
-type Png = { width: number; height: number; channels: number; pixels: Buffer };
+type Png = { width: number; height: number; pixels: Buffer };
 
 function pixelAt(image: Png, col: number, row: number, scale: number): [number, number, number] {
   const px = Math.min(image.width - 1, Math.floor((col + 0.5) * scale));
   const py = Math.min(image.height - 1, Math.floor((row + 0.5) * scale));
-  const i = (py * image.width + px) * image.channels;
+  const i = (py * image.width + px) * 3;
   return [image.pixels[i], image.pixels[i + 1], image.pixels[i + 2]];
 }
 
-const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-
-// QEMU's screendump writes non-interlaced 8-bit RGB; that is the only shape decoded here.
+// QEMU's screendump writes a non-interlaced 8-bit RGB PNG; that is the only shape decoded here.
 function decodePng(png: Buffer): Png {
-  if (!png.subarray(0, 8).equals(PNG_SIGNATURE)) {
-    throw new Error("not a png");
-  }
   let width = 0;
   let height = 0;
   let bitDepth = 0;
@@ -215,12 +166,11 @@ function decodePng(png: Buffer): Png {
     }
     offset += length + 12;
   }
-  if (bitDepth !== 8 || (colorType !== 2 && colorType !== 6) || interlace !== 0) {
+  if (bitDepth !== 8 || colorType !== 2 || interlace !== 0) {
     throw new Error(`unsupported png: bit depth ${bitDepth}, color type ${colorType}, interlace ${interlace}`);
   }
-  const channels = colorType === 2 ? 3 : 4;
   const raw = inflateSync(Buffer.concat(idat));
-  const stride = width * channels;
+  const stride = width * 3;
   const pixels = Buffer.allocUnsafe(height * stride);
   for (let y = 0; y < height; y++) {
     const filter = raw[y * (stride + 1)];
@@ -228,9 +178,9 @@ function decodePng(png: Buffer): Png {
     const rowOut = y * stride;
     for (let x = 0; x < stride; x++) {
       const value = raw[rowIn + x];
-      const left = x >= channels ? pixels[rowOut + x - channels] : 0;
+      const left = x >= 3 ? pixels[rowOut + x - 3] : 0;
       const up = y > 0 ? pixels[rowOut + x - stride] : 0;
-      const upLeft = y > 0 && x >= channels ? pixels[rowOut + x - stride - channels] : 0;
+      const upLeft = y > 0 && x >= 3 ? pixels[rowOut + x - stride - 3] : 0;
       let unfiltered: number;
       if (filter === 0) {
         unfiltered = value;
@@ -248,7 +198,7 @@ function decodePng(png: Buffer): Png {
       pixels[rowOut + x] = unfiltered & 0xff;
     }
   }
-  return { width, height, channels, pixels };
+  return { width, height, pixels };
 }
 
 function paeth(a: number, b: number, c: number): number {
@@ -283,14 +233,17 @@ async function dispatch(line: string): Promise<void> {
       if (words.length === 2) {
         args.push("--disk", words[1]);
       }
+      agentId = `runner-${randomUUID()}`;
       console.log("booting; a first-time iso download can take a while...");
-      const result = await runClient(args);
+      startInFlight = runClient(args);
+      const result = await startInFlight;
+      startInFlight = undefined;
       if (result.code !== 0) {
         console.log(result.stderr);
         return;
       }
       sessionId = result.stdout.toString("utf8").trim();
-      intentOpen = false;
+      console.log(`agent   ${agentId}`);
       console.log(`session ${sessionId}`);
       return;
     }
@@ -330,7 +283,7 @@ async function dispatch(line: string): Promise<void> {
         console.log("usage: send-keys <keys>");
         return;
       }
-      const result = await runClient(["send-keys", id, unquote(rest)]);
+      const result = await runClient(["send-keys", id, rest]);
       console.log(result.code === 0 ? "ok" : result.stderr);
       return;
     }
@@ -360,7 +313,7 @@ async function dispatch(line: string): Promise<void> {
           console.log("usage: intent start <message>");
           return;
         }
-        const result = await runClient(["intent", "start", "--session_id", id, "--test_result_id", "manual", "--message", unquote(message)]);
+        const result = await runClient(["intent", "start", "--session_id", id, "--test_result_id", "manual", "--message", message]);
         if (result.code !== 0) {
           console.log(result.stderr);
           return;
@@ -402,17 +355,15 @@ async function dispatch(line: string): Promise<void> {
         args.push(status);
         const reason = rest.slice(status.length).trim();
         if (reason !== "") {
-          args.push(unquote(reason));
+          args.push(reason);
         }
       }
       const result = await runClient(args);
-      if (result.code !== 0) {
-        console.log(result.stderr);
-        return;
-      }
+      // Clear the session either way: a failed stop means the proxy already lost it
+      // (killed on timeout, gone), so keeping the id would only wedge the next start.
       sessionId = undefined;
       intentOpen = false;
-      console.log(`stopped ${id}`);
+      console.log(result.code === 0 ? `stopped ${id}` : result.stderr);
       return;
     }
     case "status": {
@@ -452,16 +403,16 @@ async function shutdown(): Promise<void> {
   }
   shuttingDown = true;
   rl.close();
-  if (running !== undefined) {
-    running.kill();
+  // A start killed mid-boot still boots on the proxy (/start is uninterruptible), so wait
+  // for the id it returns and stop that, rather than leaving an unreachable session behind.
+  const inflight = startInFlight;
+  if (inflight !== undefined) {
+    const result = await inflight;
+    if (sessionId === undefined && result.code === 0) {
+      sessionId = result.stdout.toString("utf8").trim();
+    }
   }
   if (sessionId !== undefined) {
-    if (intentOpen) {
-      const ended = await runClient(["intent", "end", "--session_id", sessionId]);
-      if (ended.code !== 0) {
-        console.log(ended.stderr);
-      }
-    }
     console.log(`stopping session ${sessionId}`);
     const result = await runClient(["stop", sessionId]);
     console.log(result.code === 0 ? "stopped" : result.stderr);
@@ -473,27 +424,24 @@ function promptText(): string {
   return sessionId === undefined ? "runner> " : `runner ${sessionId.slice(0, 8)}> `;
 }
 
-console.log(`agent  ${agentId}`);
 console.log(`server ${serverUrl}`);
 console.log('tab lists commands, "help" explains them, "exit" stops the session and leaves');
 
-for (;;) {
+rl.setPrompt(promptText());
+rl.prompt();
+for await (const line of rl) {
+  const trimmed = line.trim();
+  if (trimmed !== "") {
+    try {
+      await dispatch(trimmed);
+    } catch (cause) {
+      console.log((cause as Error).message);
+    }
+  }
   if (shuttingDown) {
     break;
   }
   rl.setPrompt(promptText());
   rl.prompt();
-  const line = (await nextLine())?.trim();
-  if (line === undefined) {
-    await shutdown();
-    break;
-  }
-  if (line === "") {
-    continue;
-  }
-  try {
-    await dispatch(line);
-  } catch (cause) {
-    console.log(errorMessage(cause));
-  }
 }
+await shutdown();

--- a/src/qemu/runner.ts
+++ b/src/qemu/runner.ts
@@ -1,0 +1,499 @@
+#!/usr/bin/env -S node --experimental-strip-types
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { loadEnvFile } from "node:process";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+import { inflateSync } from "node:zlib";
+
+if (existsSync(".env")) {
+  loadEnvFile();
+}
+
+if (process.env.OLIGARCHY_TOKEN === undefined || process.env.OLIGARCHY_TOKEN === "") {
+  console.error("OLIGARCHY_TOKEN is not set");
+  process.exit(1);
+}
+
+if (process.argv.length > 3 || process.argv[2]?.startsWith("-") === true) {
+  console.error("usage: ./runner [server-url]");
+  process.exit(1);
+}
+
+const serverUrl = process.argv[2] ?? "http://127.0.0.1:42069";
+const agentId = `runner-${randomUUID().slice(0, 8)}`;
+const cliPath = fileURLToPath(new URL("./cli.ts", import.meta.url));
+
+let sessionId: string | undefined;
+let intentOpen = false;
+let running: ChildProcess | undefined;
+let shuttingDown = false;
+
+const COMMANDS = ["start", "get-image", "get-serial", "send-keys", "send-mouse", "intent", "stop", "status", "help", "exit", "quit"];
+const STOP_STATUSES = ["succeeded", "failed", "aborted"];
+
+function completer(line: string): [string[], string] {
+  const intentArg = /^\s*intent\s+(\S*)$/.exec(line);
+  if (intentArg !== null) {
+    return [["start", "end"].filter((word) => word.startsWith(intentArg[1])), intentArg[1]];
+  }
+  const stopArg = /^\s*stop\s+(\S*)$/.exec(line);
+  if (stopArg !== null) {
+    return [STOP_STATUSES.filter((word) => word.startsWith(stopArg[1])), stopArg[1]];
+  }
+  const word = line.trimStart();
+  if (/\s/.test(word)) {
+    return [[], line];
+  }
+  return [COMMANDS.filter((command) => command.startsWith(word)), word];
+}
+
+const rl = createInterface({ input: process.stdin, output: process.stdout, completer });
+rl.on("SIGINT", () => void shutdown());
+process.on("SIGTERM", () => void shutdown());
+
+const pending: string[] = [];
+let closed = false;
+let notify: (() => void) | undefined;
+rl.on("line", (line) => {
+  pending.push(line);
+  notify?.();
+});
+rl.on("close", () => {
+  closed = true;
+  notify?.();
+});
+
+// Piped input can close stdin while lines are still queued; drain them before shutting down.
+async function nextLine(): Promise<string | undefined> {
+  for (;;) {
+    const line = pending.shift();
+    if (line !== undefined) {
+      return line;
+    }
+    if (closed) {
+      return undefined;
+    }
+    await new Promise<void>((resolve) => {
+      notify = resolve;
+    });
+    notify = undefined;
+  }
+}
+
+type ClientResult = { code: number; stdout: Buffer; stderr: string };
+
+function runClient(args: string[]): Promise<ClientResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--experimental-strip-types", "--disable-warning=ExperimentalWarning", cliPath, "--agent-id", agentId, "--server-url", serverUrl, ...args],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    running = child;
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => err.push(chunk));
+    child.on("error", (cause) => {
+      running = undefined;
+      reject(cause);
+    });
+    child.on("close", (code) => {
+      running = undefined;
+      resolve({ code: code ?? 1, stdout: Buffer.concat(out), stderr: Buffer.concat(err).toString("utf8").trim() });
+    });
+  });
+}
+
+function requireSession(): string | undefined {
+  if (sessionId === undefined) {
+    console.log("no session. run start first.");
+  }
+  return sessionId;
+}
+
+function unquote(text: string): string {
+  if (text.length >= 2 && text.startsWith('"') && text.endsWith('"')) {
+    return text.slice(1, -1);
+  }
+  return text;
+}
+
+function errorMessage(cause: unknown): string {
+  const error = cause as Error;
+  // Node's fetch and spawn bury the useful detail in the cause.
+  return error.cause instanceof Error ? `${error.message}: ${error.cause.message}` : error.message;
+}
+
+const imageProtocol = (() => {
+  const term = process.env.TERM ?? "";
+  const program = process.env.TERM_PROGRAM ?? "";
+  if (process.env.KITTY_WINDOW_ID !== undefined || term.includes("kitty") || term.includes("ghostty") || program === "ghostty") {
+    return "kitty";
+  }
+  if (program === "iTerm.app" || program === "WezTerm" || process.env.LC_TERMINAL === "iTerm2" || process.env.KONSOLE_VERSION !== undefined) {
+    return "iterm";
+  }
+  return "ansi";
+})();
+
+function renderImage(png: Buffer): void {
+  const cols = process.stdout.columns ?? 80;
+  if (imageProtocol === "kitty") {
+    const data = png.toString("base64");
+    for (let i = 0; i < data.length; i += 4096) {
+      const first = i === 0 ? `a=T,f=100,c=${cols},` : "";
+      const more = i + 4096 < data.length ? 1 : 0;
+      process.stdout.write(`\x1b_G${first}m=${more};${data.slice(i, i + 4096)}\x1b\\`);
+    }
+    process.stdout.write("\n");
+    return;
+  }
+  if (imageProtocol === "iterm") {
+    process.stdout.write(`\x1b]1337;File=inline=1;size=${png.length};width=100%;preserveAspectRatio=1:${png.toString("base64")}\x07\n`);
+    return;
+  }
+  const image = decodePng(png);
+  const outCols = Math.min(cols, image.width);
+  const scale = image.width / outCols;
+  const outRows = Math.round(image.height / scale);
+  let text = "";
+  for (let row = 0; row < outRows; row += 2) {
+    for (let col = 0; col < outCols; col++) {
+      const [r, g, b] = pixelAt(image, col, row, scale);
+      text += `\x1b[38;2;${r};${g};${b}m`;
+      if (row + 1 < outRows) {
+        const [br, bg, bb] = pixelAt(image, col, row + 1, scale);
+        text += `\x1b[48;2;${br};${bg};${bb}m▀`;
+      } else {
+        text += "\x1b[49m▀";
+      }
+    }
+    text += "\x1b[0m\n";
+  }
+  process.stdout.write(text);
+}
+
+type Png = { width: number; height: number; channels: number; pixels: Buffer };
+
+function pixelAt(image: Png, col: number, row: number, scale: number): [number, number, number] {
+  const px = Math.min(image.width - 1, Math.floor((col + 0.5) * scale));
+  const py = Math.min(image.height - 1, Math.floor((row + 0.5) * scale));
+  const i = (py * image.width + px) * image.channels;
+  return [image.pixels[i], image.pixels[i + 1], image.pixels[i + 2]];
+}
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+// QEMU's screendump writes non-interlaced 8-bit RGB; that is the only shape decoded here.
+function decodePng(png: Buffer): Png {
+  if (!png.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    throw new Error("not a png");
+  }
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  let interlace = 0;
+  const idat: Buffer[] = [];
+  let offset = 8;
+  while (offset + 8 <= png.length) {
+    const length = png.readUInt32BE(offset);
+    const type = png.toString("latin1", offset + 4, offset + 8);
+    if (type === "IHDR") {
+      width = png.readUInt32BE(offset + 8);
+      height = png.readUInt32BE(offset + 12);
+      bitDepth = png[offset + 16];
+      colorType = png[offset + 17];
+      interlace = png[offset + 20];
+    } else if (type === "IDAT") {
+      idat.push(png.subarray(offset + 8, offset + 8 + length));
+    } else if (type === "IEND") {
+      break;
+    }
+    offset += length + 12;
+  }
+  if (bitDepth !== 8 || (colorType !== 2 && colorType !== 6) || interlace !== 0) {
+    throw new Error(`unsupported png: bit depth ${bitDepth}, color type ${colorType}, interlace ${interlace}`);
+  }
+  const channels = colorType === 2 ? 3 : 4;
+  const raw = inflateSync(Buffer.concat(idat));
+  const stride = width * channels;
+  const pixels = Buffer.allocUnsafe(height * stride);
+  for (let y = 0; y < height; y++) {
+    const filter = raw[y * (stride + 1)];
+    const rowIn = y * (stride + 1) + 1;
+    const rowOut = y * stride;
+    for (let x = 0; x < stride; x++) {
+      const value = raw[rowIn + x];
+      const left = x >= channels ? pixels[rowOut + x - channels] : 0;
+      const up = y > 0 ? pixels[rowOut + x - stride] : 0;
+      const upLeft = y > 0 && x >= channels ? pixels[rowOut + x - stride - channels] : 0;
+      let unfiltered: number;
+      if (filter === 0) {
+        unfiltered = value;
+      } else if (filter === 1) {
+        unfiltered = value + left;
+      } else if (filter === 2) {
+        unfiltered = value + up;
+      } else if (filter === 3) {
+        unfiltered = value + ((left + up) >> 1);
+      } else if (filter === 4) {
+        unfiltered = value + paeth(left, up, upLeft);
+      } else {
+        throw new Error(`bad png filter ${filter}`);
+      }
+      pixels[rowOut + x] = unfiltered & 0xff;
+    }
+  }
+  return { width, height, channels, pixels };
+}
+
+function paeth(a: number, b: number, c: number): number {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+  if (pa <= pb && pa <= pc) {
+    return a;
+  }
+  return pb <= pc ? b : c;
+}
+
+async function dispatch(line: string): Promise<void> {
+  const command = line.split(/\s+/, 1)[0];
+  const rest = line.slice(command.length).trim();
+  switch (command) {
+    case "start": {
+      if (sessionId !== undefined) {
+        console.log(`session ${sessionId} is already running. stop it first.`);
+        return;
+      }
+      const words = rest === "" ? [] : rest.split(/\s+/);
+      if (words.length > 2) {
+        console.log("usage: start [iso] [disk]");
+        return;
+      }
+      const args = ["start"];
+      if (words.length >= 1) {
+        args.push("--iso", words[0]);
+      }
+      if (words.length === 2) {
+        args.push("--disk", words[1]);
+      }
+      console.log("booting; a first-time iso download can take a while...");
+      const result = await runClient(args);
+      if (result.code !== 0) {
+        console.log(result.stderr);
+        return;
+      }
+      sessionId = result.stdout.toString("utf8").trim();
+      intentOpen = false;
+      console.log(`session ${sessionId}`);
+      return;
+    }
+    case "get-image": {
+      const id = requireSession();
+      if (id === undefined) {
+        return;
+      }
+      const result = await runClient(["get-image", id]);
+      if (result.code !== 0) {
+        console.log(result.stderr);
+        return;
+      }
+      renderImage(result.stdout);
+      return;
+    }
+    case "get-serial": {
+      const id = requireSession();
+      if (id === undefined) {
+        return;
+      }
+      const result = await runClient(["get-serial", id]);
+      if (result.code !== 0) {
+        console.log(result.stderr);
+        return;
+      }
+      const text = result.stdout.toString("utf8");
+      console.log(text === "" ? "(serial is empty)" : text);
+      return;
+    }
+    case "send-keys": {
+      const id = requireSession();
+      if (id === undefined) {
+        return;
+      }
+      if (rest === "") {
+        console.log("usage: send-keys <keys>");
+        return;
+      }
+      const result = await runClient(["send-keys", id, unquote(rest)]);
+      console.log(result.code === 0 ? "ok" : result.stderr);
+      return;
+    }
+    case "send-mouse": {
+      const id = requireSession();
+      if (id === undefined) {
+        return;
+      }
+      const words = rest === "" ? [] : rest.split(/\s+/);
+      if (words.length < 2 || words.length > 4) {
+        console.log("usage: send-mouse <x> <y> [button] [clicks]");
+        return;
+      }
+      const result = await runClient(["send-mouse", id, ...words]);
+      console.log(result.code === 0 ? "ok" : result.stderr);
+      return;
+    }
+    case "intent": {
+      const id = requireSession();
+      if (id === undefined) {
+        return;
+      }
+      const sub = rest.split(/\s+/, 1)[0];
+      const message = rest.slice(sub.length).trim();
+      if (sub === "start") {
+        if (message === "") {
+          console.log("usage: intent start <message>");
+          return;
+        }
+        const result = await runClient(["intent", "start", "--session_id", id, "--test_result_id", "manual", "--message", unquote(message)]);
+        if (result.code !== 0) {
+          console.log(result.stderr);
+          return;
+        }
+        intentOpen = true;
+        console.log("ok");
+        return;
+      }
+      if (sub === "end") {
+        if (message !== "") {
+          console.log("usage: intent end");
+          return;
+        }
+        const result = await runClient(["intent", "end", "--session_id", id]);
+        if (result.code !== 0) {
+          console.log(result.stderr);
+          return;
+        }
+        intentOpen = false;
+        console.log("ok");
+        return;
+      }
+      console.log("usage: intent start <message> | intent end");
+      return;
+    }
+    case "stop": {
+      const id = requireSession();
+      if (id === undefined) {
+        return;
+      }
+      const words = rest === "" ? [] : rest.split(/\s+/);
+      const status = words[0];
+      if (status !== undefined && !STOP_STATUSES.includes(status)) {
+        console.log("usage: stop [succeeded|failed|aborted] [reason]");
+        return;
+      }
+      const args = ["stop", id];
+      if (status !== undefined) {
+        args.push(status);
+        const reason = rest.slice(status.length).trim();
+        if (reason !== "") {
+          args.push(unquote(reason));
+        }
+      }
+      const result = await runClient(args);
+      if (result.code !== 0) {
+        console.log(result.stderr);
+        return;
+      }
+      sessionId = undefined;
+      intentOpen = false;
+      console.log(`stopped ${id}`);
+      return;
+    }
+    case "status": {
+      console.log(`agent   ${agentId}`);
+      console.log(`server  ${serverUrl}`);
+      console.log(`session ${sessionId ?? "none"}`);
+      console.log(`intent  ${intentOpen ? "open" : "none"}`);
+      return;
+    }
+    case "help": {
+      console.log("start [iso] [disk]                    boot a qemu session (default iso: omarchy.iso)");
+      console.log("get-image                             show the guest display inline");
+      console.log("get-serial                            print the guest serial console");
+      console.log("send-keys <keys>                      type into the guest, e.g. send-keys hello<ENTER>");
+      console.log("send-mouse <x> <y> [button] [clicks]  move, click, or scroll; x and y are 0..1 fractions");
+      console.log("intent start <message>                declare what you are about to do");
+      console.log("intent end                            close the open intent");
+      console.log("stop [status] [reason]                stop the session; status is succeeded, failed, or aborted");
+      console.log("status                                show agent, server, session, and intent");
+      console.log("exit                                  stop the session and leave");
+      return;
+    }
+    case "exit":
+    case "quit": {
+      await shutdown();
+      return;
+    }
+    default: {
+      console.log(`unknown command: ${command}. tab lists commands; help explains them.`);
+    }
+  }
+}
+
+async function shutdown(): Promise<void> {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  rl.close();
+  if (running !== undefined) {
+    running.kill();
+  }
+  if (sessionId !== undefined) {
+    if (intentOpen) {
+      const ended = await runClient(["intent", "end", "--session_id", sessionId]);
+      if (ended.code !== 0) {
+        console.log(ended.stderr);
+      }
+    }
+    console.log(`stopping session ${sessionId}`);
+    const result = await runClient(["stop", sessionId]);
+    console.log(result.code === 0 ? "stopped" : result.stderr);
+  }
+  process.exit(0);
+}
+
+function promptText(): string {
+  return sessionId === undefined ? "runner> " : `runner ${sessionId.slice(0, 8)}> `;
+}
+
+console.log(`agent  ${agentId}`);
+console.log(`server ${serverUrl}`);
+console.log('tab lists commands, "help" explains them, "exit" stops the session and leaves');
+
+for (;;) {
+  if (shuttingDown) {
+    break;
+  }
+  rl.setPrompt(promptText());
+  rl.prompt();
+  const line = (await nextLine())?.trim();
+  if (line === undefined) {
+    await shutdown();
+    break;
+  }
+  if (line === "") {
+    continue;
+  }
+  try {
+    await dispatch(line);
+  } catch (cause) {
+    console.log(errorMessage(cause));
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A root-level `./runner` script pointing at `src/qemu/runner.ts`: an interactive REPL for driving a QEMU session by hand through the proxy.

- `./runner [server-url]` is the whole invocation; the server URL is the only parameter (default `http://127.0.0.1:42069`).
- Tracks the agent id, session id, and open intent for the whole sitting; the prompt shows the short session id.
- Tab completion over every client action (`start`, `get-image`, `get-serial`, `send-keys`, `send-mouse`, `intent`, `stop`) plus `status`, `help`, `exit`.
- `start` mints a fresh agent id (the proxy keys one session per agent id) and remembers it; later commands reuse it automatically.
- `get-image` renders the guest display inline: kitty graphics protocol on kitty/ghostty, OSC 1337 on iTerm2/WezTerm/Konsole, and a built-in PNG decode to truecolor half-blocks everywhere else.
- `intent start <message>` / `intent end` declare intent around actions; `status` shows the open intent.
- Killing the runner (Ctrl-C, SIGTERM, SIGHUP, `exit`, or piped stdin ending) stops the tracked session on the server, so no QEMU is left running. The CLI child is spawned in its own process group and an in-flight `start` is awaited during shutdown, so even a hangup or Ctrl-C mid-boot stops the session it boots rather than orphaning it.

Every action shells out to `src/qemu/cli.ts`, so wire behavior stays defined in one place; the runner only tracks state and renders.

## Verification

Driven live against a throwaway stub proxy implementing the real HTTP contract (auth, intent single-open, verdicts), plus:

- PNG decoder checked byte-for-byte against Pillow on adaptive-filtered images covering all five PNG filter types.
- kitty and iTerm2 escape emission checked by piping a scripted session and grepping the protocol prefixes.
- Kill paths confirmed by watching the stub receive `POST /stop`: Ctrl-C, SIGTERM, SIGHUP, `exit`, and stdin EOF.
- In-flight-start shutdown confirmed for a signal sent during a 6s boot — SIGTERM, SIGHUP, and Ctrl-C each produce `POST /start` then `POST /stop` with the matching session id (no orphan).
- Fresh agent id per `start` confirmed (two starts in one session send two distinct ids).
- Stop-wedge fix confirmed: after the proxy loses a session, a failed `stop` clears state so the next `start` succeeds.
- `npm run lint` clean, all 84 existing tests pass.

Reviewed by GPT-5.6 Sol (twice) and Claude Fable per `development.md`; every finding — agent-id reuse, post-timeout wedge, in-flight-start shutdown, signal coverage including the hangup orphan, and the simplifications — is applied.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89119e20-05ef-4602-9221-ba5091f8483c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89119e20-05ef-4602-9221-ba5091f8483c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

