### PR TITLE
Add client runner with tab completion, state tracking, and inline images

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "private": true,
   "type": "module",
   "bin": {
-    "client": "src/qemu/cli.ts"
+    "client": "src/qemu/cli.ts",
+    "runner": "src/runner.ts"
   },
   "scripts": {
     "client": "node --experimental-strip-types src/qemu/cli.ts",
+    "runner": "node --experimental-strip-types src/runner.ts",
     "dev": "wrangler dev --remote",
-    "test": "node --test --experimental-strip-types src/client.test.ts src/cursor-agent/client.test.ts src/experiment.test.ts src/qmp/json-stream.test.ts src/qemu/client.test.ts src/qemu/keys.test.ts src/sentry.test.ts src/test-def.test.ts",
+    "test": "node --test --experimental-strip-types src/client.test.ts src/cursor-agent/client.test.ts src/experiment.test.ts src/qmp/json-stream.test.ts src/qemu/client.test.ts src/qemu/keys.test.ts src/sentry.test.ts src/test-def.test.ts src/runner.test.ts",
     "lint": "oxlint --type-aware --type-check",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "node --experimental-strip-types src/db/migrate.ts"

--- a/runner
+++ b/runner
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node --experimental-strip-types "$(dirname "$0")/src/runner.ts" "$@"

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -36,7 +36,7 @@ describe("runner state and command execution happy path", () => {
     });
   });
 
-  it("executes send-keys with session id tracked automatically", async () => {
+  it("executes send-keys with rest of line passed as string", async () => {
     let capturedUrl: string | undefined;
     let capturedBody: unknown;
     const fetchFn: typeof fetch = async (input, init) => {
@@ -48,11 +48,11 @@ describe("runner state and command execution happy path", () => {
     const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
     runner.sessionId = "session-123";
 
-    const output = await executeRunnerLine(runner, "send-keys hello<ENTER>");
+    const output = await executeRunnerLine(runner, "send-keys hello world<ENTER>");
     assert.equal(capturedUrl, "http://127.0.0.1:42069/send-keys");
     assert.deepEqual(capturedBody, {
       id: "session-123",
-      keys: "hello<ENTER>",
+      keys: "hello world<ENTER>",
       encoding: "oligarchy",
       agent: runner.agentId,
     });
@@ -201,20 +201,12 @@ describe("tab completion unhappy path", () => {
 });
 
 describe("terminal image rendering happy path", () => {
-  it("generates iTerm2 inline image escape sequence", () => {
+  it("generates simple inline image escape sequence", () => {
     const png = Buffer.from("fake-png-bytes");
-    const output = formatTerminalImage(png, { protocol: "iterm2" });
+    const output = formatTerminalImage(png);
     assert.ok(output.startsWith("\x1b]1337;File="));
     assert.ok(output.includes(png.toString("base64")));
     assert.ok(output.endsWith("\x07\n"));
-  });
-
-  it("generates kitty inline image escape sequence", () => {
-    const png = Buffer.from("fake-png-bytes");
-    const output = formatTerminalImage(png, { protocol: "kitty" });
-    assert.ok(output.startsWith("\x1b_G"));
-    assert.ok(output.includes("f=100"));
-    assert.ok(output.endsWith("\x1b\\\n"));
   });
 });
 

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -36,6 +36,20 @@ describe("runner state and command execution happy path", () => {
     });
   });
 
+  it("rotates agentId after stop so a new session can start", async () => {
+    const fetchFn: typeof fetch = async (input, init) => {
+      return new Response(JSON.stringify({ ok: "true" }), { status: 200 });
+    };
+
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    const originalAgentId = runner.agentId;
+    runner.sessionId = "session-123";
+
+    await stopRunnerSession(runner);
+    assert.notEqual(runner.agentId, originalAgentId);
+    assert.equal(runner.sessionId, undefined);
+  });
+
   it("executes send-keys with rest of line passed as string", async () => {
     let capturedUrl: string | undefined;
     let capturedBody: unknown;
@@ -127,6 +141,22 @@ describe("runner state and command execution unhappy path", () => {
       () => executeRunnerLine(runner, "start"),
       { message: "A session is already running (existing-session). Stop it before starting a new one." },
     );
+  });
+
+  it("rejects start with invalid arguments", async () => {
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok" });
+    await assert.rejects(() => executeRunnerLine(runner, "start --iso"), {
+      message: "Missing value for --iso",
+    });
+    await assert.rejects(() => executeRunnerLine(runner, "start --iso="), {
+      message: "Missing value for --iso",
+    });
+    await assert.rejects(() => executeRunnerLine(runner, "start --disk"), {
+      message: "Missing value for --disk",
+    });
+    await assert.rejects(() => executeRunnerLine(runner, "start --unknown"), {
+      message: "Unknown option for start: --unknown",
+    });
   });
 
   it("rejects when OLIGARCHY_TOKEN is missing", () => {
@@ -228,12 +258,13 @@ describe("cleanup on exit / kill happy path", () => {
     };
 
     const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    const originalAgent = runner.agentId;
     runner.sessionId = "session-123";
 
     await stopRunnerSession(runner, "aborted", "runner exited");
     assert.deepEqual(stoppedBody, {
       id: "session-123",
-      agent: runner.agentId,
+      agent: originalAgent,
       status: "aborted",
       reason: "runner exited",
     });

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import {
+  createRunner,
+  executeRunnerLine,
+  formatTerminalImage,
+  completeRunnerLine,
+  stopRunnerSession,
+  type RunnerState,
+} from "./runner.ts";
+
+describe("runner state and command execution happy path", () => {
+  it("initializes runner with serverUrl and unique agentId", () => {
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069" });
+    assert.equal(runner.serverUrl, "http://127.0.0.1:42069");
+    assert.ok(runner.agentId.length > 0);
+    assert.equal(runner.sessionId, undefined);
+  });
+
+  it("executes start command, updates sessionId and returns it", async () => {
+    let capturedBody: unknown;
+    const fetchFn: typeof fetch = async (input, init) => {
+      capturedBody = JSON.parse(init?.body as string);
+      return new Response(JSON.stringify({ id: "session-test-uuid" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    const output = await executeRunnerLine(runner, "start --iso test.iso");
+
+    assert.equal(runner.sessionId, "session-test-uuid");
+    assert.match(output, /session-test-uuid/);
+    assert.deepEqual(capturedBody, {
+      iso: resolve("test.iso"),
+      agent: runner.agentId,
+    });
+  });
+
+  it("executes send-keys with session id tracked automatically", async () => {
+    let capturedUrl: string | undefined;
+    let capturedBody: unknown;
+    const fetchFn: typeof fetch = async (input, init) => {
+      capturedUrl = String(input);
+      capturedBody = JSON.parse(init?.body as string);
+      return new Response(JSON.stringify({ ok: "true" }), { status: 200 });
+    };
+
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    runner.sessionId = "session-123";
+
+    const output = await executeRunnerLine(runner, "send-keys hello<ENTER>");
+    assert.equal(capturedUrl, "http://127.0.0.1:42069/send-keys");
+    assert.deepEqual(capturedBody, {
+      id: "session-123",
+      keys: "hello<ENTER>",
+      encoding: "oligarchy",
+      agent: runner.agentId,
+    });
+    assert.match(output, /ok/);
+  });
+
+  it("executes send-mouse with tracked session", async () => {
+    let capturedBody: unknown;
+    const fetchFn: typeof fetch = async (input, init) => {
+      capturedBody = JSON.parse(init?.body as string);
+      return new Response(JSON.stringify({ ok: "true" }), { status: 200 });
+    };
+
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    runner.sessionId = "session-123";
+
+    await executeRunnerLine(runner, "send-mouse 0.5 0.5 left 2");
+    assert.deepEqual(capturedBody, {
+      id: "session-123",
+      x: 0.5,
+      y: 0.5,
+      button: "left",
+      clicks: 2,
+      agent: runner.agentId,
+    });
+  });
+
+  it("executes intent start and intent end tracking active intent", async () => {
+    const bodies: unknown[] = [];
+    const fetchFn: typeof fetch = async (input, init) => {
+      bodies.push(JSON.parse(init?.body as string));
+      return new Response(JSON.stringify({ ok: "true" }), { status: 200 });
+    };
+
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    runner.sessionId = "session-123";
+
+    await executeRunnerLine(runner, "intent start --message \"test intent message\" --test_result_id res-1");
+    assert.equal(runner.activeIntent, "test intent message");
+
+    await executeRunnerLine(runner, "intent end");
+    assert.equal(runner.activeIntent, undefined);
+    assert.equal(bodies.length, 2);
+
+    await executeRunnerLine(runner, "intent \"shorthand intent\"");
+    assert.equal(runner.activeIntent, "shorthand intent");
+    await executeRunnerLine(runner, "intent end");
+  });
+});
+
+describe("runner state and command execution unhappy path", () => {
+  it("rejects commands requiring session when no session is active", async () => {
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069" });
+    await assert.rejects(
+      () => executeRunnerLine(runner, "send-keys hello"),
+      { message: "No active session. Run 'start' first." },
+    );
+    await assert.rejects(
+      () => executeRunnerLine(runner, "get-image"),
+      { message: "No active session. Run 'start' first." },
+    );
+    await assert.rejects(
+      () => executeRunnerLine(runner, "send-mouse 0.5 0.5"),
+      { message: "No active session. Run 'start' first." },
+    );
+  });
+
+  it("handles server error responses gracefully", async () => {
+    const fetchFn = async () => {
+      return new Response(JSON.stringify({ error: "Session crashed" }), { status: 500 });
+    };
+
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    runner.sessionId = "session-123";
+
+    await assert.rejects(
+      () => executeRunnerLine(runner, "send-keys hello"),
+      { message: "Session crashed" },
+    );
+  });
+
+  it("rejects unknown commands", async () => {
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069" });
+    await assert.rejects(
+      () => executeRunnerLine(runner, "unknown-command foo"),
+      { message: "Unknown command: unknown-command" },
+    );
+  });
+});
+
+describe("tab completion happy path", () => {
+  it("completes top-level actions when line is empty or prefix matches", () => {
+    const runner = createRunner();
+    const [completions, match] = completeRunnerLine(runner, "");
+    assert.ok(completions.includes("start"));
+    assert.ok(completions.includes("send-keys"));
+    assert.ok(completions.includes("get-image"));
+    assert.ok(completions.includes("send-mouse"));
+    assert.ok(completions.includes("intent"));
+    assert.ok(completions.includes("stop"));
+    assert.equal(match, "");
+
+    const [sCompletions, sMatch] = completeRunnerLine(runner, "se");
+    assert.deepEqual(sCompletions, ["send-keys", "send-mouse"]);
+    assert.equal(sMatch, "se");
+  });
+
+  it("completes intent subcommands", () => {
+    const runner = createRunner();
+    const [completions, match] = completeRunnerLine(runner, "intent ");
+    assert.deepEqual(completions, ["start", "end"]);
+    assert.equal(match, "");
+  });
+});
+
+describe("tab completion unhappy path", () => {
+  it("returns empty completions for non-matching input", () => {
+    const runner = createRunner();
+    const [completions, match] = completeRunnerLine(runner, "xyz");
+    assert.deepEqual(completions, []);
+    assert.equal(match, "xyz");
+  });
+});
+
+describe("terminal image rendering happy path", () => {
+  it("generates iTerm2 inline image escape sequence", () => {
+    const png = Buffer.from("fake-png-bytes");
+    const output = formatTerminalImage(png, { protocol: "iterm2" });
+    assert.ok(output.startsWith("\x1b]1337;File="));
+    assert.ok(output.includes(png.toString("base64")));
+    assert.ok(output.endsWith("\x07\n"));
+  });
+
+  it("generates kitty inline image escape sequence", () => {
+    const png = Buffer.from("fake-png-bytes");
+    const output = formatTerminalImage(png, { protocol: "kitty" });
+    assert.ok(output.startsWith("\x1b_G"));
+    assert.ok(output.includes("f=100"));
+    assert.ok(output.endsWith("\x1b\\\n"));
+  });
+});
+
+describe("terminal image rendering unhappy path", () => {
+  it("handles empty or invalid image buffer", () => {
+    assert.throws(
+      () => formatTerminalImage(Buffer.alloc(0)),
+      { message: "Cannot display empty image" },
+    );
+  });
+});
+
+describe("cleanup on exit / kill happy path", () => {
+  it("calls stop on proxy when session is active and clears session", async () => {
+    let stoppedBody: unknown;
+    const fetchFn: typeof fetch = async (input, init) => {
+      stoppedBody = JSON.parse(init?.body as string);
+      return new Response(JSON.stringify({ ok: "true" }), { status: 200 });
+    };
+
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    runner.sessionId = "session-123";
+
+    await stopRunnerSession(runner);
+    assert.deepEqual(stoppedBody, {
+      id: "session-123",
+      agent: runner.agentId,
+      status: "aborted",
+      reason: "runner exited",
+    });
+    assert.equal(runner.sessionId, undefined);
+  });
+});
+
+describe("cleanup on exit / kill unhappy path", () => {
+  it("does not throw if stop fails during cleanup", async () => {
+    const fetchFn = async () => {
+      throw new Error("Network offline");
+    };
+
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    runner.sessionId = "session-123";
+
+    // Should not throw
+    await stopRunnerSession(runner);
+    assert.equal(runner.sessionId, undefined);
+  });
+
+  it("does nothing if no active session", async () => {
+    let called = false;
+    const fetchFn = async () => {
+      called = true;
+      return new Response("{}");
+    };
+
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    await stopRunnerSession(runner);
+    assert.equal(called, false);
+  });
+});

--- a/src/runner.test.ts
+++ b/src/runner.test.ts
@@ -12,7 +12,7 @@ import {
 
 describe("runner state and command execution happy path", () => {
   it("initializes runner with serverUrl and unique agentId", () => {
-    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069" });
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok" });
     assert.equal(runner.serverUrl, "http://127.0.0.1:42069");
     assert.ok(runner.agentId.length > 0);
     assert.equal(runner.sessionId, undefined);
@@ -20,15 +20,12 @@ describe("runner state and command execution happy path", () => {
 
   it("executes start command, updates sessionId and returns it", async () => {
     let capturedBody: unknown;
-    const fetchFn: typeof fetch = async (input, init) => {
-      capturedBody = JSON.parse(init?.body as string);
-      return new Response(JSON.stringify({ id: "session-test-uuid" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+    const postStart = async (serverUrl: string, body: unknown) => {
+      capturedBody = body;
+      return JSON.stringify({ id: "session-test-uuid" });
     };
 
-    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", postStart });
     const output = await executeRunnerLine(runner, "start --iso test.iso");
 
     assert.equal(runner.sessionId, "session-test-uuid");
@@ -108,7 +105,7 @@ describe("runner state and command execution happy path", () => {
 
 describe("runner state and command execution unhappy path", () => {
   it("rejects commands requiring session when no session is active", async () => {
-    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069" });
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok" });
     await assert.rejects(
       () => executeRunnerLine(runner, "send-keys hello"),
       { message: "No active session. Run 'start' first." },
@@ -121,6 +118,29 @@ describe("runner state and command execution unhappy path", () => {
       () => executeRunnerLine(runner, "send-mouse 0.5 0.5"),
       { message: "No active session. Run 'start' first." },
     );
+  });
+
+  it("rejects start when session is already running", async () => {
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok" });
+    runner.sessionId = "existing-session";
+    await assert.rejects(
+      () => executeRunnerLine(runner, "start"),
+      { message: "A session is already running (existing-session). Stop it before starting a new one." },
+    );
+  });
+
+  it("rejects when OLIGARCHY_TOKEN is missing", () => {
+    const prev = process.env.OLIGARCHY_TOKEN;
+    delete process.env.OLIGARCHY_TOKEN;
+    try {
+      assert.throws(() => createRunner({ token: "" }), {
+        message: "OLIGARCHY_TOKEN is not set",
+      });
+    } finally {
+      if (prev !== undefined) {
+        process.env.OLIGARCHY_TOKEN = prev;
+      }
+    }
   });
 
   it("handles server error responses gracefully", async () => {
@@ -138,7 +158,7 @@ describe("runner state and command execution unhappy path", () => {
   });
 
   it("rejects unknown commands", async () => {
-    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069" });
+    const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok" });
     await assert.rejects(
       () => executeRunnerLine(runner, "unknown-command foo"),
       { message: "Unknown command: unknown-command" },
@@ -148,7 +168,7 @@ describe("runner state and command execution unhappy path", () => {
 
 describe("tab completion happy path", () => {
   it("completes top-level actions when line is empty or prefix matches", () => {
-    const runner = createRunner();
+    const runner = createRunner({ token: "tok" });
     const [completions, match] = completeRunnerLine(runner, "");
     assert.ok(completions.includes("start"));
     assert.ok(completions.includes("send-keys"));
@@ -164,7 +184,7 @@ describe("tab completion happy path", () => {
   });
 
   it("completes intent subcommands", () => {
-    const runner = createRunner();
+    const runner = createRunner({ token: "tok" });
     const [completions, match] = completeRunnerLine(runner, "intent ");
     assert.deepEqual(completions, ["start", "end"]);
     assert.equal(match, "");
@@ -173,7 +193,7 @@ describe("tab completion happy path", () => {
 
 describe("tab completion unhappy path", () => {
   it("returns empty completions for non-matching input", () => {
-    const runner = createRunner();
+    const runner = createRunner({ token: "tok" });
     const [completions, match] = completeRunnerLine(runner, "xyz");
     assert.deepEqual(completions, []);
     assert.equal(match, "xyz");
@@ -218,7 +238,7 @@ describe("cleanup on exit / kill happy path", () => {
     const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
     runner.sessionId = "session-123";
 
-    await stopRunnerSession(runner);
+    await stopRunnerSession(runner, "aborted", "runner exited");
     assert.deepEqual(stoppedBody, {
       id: "session-123",
       agent: runner.agentId,
@@ -230,28 +250,28 @@ describe("cleanup on exit / kill happy path", () => {
 });
 
 describe("cleanup on exit / kill unhappy path", () => {
-  it("does not throw if stop fails during cleanup", async () => {
-    const fetchFn = async () => {
+  it("leaves sessionId set if stop fails during cleanup so it can be retried", async () => {
+    const fetchFn: typeof fetch = async () => {
       throw new Error("Network offline");
     };
 
     const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
     runner.sessionId = "session-123";
 
-    // Should not throw
-    await stopRunnerSession(runner);
-    assert.equal(runner.sessionId, undefined);
+    await assert.rejects(() => stopRunnerSession(runner));
+    assert.equal(runner.sessionId, "session-123");
   });
 
   it("does nothing if no active session", async () => {
     let called = false;
-    const fetchFn = async () => {
+    const fetchFn: typeof fetch = async () => {
       called = true;
       return new Response("{}");
     };
 
     const runner = createRunner({ serverUrl: "http://127.0.0.1:42069", token: "tok", fetch: fetchFn });
-    await stopRunnerSession(runner);
+    const output = await stopRunnerSession(runner);
+    assert.equal(output, "No active session.");
     assert.equal(called, false);
   });
 });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -45,6 +45,7 @@ export type RunnerState = {
   sessionId?: string;
   activeIntent?: string;
   testResultId?: string;
+  startingPromise?: Promise<string>;
 };
 
 export function createRunner(options: RunnerOptions = {}): RunnerState {
@@ -236,6 +237,7 @@ export async function stopRunnerSession(
 
   runner.sessionId = undefined;
   runner.activeIntent = undefined;
+  runner.agentId = `runner-${randomUUID().slice(0, 8)}`;
   return `Session ${sessionId} stopped${status !== undefined ? ` (${status}${reason !== undefined ? `: ${reason}` : ""})` : ""}.`;
 }
 
@@ -280,19 +282,38 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
       if (runner.sessionId !== undefined) {
         throw new Error(`A session is already running (${runner.sessionId}). Stop it before starting a new one.`);
       }
+      if (runner.startingPromise !== undefined) {
+        throw new Error("A session is currently starting. Please wait.");
+      }
 
       let iso = DEFAULT_ISO;
       let disk: string | undefined;
 
       for (let i = 1; i < parts.length; i++) {
-        if (parts[i] === "--iso" && parts[i + 1] !== undefined) {
+        if (parts[i] === "--iso") {
+          if (parts[i + 1] === undefined) {
+            throw new Error("Missing value for --iso");
+          }
           iso = parts[++i];
         } else if (parts[i].startsWith("--iso=")) {
-          iso = parts[i].slice(6);
-        } else if (parts[i] === "--disk" && parts[i + 1] !== undefined) {
+          const val = parts[i].slice(6);
+          if (val === "") {
+            throw new Error("Missing value for --iso");
+          }
+          iso = val;
+        } else if (parts[i] === "--disk") {
+          if (parts[i + 1] === undefined) {
+            throw new Error("Missing value for --disk");
+          }
           disk = parts[++i];
         } else if (parts[i].startsWith("--disk=")) {
-          disk = parts[i].slice(7);
+          const val = parts[i].slice(7);
+          if (val === "") {
+            throw new Error("Missing value for --disk");
+          }
+          disk = val;
+        } else {
+          throw new Error(`Unknown option for start: ${parts[i]}`);
         }
       }
 
@@ -311,7 +332,15 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
         startPayload.disk = disk;
       }
 
-      const raw = await runner.postStart(runner.serverUrl, startPayload, runner.token);
+      const starting = runner.postStart(runner.serverUrl, startPayload, runner.token);
+      runner.startingPromise = starting;
+
+      let raw: string;
+      try {
+        raw = await starting;
+      } finally {
+        runner.startingPromise = undefined;
+      }
 
       const parsed = JSON.parse(raw) as { id: string };
       runner.sessionId = parsed.id;
@@ -517,6 +546,13 @@ export async function runInteractiveSession(serverUrl?: string): Promise<void> {
   const cleanup = async () => {
     if (cleanupRunning) return;
     cleanupRunning = true;
+    if (runner.startingPromise !== undefined) {
+      try {
+        const raw = await runner.startingPromise;
+        const parsed = JSON.parse(raw) as { id: string };
+        runner.sessionId = parsed.id;
+      } catch {}
+    }
     if (runner.sessionId !== undefined) {
       try {
         await stopRunnerSession(runner, "aborted", "runner terminated");

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,0 +1,569 @@
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { createInterface } from "node:readline";
+import { loadEnvFile } from "node:process";
+
+if (existsSync(".env")) {
+  loadEnvFile();
+}
+
+const DEFAULT_SERVER_URL = "http://127.0.0.1:42069";
+const DEFAULT_ISO = "omarchy.iso";
+const DEFAULT_ENCODING = "oligarchy";
+
+export const CLIENT_ACTIONS = [
+  "start",
+  "get-image",
+  "get-serial",
+  "send-keys",
+  "send-mouse",
+  "intent",
+  "stop",
+  "help",
+  "status",
+  "exit",
+] as const;
+
+export type TerminalImageOptions = {
+  protocol?: "iterm2" | "kitty" | "none";
+};
+
+export type RunnerOptions = {
+  serverUrl?: string;
+  agentId?: string;
+  token?: string;
+  fetch?: typeof fetch;
+};
+
+export type RunnerState = {
+  serverUrl: string;
+  agentId: string;
+  token: string;
+  fetch: typeof fetch;
+  sessionId?: string;
+  activeIntent?: string;
+  testResultId?: string;
+};
+
+export function createRunner(options: RunnerOptions = {}): RunnerState {
+  const token = options.token ?? process.env.OLIGARCHY_TOKEN ?? "";
+  return {
+    serverUrl: options.serverUrl ?? DEFAULT_SERVER_URL,
+    agentId: options.agentId ?? `runner-${randomUUID().slice(0, 8)}`,
+    token,
+    fetch: options.fetch ?? globalThis.fetch,
+  };
+}
+
+export function detectTerminalImageProtocol(): "iterm2" | "kitty" | "none" {
+  const termProgram = process.env.TERM_PROGRAM;
+  const term = process.env.TERM ?? "";
+  const lcTerm = process.env.LC_TERMINAL;
+
+  if (termProgram === "iTerm.app" || termProgram === "WezTerm" || lcTerm === "iTerm2") {
+    return "iterm2";
+  }
+  if (termProgram === "kitty" || term.includes("kitty")) {
+    return "kitty";
+  }
+  if (process.env.GHOSTTY_RESOURCES_DIR !== undefined) {
+    return "kitty";
+  }
+  return "iterm2";
+}
+
+export function formatTerminalImage(data: Buffer, options: TerminalImageOptions = {}): string {
+  if (data.length === 0) {
+    throw new Error("Cannot display empty image");
+  }
+  const protocol = options.protocol ?? detectTerminalImageProtocol();
+  if (protocol === "kitty") {
+    const b64 = data.toString("base64");
+    const chunkSize = 4096;
+    let out = "";
+    for (let i = 0; i < b64.length; i += chunkSize) {
+      const chunk = b64.slice(i, i + chunkSize);
+      const isLast = i + chunkSize >= b64.length;
+      if (i === 0) {
+        out += `\x1b_Ga=T,f=100,m=${isLast ? 0 : 1};${chunk}\x1b\\`;
+      } else {
+        out += `\x1b_Gm=${isLast ? 0 : 1};${chunk}\x1b\\`;
+      }
+    }
+    return `${out}\n`;
+  }
+
+  const b64 = data.toString("base64");
+  return `\x1b]1337;File=inline=1;width=auto;height=auto:${b64}\x07\n`;
+}
+
+export function completeRunnerLine(runner: RunnerState, line: string): [string[], string] {
+  const trimmed = line.trimStart();
+  const parts = trimmed.split(/\s+/);
+
+  if (parts.length <= 1 && !line.endsWith(" ")) {
+    const prefix = parts[0] ?? "";
+    const hits = CLIENT_ACTIONS.filter((cmd) => cmd.startsWith(prefix));
+    return [hits, prefix];
+  }
+
+  const cmd = parts[0];
+  if (cmd === "intent") {
+    const subcommands = ["start", "end"];
+    if (parts.length === 2 && !line.endsWith(" ")) {
+      const prefix = parts[1];
+      const hits = subcommands.filter((sub) => sub.startsWith(prefix));
+      return [hits, prefix];
+    }
+    if (parts.length === 1 || (parts.length === 2 && line.endsWith(" "))) {
+      return [subcommands, ""];
+    }
+  }
+
+  return [[], ""];
+}
+
+function parseArgs(raw: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  let escape = false;
+
+  for (let i = 0; i < raw.length; i++) {
+    const char = raw[i];
+    if (escape) {
+      current += char;
+      escape = false;
+      continue;
+    }
+    if (char === "\\") {
+      escape = true;
+      continue;
+    }
+    if (quote !== null) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        args.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current.length > 0) {
+    args.push(current);
+  }
+  return args;
+}
+
+async function requestJson(
+  runner: RunnerState,
+  path: string,
+  method: string,
+  body?: unknown,
+): Promise<string> {
+  const headers: Record<string, string> = {};
+  if (runner.token !== "") {
+    headers.Authorization = `Bearer ${runner.token}`;
+  }
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const res = await runner.fetch(`${runner.serverUrl}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+
+  const text = await res.text();
+  if (res.status < 200 || res.status >= 300) {
+    let message = text;
+    try {
+      const parsed = JSON.parse(text) as { error?: string };
+      if (parsed.error !== undefined) {
+        message = parsed.error;
+      }
+    } catch {}
+    throw new Error(message || `Request failed with status ${res.status}`);
+  }
+  return text;
+}
+
+export async function stopRunnerSession(
+  runner: RunnerState,
+  status: "succeeded" | "failed" | "aborted" = "aborted",
+  reason = "runner exited",
+): Promise<string> {
+  if (runner.sessionId === undefined) {
+    return "No active session.";
+  }
+  const sessionId = runner.sessionId;
+  runner.sessionId = undefined;
+  runner.activeIntent = undefined;
+
+  try {
+    await requestJson(runner, "/stop", "POST", {
+      id: sessionId,
+      agent: runner.agentId,
+      status,
+      reason,
+    });
+    return `Session ${sessionId} stopped (${status}: ${reason}).`;
+  } catch (err) {
+    return `Failed to stop session ${sessionId}: ${(err as Error).message}`;
+  }
+}
+
+export async function executeRunnerLine(runner: RunnerState, line: string): Promise<string> {
+  const trimmed = line.trim();
+  if (trimmed === "") {
+    return "";
+  }
+
+  const parts = parseArgs(trimmed);
+  const command = parts[0];
+
+  switch (command) {
+    case "help": {
+      return [
+        "Available actions:",
+        "  start [--iso <path|url>] [--disk <path>]  Start a QEMU session",
+        "  get-image [-o <path>]                    Capture display and show inline",
+        "  get-serial [-o <path>]                   Read guest serial output",
+        "  send-keys <keys> [encoding]              Send key string (e.g. 'hello<ENTER>')",
+        "  send-mouse <x> <y> [button] [clicks]     Send mouse pointer / click (0..1 coords)",
+        "  intent start --message <msg> [--test_result_id <id>]  Declare intent",
+        "  intent end                               Complete active intent",
+        "  intent                                   Show current active intent",
+        "  stop [status] [reason]                   Stop current QEMU session",
+        "  status                                   Show current runner state",
+        "  exit / quit                              Stop session and exit runner",
+      ].join("\n");
+    }
+
+    case "status": {
+      return [
+        `Server URL:    ${runner.serverUrl}`,
+        `Agent ID:      ${runner.agentId}`,
+        `Session ID:    ${runner.sessionId ?? "(none)"}`,
+        `Active Intent: ${runner.activeIntent ?? "(none)"}`,
+      ].join("\n");
+    }
+
+    case "start": {
+      let iso = DEFAULT_ISO;
+      let disk: string | undefined;
+
+      for (let i = 1; i < parts.length; i++) {
+        if (parts[i] === "--iso" && parts[i + 1] !== undefined) {
+          iso = parts[++i];
+        } else if (parts[i].startsWith("--iso=")) {
+          iso = parts[i].slice(6);
+        } else if (parts[i] === "--disk" && parts[i + 1] !== undefined) {
+          disk = parts[++i];
+        } else if (parts[i].startsWith("--disk=")) {
+          disk = parts[i].slice(7);
+        }
+      }
+
+      if (!iso.startsWith("http://") && !iso.startsWith("https://")) {
+        iso = resolve(iso);
+      }
+      if (disk !== undefined) {
+        disk = resolve(disk);
+      }
+
+      const raw = await requestJson(runner, "/start", "POST", {
+        iso,
+        disk,
+        agent: runner.agentId,
+      });
+
+      const parsed = JSON.parse(raw) as { id: string };
+      runner.sessionId = parsed.id;
+      return `Session started: ${parsed.id}`;
+    }
+
+    case "get-image": {
+      if (runner.sessionId === undefined) {
+        throw new Error("No active session. Run 'start' first.");
+      }
+
+      let outputPath: string | undefined;
+      for (let i = 1; i < parts.length; i++) {
+        if ((parts[i] === "-o" || parts[i] === "--output") && parts[i + 1] !== undefined) {
+          outputPath = parts[++i];
+        }
+      }
+
+      const headers: Record<string, string> = {};
+      if (runner.token !== "") {
+        headers.Authorization = `Bearer ${runner.token}`;
+      }
+      const url = `${runner.serverUrl}/image?id=${encodeURIComponent(runner.sessionId)}&agent=${encodeURIComponent(runner.agentId)}`;
+      const res = await runner.fetch(url, { headers });
+      if (res.status !== 200) {
+        const text = await res.text();
+        throw new Error(text || `Failed to get image (${res.status})`);
+      }
+
+      const buffer = Buffer.from(await res.arrayBuffer());
+      if (outputPath !== undefined) {
+        const { writeFile } = await import("node:fs/promises");
+        await writeFile(resolve(outputPath), buffer);
+        return `Image saved to ${outputPath}`;
+      }
+
+      const imgSequence = formatTerminalImage(buffer);
+      return `${imgSequence}Image displayed (${buffer.length} bytes)`;
+    }
+
+    case "get-serial": {
+      if (runner.sessionId === undefined) {
+        throw new Error("No active session. Run 'start' first.");
+      }
+
+      let outputPath: string | undefined;
+      for (let i = 1; i < parts.length; i++) {
+        if ((parts[i] === "-o" || parts[i] === "--output") && parts[i + 1] !== undefined) {
+          outputPath = parts[++i];
+        }
+      }
+
+      const headers: Record<string, string> = {};
+      if (runner.token !== "") {
+        headers.Authorization = `Bearer ${runner.token}`;
+      }
+      const url = `${runner.serverUrl}/serial?id=${encodeURIComponent(runner.sessionId)}&agent=${encodeURIComponent(runner.agentId)}`;
+      const res = await runner.fetch(url, { headers });
+      if (res.status !== 200) {
+        const text = await res.text();
+        throw new Error(text || `Failed to get serial (${res.status})`);
+      }
+
+      const text = await res.text();
+      if (outputPath !== undefined) {
+        const { writeFile } = await import("node:fs/promises");
+        await writeFile(resolve(outputPath), text);
+        return `Serial output saved to ${outputPath}`;
+      }
+      return text;
+    }
+
+    case "send-keys": {
+      if (runner.sessionId === undefined) {
+        throw new Error("No active session. Run 'start' first.");
+      }
+      const keys = parts[1];
+      if (keys === undefined) {
+        throw new Error("send-keys requires keys argument (e.g. send-keys \"hello<ENTER>\")");
+      }
+      const encoding = parts[2] ?? DEFAULT_ENCODING;
+
+      await requestJson(runner, "/send-keys", "POST", {
+        id: runner.sessionId,
+        keys,
+        encoding,
+        agent: runner.agentId,
+      });
+      return "Keys sent: ok";
+    }
+
+    case "send-mouse": {
+      if (runner.sessionId === undefined) {
+        throw new Error("No active session. Run 'start' first.");
+      }
+      if (parts[1] === undefined || parts[2] === undefined) {
+        throw new Error("send-mouse requires x and y arguments (e.g. send-mouse 0.5 0.5 [button] [clicks])");
+      }
+      const x = parseFloat(parts[1]);
+      const y = parseFloat(parts[2]);
+      const button = parts[3];
+      const clicks = parts[4] !== undefined ? parseInt(parts[4], 10) : undefined;
+
+      await requestJson(runner, "/send-mouse", "POST", {
+        id: runner.sessionId,
+        x,
+        y,
+        button,
+        clicks,
+        agent: runner.agentId,
+      });
+      return "Mouse event sent: ok";
+    }
+
+    case "intent": {
+      if (parts.length === 1) {
+        return runner.activeIntent !== undefined
+          ? `Active intent: "${runner.activeIntent}"`
+          : "No active intent.";
+      }
+
+      const sub = parts[1];
+      if (sub === "start" || (sub !== "end" && parts.length > 1)) {
+        if (runner.sessionId === undefined) {
+          throw new Error("No active session. Run 'start' first.");
+        }
+        let message = "";
+        let testResultId = runner.testResultId ?? `intent-${Date.now()}`;
+        const startIdx = sub === "start" ? 2 : 1;
+
+        for (let i = startIdx; i < parts.length; i++) {
+          if (parts[i] === "--message" && parts[i + 1] !== undefined) {
+            message = parts[++i];
+          } else if (parts[i].startsWith("--message=")) {
+            message = parts[i].slice(10);
+          } else if (parts[i] === "--test_result_id" && parts[i + 1] !== undefined) {
+            testResultId = parts[++i];
+          } else if (parts[i].startsWith("--test_result_id=")) {
+            testResultId = parts[i].slice(17);
+          } else if (message === "") {
+            message = parts[i];
+          } else {
+            message += ` ${parts[i]}`;
+          }
+        }
+
+        if (message === "") {
+          throw new Error("intent requires a message (e.g. intent \"installing OS\" or intent start --message \"installing OS\")");
+        }
+
+        await requestJson(runner, "/intent/start", "POST", {
+          id: runner.sessionId,
+          agent: runner.agentId,
+          test_result_id: testResultId,
+          message,
+        });
+        runner.activeIntent = message;
+        runner.testResultId = testResultId;
+        return `Intent started: "${message}"`;
+      }
+
+      if (sub === "end") {
+        if (runner.sessionId === undefined) {
+          throw new Error("No active session. Run 'start' first.");
+        }
+        await requestJson(runner, "/intent/end", "POST", {
+          id: runner.sessionId,
+          agent: runner.agentId,
+        });
+        const finished = runner.activeIntent;
+        runner.activeIntent = undefined;
+        return `Intent ended: "${finished ?? ""}"`;
+      }
+
+      throw new Error(`Unknown intent subcommand: ${sub}. Use 'intent start' or 'intent end'.`);
+    }
+
+    case "stop": {
+      if (runner.sessionId === undefined) {
+        throw new Error("No active session. Run 'start' first.");
+      }
+      const status = (parts[1] as "succeeded" | "failed" | "aborted") ?? "succeeded";
+      const reason = parts[2];
+      return await stopRunnerSession(runner, status, reason);
+    }
+
+    case "exit":
+    case "quit": {
+      if (runner.sessionId !== undefined) {
+        await stopRunnerSession(runner, "aborted", "runner exited");
+      }
+      return "Goodbye!";
+    }
+
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+}
+
+export async function runInteractiveSession(serverUrl?: string): Promise<void> {
+  const runner = createRunner({ serverUrl });
+
+  console.log("=== Oligarchy Client Runner ===");
+  console.log(`Server URL: ${runner.serverUrl}`);
+  console.log(`Agent ID:   ${runner.agentId}`);
+  console.log("Press TAB for available commands, or type 'help' for usage.");
+  console.log("Ctrl+C or 'exit' will cleanly stop any running session.");
+  console.log("");
+
+  let cleanupRunning = false;
+  const cleanup = async () => {
+    if (cleanupRunning) return;
+    cleanupRunning = true;
+    if (runner.sessionId !== undefined) {
+      console.log(`\nStopping session ${runner.sessionId}...`);
+      await stopRunnerSession(runner, "aborted", "runner terminated");
+      console.log("Session stopped. Exiting.");
+    }
+  };
+
+  process.once("SIGINT", () => {
+    void cleanup().then(() => process.exit(0));
+  });
+  process.once("SIGTERM", () => {
+    void cleanup().then(() => process.exit(0));
+  });
+
+  const rl = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: "oligarchy> ",
+    completer: (line: string) => completeRunnerLine(runner, line),
+  });
+
+  rl.prompt();
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (trimmed === "exit" || trimmed === "quit") {
+      await cleanup();
+      break;
+    }
+
+    try {
+      const output = await executeRunnerLine(runner, line);
+      if (output !== "") {
+        console.log(output);
+      }
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+    }
+
+    const intentPrompt = runner.activeIntent !== undefined ? ` [${runner.activeIntent}]` : "";
+    const sessionPrompt = runner.sessionId !== undefined ? ` (${runner.sessionId.slice(0, 8)})` : "";
+    rl.setPrompt(`oligarchy${sessionPrompt}${intentPrompt}> `);
+    rl.prompt();
+  }
+
+  rl.close();
+}
+
+if (process.argv[1] === import.meta.filename) {
+  let serverUrl: string | undefined;
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+    if (arg === "--server-url" && process.argv[i + 1] !== undefined) {
+      serverUrl = process.argv[++i];
+    } else if (arg.startsWith("--server-url=")) {
+      serverUrl = arg.slice(13);
+    } else if (!arg.startsWith("-") && serverUrl === undefined) {
+      serverUrl = arg;
+    }
+  }
+  await runInteractiveSession(serverUrl);
+}
+

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -28,10 +28,6 @@ export const CLIENT_ACTIONS = [
   "exit",
 ] as const;
 
-export type TerminalImageOptions = {
-  protocol?: "iterm2" | "kitty" | "none";
-};
-
 export type RunnerOptions = {
   serverUrl?: string;
   agentId?: string;
@@ -65,44 +61,10 @@ export function createRunner(options: RunnerOptions = {}): RunnerState {
   };
 }
 
-export function detectTerminalImageProtocol(): "iterm2" | "kitty" | "none" {
-  const termProgram = process.env.TERM_PROGRAM;
-  const term = process.env.TERM ?? "";
-  const lcTerm = process.env.LC_TERMINAL;
-
-  if (termProgram === "iTerm.app" || termProgram === "WezTerm" || lcTerm === "iTerm2") {
-    return "iterm2";
-  }
-  if (termProgram === "kitty" || term.includes("kitty")) {
-    return "kitty";
-  }
-  if (process.env.GHOSTTY_RESOURCES_DIR !== undefined) {
-    return "kitty";
-  }
-  return "iterm2";
-}
-
-export function formatTerminalImage(data: Buffer, options: TerminalImageOptions = {}): string {
+export function formatTerminalImage(data: Buffer): string {
   if (data.length === 0) {
     throw new Error("Cannot display empty image");
   }
-  const protocol = options.protocol ?? detectTerminalImageProtocol();
-  if (protocol === "kitty") {
-    const b64 = data.toString("base64");
-    const chunkSize = 4096;
-    let out = "";
-    for (let i = 0; i < b64.length; i += chunkSize) {
-      const chunk = b64.slice(i, i + chunkSize);
-      const isLast = i + chunkSize >= b64.length;
-      if (i === 0) {
-        out += `\x1b_Ga=T,f=100,m=${isLast ? 0 : 1};${chunk}\x1b\\`;
-      } else {
-        out += `\x1b_Gm=${isLast ? 0 : 1};${chunk}\x1b\\`;
-      }
-    }
-    return `${out}\n`;
-  }
-
   const b64 = data.toString("base64");
   return `\x1b]1337;File=inline=1;width=auto;height=auto:${b64}\x07\n`;
 }
@@ -295,7 +257,8 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
         "  get-serial [-o <path>]                   Read guest serial output",
         "  send-keys <keys> [encoding]              Send key string (e.g. 'hello<ENTER>')",
         "  send-mouse <x> <y> [button] [clicks]     Send mouse pointer / click (0..1 coords)",
-        "  intent start --message <msg> [--test_result_id <id>]  Declare intent",
+        "  intent start --message <msg>             Declare intent",
+        "  intent <message>                         Declare intent shorthand",
         "  intent end                               Complete active intent",
         "  intent                                   Show current active intent",
         "  stop [status] [reason]                   Stop current QEMU session",
@@ -382,8 +345,7 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
         return `Image saved to ${outputPath}`;
       }
 
-      const imgSequence = formatTerminalImage(buffer);
-      return `${imgSequence}Image displayed (${buffer.length} bytes)`;
+      return formatTerminalImage(buffer);
     }
 
     case "get-serial": {
@@ -419,16 +381,22 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
       if (runner.sessionId === undefined) {
         throw new Error("No active session. Run 'start' first.");
       }
-      const keys = parts[1];
-      if (keys === undefined) {
+      const rawAfterCmd = trimmed.slice(command.length).trim();
+      if (rawAfterCmd === "") {
         throw new Error("send-keys requires keys argument (e.g. send-keys \"hello<ENTER>\")");
       }
-      const encoding = parts[2] ?? DEFAULT_ENCODING;
+      let keys = rawAfterCmd;
+      if (
+        (keys.startsWith('"') && keys.endsWith('"'))
+        || (keys.startsWith("'") && keys.endsWith("'"))
+      ) {
+        keys = keys.slice(1, -1);
+      }
 
       await requestJson(runner, "/send-keys", "POST", {
         id: runner.sessionId,
         keys,
-        encoding,
+        encoding: DEFAULT_ENCODING,
         agent: runner.agentId,
       });
       return "Keys sent: ok";
@@ -545,22 +513,13 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
 export async function runInteractiveSession(serverUrl?: string): Promise<void> {
   const runner = createRunner({ serverUrl });
 
-  console.log("=== Oligarchy Client Runner ===");
-  console.log(`Server URL: ${runner.serverUrl}`);
-  console.log(`Agent ID:   ${runner.agentId}`);
-  console.log("Press TAB for available commands, or type 'help' for usage.");
-  console.log("Ctrl+C or 'exit' will cleanly stop any running session.");
-  console.log("");
-
   let cleanupRunning = false;
   const cleanup = async () => {
     if (cleanupRunning) return;
     cleanupRunning = true;
     if (runner.sessionId !== undefined) {
-      console.log(`\nStopping session ${runner.sessionId}...`);
       try {
         await stopRunnerSession(runner, "aborted", "runner terminated");
-        console.log("Session stopped. Exiting.");
       } catch (err) {
         console.error(`Failed to stop session: ${(err as Error).message}`);
       }
@@ -580,7 +539,7 @@ export async function runInteractiveSession(serverUrl?: string): Promise<void> {
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout,
-    prompt: "oligarchy> ",
+    prompt: "> ",
     completer: (line: string) => completeRunnerLine(runner, line),
   });
 
@@ -602,13 +561,9 @@ export async function runInteractiveSession(serverUrl?: string): Promise<void> {
       console.error(`Error: ${(err as Error).message}`);
     }
 
-    const intentPrompt = runner.activeIntent !== undefined ? ` [${runner.activeIntent}]` : "";
-    const sessionPrompt = runner.sessionId !== undefined ? ` (${runner.sessionId.slice(0, 8)})` : "";
-    rl.setPrompt(`oligarchy${sessionPrompt}${intentPrompt}> `);
     rl.prompt();
   }
 
-  // Handle EOF (Ctrl+D) when the async iterator finishes without an exit command
   await cleanup();
   rl.close();
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { createInterface } from "node:readline";
@@ -11,6 +13,7 @@ if (existsSync(".env")) {
 const DEFAULT_SERVER_URL = "http://127.0.0.1:42069";
 const DEFAULT_ISO = "omarchy.iso";
 const DEFAULT_ENCODING = "oligarchy";
+const START_TIMEOUT_MS = 45 * 60 * 1000;
 
 export const CLIENT_ACTIONS = [
   "start",
@@ -34,6 +37,7 @@ export type RunnerOptions = {
   agentId?: string;
   token?: string;
   fetch?: typeof fetch;
+  postStart?: (serverUrl: string, body: unknown, token: string) => Promise<string>;
 };
 
 export type RunnerState = {
@@ -41,6 +45,7 @@ export type RunnerState = {
   agentId: string;
   token: string;
   fetch: typeof fetch;
+  postStart: (serverUrl: string, body: unknown, token: string) => Promise<string>;
   sessionId?: string;
   activeIntent?: string;
   testResultId?: string;
@@ -48,11 +53,15 @@ export type RunnerState = {
 
 export function createRunner(options: RunnerOptions = {}): RunnerState {
   const token = options.token ?? process.env.OLIGARCHY_TOKEN ?? "";
+  if (token === "") {
+    throw new Error("OLIGARCHY_TOKEN is not set");
+  }
   return {
     serverUrl: options.serverUrl ?? DEFAULT_SERVER_URL,
     agentId: options.agentId ?? `runner-${randomUUID().slice(0, 8)}`,
     token,
     fetch: options.fetch ?? globalThis.fetch,
+    postStart: options.postStart ?? defaultPostStart,
   };
 }
 
@@ -168,16 +177,60 @@ function parseArgs(raw: string): string[] {
   return args;
 }
 
+function defaultPostStart(serverUrl: string, body: unknown, token: string): Promise<string> {
+  const url = new URL(`${serverUrl}/start`);
+  const send = url.protocol === "https:" ? httpsRequest : httpRequest;
+  const payload = JSON.stringify(body);
+  return new Promise<string>((resolveReq, reject) => {
+    const req = send(
+      url,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          data += chunk;
+        });
+        res.on("error", reject);
+        res.on("end", () => {
+          const status = res.statusCode!;
+          if (status >= 200 && status < 300) {
+            resolveReq(data);
+          } else {
+            let message = data;
+            try {
+              const parsed = JSON.parse(data) as { error?: string };
+              if (parsed.error !== undefined) {
+                message = parsed.error;
+              }
+            } catch {}
+            reject(new Error(message || "start: request failed"));
+          }
+        });
+      },
+    );
+    req.setTimeout(START_TIMEOUT_MS, () => req.destroy(new Error("start: no response within timeout")));
+    req.on("error", reject);
+    req.end(payload);
+  });
+}
+
 async function requestJson(
   runner: RunnerState,
   path: string,
   method: string,
   body?: unknown,
 ): Promise<string> {
-  const headers: Record<string, string> = {};
-  if (runner.token !== "") {
-    headers.Authorization = `Bearer ${runner.token}`;
-  }
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${runner.token}`,
+  };
   if (body !== undefined) {
     headers["Content-Type"] = "application/json";
   }
@@ -204,27 +257,24 @@ async function requestJson(
 
 export async function stopRunnerSession(
   runner: RunnerState,
-  status: "succeeded" | "failed" | "aborted" = "aborted",
-  reason = "runner exited",
+  status?: "succeeded" | "failed" | "aborted",
+  reason?: string,
 ): Promise<string> {
   if (runner.sessionId === undefined) {
     return "No active session.";
   }
   const sessionId = runner.sessionId;
+
+  await requestJson(runner, "/stop", "POST", {
+    id: sessionId,
+    agent: runner.agentId,
+    status,
+    reason,
+  });
+
   runner.sessionId = undefined;
   runner.activeIntent = undefined;
-
-  try {
-    await requestJson(runner, "/stop", "POST", {
-      id: sessionId,
-      agent: runner.agentId,
-      status,
-      reason,
-    });
-    return `Session ${sessionId} stopped (${status}: ${reason}).`;
-  } catch (err) {
-    return `Failed to stop session ${sessionId}: ${(err as Error).message}`;
-  }
+  return `Session ${sessionId} stopped${status !== undefined ? ` (${status}${reason !== undefined ? `: ${reason}` : ""})` : ""}.`;
 }
 
 export async function executeRunnerLine(runner: RunnerState, line: string): Promise<string> {
@@ -264,6 +314,10 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
     }
 
     case "start": {
+      if (runner.sessionId !== undefined) {
+        throw new Error(`A session is already running (${runner.sessionId}). Stop it before starting a new one.`);
+      }
+
       let iso = DEFAULT_ISO;
       let disk: string | undefined;
 
@@ -286,11 +340,15 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
         disk = resolve(disk);
       }
 
-      const raw = await requestJson(runner, "/start", "POST", {
+      const startPayload: { iso: string; disk?: string; agent: string } = {
         iso,
-        disk,
         agent: runner.agentId,
-      });
+      };
+      if (disk !== undefined) {
+        startPayload.disk = disk;
+      }
+
+      const raw = await runner.postStart(runner.serverUrl, startPayload, runner.token);
 
       const parsed = JSON.parse(raw) as { id: string };
       runner.sessionId = parsed.id;
@@ -309,10 +367,7 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
         }
       }
 
-      const headers: Record<string, string> = {};
-      if (runner.token !== "") {
-        headers.Authorization = `Bearer ${runner.token}`;
-      }
+      const headers = { Authorization: `Bearer ${runner.token}` };
       const url = `${runner.serverUrl}/image?id=${encodeURIComponent(runner.sessionId)}&agent=${encodeURIComponent(runner.agentId)}`;
       const res = await runner.fetch(url, { headers });
       if (res.status !== 200) {
@@ -343,10 +398,7 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
         }
       }
 
-      const headers: Record<string, string> = {};
-      if (runner.token !== "") {
-        headers.Authorization = `Bearer ${runner.token}`;
-      }
+      const headers = { Authorization: `Bearer ${runner.token}` };
       const url = `${runner.serverUrl}/serial?id=${encodeURIComponent(runner.sessionId)}&agent=${encodeURIComponent(runner.agentId)}`;
       const res = await runner.fetch(url, { headers });
       if (res.status !== 200) {
@@ -472,7 +524,7 @@ export async function executeRunnerLine(runner: RunnerState, line: string): Prom
       if (runner.sessionId === undefined) {
         throw new Error("No active session. Run 'start' first.");
       }
-      const status = (parts[1] as "succeeded" | "failed" | "aborted") ?? "succeeded";
+      const status = parts[1] as "succeeded" | "failed" | "aborted" | undefined;
       const reason = parts[2];
       return await stopRunnerSession(runner, status, reason);
     }
@@ -506,8 +558,12 @@ export async function runInteractiveSession(serverUrl?: string): Promise<void> {
     cleanupRunning = true;
     if (runner.sessionId !== undefined) {
       console.log(`\nStopping session ${runner.sessionId}...`);
-      await stopRunnerSession(runner, "aborted", "runner terminated");
-      console.log("Session stopped. Exiting.");
+      try {
+        await stopRunnerSession(runner, "aborted", "runner terminated");
+        console.log("Session stopped. Exiting.");
+      } catch (err) {
+        console.error(`Failed to stop session: ${(err as Error).message}`);
+      }
     }
   };
 
@@ -515,6 +571,9 @@ export async function runInteractiveSession(serverUrl?: string): Promise<void> {
     void cleanup().then(() => process.exit(0));
   });
   process.once("SIGTERM", () => {
+    void cleanup().then(() => process.exit(0));
+  });
+  process.once("SIGHUP", () => {
     void cleanup().then(() => process.exit(0));
   });
 
@@ -549,6 +608,8 @@ export async function runInteractiveSession(serverUrl?: string): Promise<void> {
     rl.prompt();
   }
 
+  // Handle EOF (Ctrl+D) when the async iterator finishes without an exit command
+  await cleanup();
   rl.close();
 }
 
@@ -566,4 +627,3 @@ if (process.argv[1] === import.meta.filename) {
   }
   await runInteractiveSession(serverUrl);
 }
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This PR adds a client runner (`./runner` and `src/runner.ts`) for the Oligarchy control plane.

### Features
- **Session & Agent State Tracking**: Generates and persists an `agentId`, tracks active `sessionId`, `serverUrl`, and active `intent` across commands without needing re-entry.
- **Direct, Simple Readline Console I/O**: Plain console input/output with prompt (`> `), no complex terminal-sniffing or unneeded ANSI formatting.
- **Tab Completion**: Auto-completes client actions (`start`, `get-image`, `get-serial`, `send-keys`, `send-mouse`, `intent`, `stop`, `help`, `status`, `exit`) and intent subcommands.
- **Inline Image Display**: Fetches guest display PNG via `get-image` and outputs the image directly inline in the terminal.
- **Intent Tracking**: Supports `intent <bunch of words>` to start an intent, `intent start --message <msg>`, and `intent end`. Actions can also be executed without an active intent.
- **Direct Keys Sending**: `send-keys <string>` accepts raw strings directly without quote nesting requirements.
- **Robust Clean Shutdown**: Cleanly stops any active QEMU session on exit (`Ctrl+C`, `Ctrl+D` EOF, `SIGHUP`, `SIGTERM`, `exit`/`quit`), including awaiting any in-flight `/start` requests before stopping. Rotates agent ID on stop so subsequent sessions succeed.
- **Unit Tests**: Full happy and unhappy path test coverage in `src/runner.test.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50a1ba78-f41a-4c17-976e-bff45de6afd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50a1ba78-f41a-4c17-976e-bff45de6afd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

