### PR TITLE
client.md, ctrl.md, ctrl-linear.md: man-page shape, one example per action

### DIFF
--- a/client.md
+++ b/client.md
@@ -5,18 +5,18 @@ Consult this table of contents first. Read only the section you need.
 | Section | Line |
 |---------|-----:|
 | [Important](#important) | 21 |
-| [Environment](#environment) | 27 |
-| [Invoke](#invoke) | 33 |
-| [start](#start) | 49 |
-| [get-image](#get-image) | 63 |
-| [get-serial](#get-serial) | 74 |
-| [send-keys](#send-keys) | 96 |
-| [send-mouse](#send-mouse) | 108 |
-| [intent](#intent) | 122 |
-| [stop](#stop) | 133 |
-| [Keys](#keys) | 145 |
-| [Mouse](#mouse) | 157 |
-| [The loop](#the-loop) | 165 |
+| [Synopsis](#synopsis) | 27 |
+| [start](#start) | 50 |
+| [get-image](#get-image) | 65 |
+| [get-serial](#get-serial) | 80 |
+| [send-keys](#send-keys) | 95 |
+| [send-mouse](#send-mouse) | 111 |
+| [intent start](#intent-start) | 128 |
+| [intent end](#intent-end) | 144 |
+| [stop](#stop) | 158 |
+| [Keys](#keys) | 174 |
+| [Mouse](#mouse) | 186 |
+| [The loop](#the-loop) | 194 |
 
 ## Important
 
@@ -24,123 +24,152 @@ If you are the client, or an agent driving the client: do not look at code. Only
 
 `./client` drives the guest. Recording the test result is `./ctrl`, described in its own guide.
 
-## Environment
+## Synopsis
 
-`OLIGARCHY_TOKEN` is already in this process. Use it. Do not write a `.env`.
+```
+./client <action> --agent-id <agent> [--server-url <url>] ...
 
-The proxy and the client both read `OLIGARCHY_TOKEN` from the environment. The client sends it on every request to the proxy. Starting either without it exits 1. Nothing else is read from the environment, except `SERVER_URL` as the fallback for `--server-url`.
-
-## Invoke
-
-The action comes first. Every value after it is a flag; there are no positional arguments. Every action takes `--agent-id <your-id>` and `--server-url <url>`; flags may sit in any order after the action. An invocation without `--agent-id` fails.
-
-```bash
-./client <action> --agent-id <agent> --server-url <url> ...
+./client start      [--iso <path|url>] [--disk <path>]
+./client get-image  --session-id <id> [-o <file>]
+./client get-serial --session-id <id> [-o <file>]
+./client send-keys  --session-id <id> --keys <keys> [--encoding <encoding>]
+./client send-mouse --session-id <id> --x <0..1> --y <0..1> [--button <button>] [--clicks <n>]
+./client intent start --session-id <id> --test-result-id <id> --message <text>
+./client intent end   --session-id <id>
+./client stop       --session-id <id> [--status succeeded|failed|aborted] [--reason <text>]
 ```
 
-`--server-url` is the proxy, a full URL used exactly as given. When omitted, `SERVER_URL` from the environment is used, then `http://127.0.0.1:42069`. The proxy must already be running.
+The action comes first. Every value is a flag; there are no positional arguments. Flags may sit in any order after the action.
 
-`start` prints a session id. Every other action takes it as `--session-id <id>`. Then `./ctrl test start` ties that session to the result id from the Linear ticket.
+- `--agent-id <agent>` — your id, from the Linear ticket. Required on every action.
+- `--server-url <url>` — the proxy, a full URL used exactly as given. Falls back to `SERVER_URL` from the environment, then `http://127.0.0.1:42069`.
+- `OLIGARCHY_TOKEN` — read from the environment and sent on every request. It is already set; do not write a `.env`. Missing means exit 1.
 
-A command that works exits 0. A command that fails exits 1 and prints the error: one headline, then the stack trace and the cause behind it. Read the headline first. `./client <action> --help` prints that action's flags.
-
-If no command arrives for ten minutes, the proxy kills the session.
+`start` prints a session id; every other action takes it as `--session-id`. A command that works exits 0. A command that fails exits 1 and prints the error: one headline, then the stack trace and the cause behind it. Read the headline first. `./client <action> --help` prints that action's flags. If no command arrives for ten minutes, the proxy kills the session.
 
 ## start
 
-Boots a QEMU session and prints its session id.
-
-```bash
-./client start --agent-id <agent> --server-url <url>
-./client start --agent-id <agent> --server-url <url> --iso omarchy.iso
-./client start --agent-id <agent> --server-url <url> --iso https://example.com/omarchy.iso
-./client start --agent-id <agent> --server-url <url> --iso omarchy.iso --disk disk.qcow2
+```
+./client start --agent-id <agent> --server-url <url> [--iso <path|url>] [--disk <path>]
 ```
 
-- `--iso` defaults to `omarchy.iso` in the current directory. A local path must exist. An http(s) URL is passed through; the server downloads and caches it.
-- `--disk` is optional. Omit it and the server creates a fresh disk.
+Boots a QEMU session and prints its session id.
+
+- `--iso <path|url>` — the ISO. A local path must exist; an http(s) URL is downloaded and cached by the server. Default `omarchy.iso` in the current directory.
+- `--disk <path>` — an existing qcow2 disk. Omit it and the server creates a fresh one.
+
+```bash
+./client start --agent-id OLI-42 --server-url https://qemu.example.com --iso https://example.com/omarchy.iso
+```
 
 ## get-image
 
-Captures the guest display as a PNG. This is the only view of a headless session. Look before you type.
-
-```bash
-./client get-image --agent-id <agent> --server-url <url> --session-id <id> -o desktop.png
-./client get-image --agent-id <agent> --server-url <url> --session-id <id> > desktop.png
+```
+./client get-image --agent-id <agent> --server-url <url> --session-id <id> [-o <file>]
 ```
 
-`-o` / `--output` is optional. Without it, PNG bytes go to stdout.
+Captures the guest display as a PNG. This is the only view of a headless session. Look before you type.
+
+- `--session-id <id>` — the session.
+- `-o <file>`, `--output <file>` — write the PNG here. Without it, PNG bytes go to stdout.
+
+```bash
+./client get-image --agent-id OLI-42 --server-url https://qemu.example.com --session-id 6f1c...e2a9 -o desktop.png
+```
 
 ## get-serial
 
-Reads everything the guest has written to `/dev/ttyS0` since boot. Empty until something writes. Use this when the desktop is dead and you need logs.
-
-```bash
-./client get-serial --agent-id <agent> --server-url <url> --session-id <id> -o journal.txt
-./client get-serial --agent-id <agent> --server-url <url> --session-id <id>
+```
+./client get-serial --agent-id <agent> --server-url <url> --session-id <id> [-o <file>]
 ```
 
-`-o` / `--output` is optional. Without it, bytes go to stdout.
+Reads everything the guest has written to `/dev/ttyS0` since boot. Empty until something writes. Use it when the desktop is dead and you need logs: switch to a TTY with `<C-A-F3>`, log in, `sudo systemctl stop serial-getty@ttyS0`, then `journalctl -b --no-pager | sudo tee /dev/ttyS0` (`--user` for a user-session failure), then read the serial. `/dev/ttyS0` is root:uucp — a user redirect is permission denied.
 
-To dump the journal onto serial: switch to a TTY, log in, stop the serial getty, then tee the journal. `/dev/ttyS0` is root:uucp — a user redirect is permission denied.
+- `--session-id <id>` — the session.
+- `-o <file>`, `--output <file>` — write the text here. Without it, bytes go to stdout.
 
 ```bash
-./client send-keys --agent-id <agent> --server-url <url> --session-id <id> --keys "<C-A-F3>"
-./client send-keys --agent-id <agent> --server-url <url> --session-id <id> --keys "sudo systemctl stop serial-getty@ttyS0<ENTER>"
-./client send-keys --agent-id <agent> --server-url <url> --session-id <id> --keys "journalctl -b --no-pager | sudo tee /dev/ttyS0<ENTER>"
-./client get-serial --agent-id <agent> --server-url <url> --session-id <id> -o journal.txt
+./client get-serial --agent-id OLI-42 --server-url https://qemu.example.com --session-id 6f1c...e2a9 -o journal.txt
 ```
-
-Image until the login prompt before typing the username and password. If sudo asks, send the user password. User-session failures are `journalctl --user -b --no-pager | sudo tee /dev/ttyS0`.
 
 ## send-keys
 
-Types a key string into the session. Quote the string so the shell does not eat `<`, `>`, or spaces.
-
-```bash
-./client send-keys --agent-id <agent> --server-url <url> --session-id <id> --keys "hello"
-./client send-keys --agent-id <agent> --server-url <url> --session-id <id> --keys "hello<ENTER>"
-./client send-keys --agent-id <agent> --server-url <url> --session-id <id> --keys "<C-c>"
+```
+./client send-keys --agent-id <agent> --server-url <url> --session-id <id> --keys <keys> [--encoding <encoding>]
 ```
 
-`--encoding` defaults to `oligarchy`. You do not need to pass it. See [Keys](#keys).
+Types a key string into the session.
+
+- `--session-id <id>` — the session.
+- `--keys <keys>` — the key string, in the `oligarchy` encoding. See [Keys](#keys). Quote it so the shell keeps `<`, `>`, and spaces.
+- `--encoding <encoding>` — the key string's encoding. Default `oligarchy`; you do not need to pass it.
+
+```bash
+./client send-keys --agent-id OLI-42 --server-url https://qemu.example.com --session-id 6f1c...e2a9 --keys "hello<ENTER>"
+```
 
 ## send-mouse
 
-Moves the pointer, and optionally clicks or scrolls, at a point on the screenshot.
-
-```bash
-./client send-mouse --agent-id <agent> --server-url <url> --session-id <id> --x 0.5 --y 0.5
-./client send-mouse --agent-id <agent> --server-url <url> --session-id <id> --x 0.5 --y 0.5 --button left
-./client send-mouse --agent-id <agent> --server-url <url> --session-id <id> --x 0.3 --y 0.2 --button left --clicks 2
-./client send-mouse --agent-id <agent> --server-url <url> --session-id <id> --x 0.8 --y 0.1 --button right
-./client send-mouse --agent-id <agent> --server-url <url> --session-id <id> --x 0.5 --y 0.5 --button wheel-down --clicks 3
+```
+./client send-mouse --agent-id <agent> --server-url <url> --session-id <id> --x <0..1> --y <0..1> [--button <button>] [--clicks <n>]
 ```
 
-`--x` and `--y` are fractions of the screenshot, `0..1` from the top-left. Omit `--button` to move only. `--button` is `left`, `middle`, `right`, `wheel-up`, or `wheel-down`. `--clicks` defaults to 1 and needs `--button` — a double-click is `--button left --clicks 2`. See [Mouse](#mouse).
+Moves the pointer to a point on the screenshot, and optionally clicks or scrolls there.
 
-## intent
-
-Declares what you are about to do on the session, before you do it. Required around every action: start an intent, run the commands that fulfill it, end it. One intent may cover many commands, sleeps, and images. One intent is active at a time: a second start while one is open fails with `Cannot start one intent when one's already running. Please end your previous intent.`, and so does an end with none open. End the open intent before `stop`.
+- `--session-id <id>` — the session.
+- `--x <0..1>`, `--y <0..1>` — fractions of the screenshot from the top-left. See [Mouse](#mouse).
+- `--button <button>` — `left`, `middle`, `right`, `wheel-up`, or `wheel-down`. Omit to move only.
+- `--clicks <n>` — how many times to pulse `--button`, 1..100. Default 1. Needs `--button`.
 
 ```bash
-./client intent start --agent-id <agent> --server-url <url> --session-id <id> --test-result-id <result> --message "wait for the boot menu"
+./client send-mouse --agent-id OLI-42 --server-url https://qemu.example.com --session-id 6f1c...e2a9 --x 0.3 --y 0.2 --button left --clicks 2
+```
+
+## intent start
+
+```
+./client intent start --agent-id <agent> --server-url <url> --session-id <id> --test-result-id <id> --message <text>
+```
+
+Declares what you are about to do on the session, before you do it. One intent is active at a time: a second start while one is open fails with `Cannot start one intent when one's already running. Please end your previous intent.` One intent may cover many commands, sleeps, and images.
+
+- `--session-id <id>` — the session.
+- `--test-result-id <id>` — the result id from your Linear ticket.
+- `--message <text>` — what you are about to do. Quote it so the shell keeps spaces.
+
+```bash
+./client intent start --agent-id OLI-42 --server-url https://qemu.example.com --session-id 6f1c...e2a9 --test-result-id 2222...2222 --message "wait for the boot menu"
+```
+
+## intent end
+
+```
 ./client intent end --agent-id <agent> --server-url <url> --session-id <id>
 ```
 
-`--test-result-id` is the result id from your Linear ticket. Quote `--message` so the shell keeps spaces.
+Ends the open intent. Ending with none open fails. End the open intent before `stop`.
+
+- `--session-id <id>` — the session.
+
+```bash
+./client intent end --agent-id OLI-42 --server-url https://qemu.example.com --session-id 6f1c...e2a9
+```
 
 ## stop
 
-Kills the session. `--agent-id` must be the agent that started it.
-
-```bash
-./client stop --agent-id <agent> --server-url <url> --session-id <id>
-./client stop --agent-id <agent> --server-url <url> --session-id <id> --status succeeded
-./client stop --agent-id <agent> --server-url <url> --session-id <id> --status failed --reason "installer hung"
+```
+./client stop --agent-id <agent> --server-url <url> --session-id <id> [--status succeeded|failed|aborted] [--reason <text>]
 ```
 
-A stop with no `--status` is an abort. `--status` is `succeeded`, `failed`, or `aborted`. `--reason` is optional text.
+Kills the session. `--agent-id` must be the agent that started it.
+
+- `--session-id <id>` — the session.
+- `--status <status>` — the verdict: `succeeded`, `failed`, or `aborted`. Omit it and the stop is an abort.
+- `--reason <text>` — optional text stored with the verdict.
+
+```bash
+./client stop --agent-id OLI-42 --server-url https://qemu.example.com --session-id 6f1c...e2a9 --status failed --reason "installer hung"
+```
 
 ## Keys
 
@@ -164,7 +193,7 @@ A greeter or installer button is a left click at that point. A double-click laun
 
 ## The loop
 
-Every guest action — keys, mouse, images — runs inside an [intent](#intent): start one that says what you are about to do, do the work, end it. Only `start`, `./ctrl`, and `stop` sit outside one.
+Every guest action — keys, mouse, images — runs inside an intent: start one that says what you are about to do, do the work, end it. Only `start`, `./ctrl`, and `stop` sit outside one.
 
 Send keys or mouse, wait about three seconds, take an image, read it, decide. That is the whole method. Never sleep more than ten seconds between actions. When something genuinely slow is running, keep taking images instead of trusting a long sleep.
 

--- a/ctrl-linear.md
+++ b/ctrl-linear.md
@@ -2,33 +2,41 @@
 
 `./ctrl` records the outcome of the test you are driving. You use exactly two of its commands: `test start` right after `./client start`, and `test-results` right before `./client stop`. Do not look at code. Run the commands.
 
-## Environment
+```
+./ctrl test start   --server-url <url> --session-id <id> --test-result-id <id>
+./ctrl test-results --agent-id <agent> --server-url <url> --id <id> --status success|failed [--reason <text>]
+```
 
-`DATABASE_URL` is already in this process. Use it. Do not write a `.env`. A missing `DATABASE_URL` exits 1 — stop.
-
-## Invoke
-
-The action comes first. Every action takes `--server-url <url>`, the same server URL you pass to `./client`; it may sit anywhere after the action. When omitted, `SERVER_URL` from the environment is used. There is no default.
-
-A command that works exits 0. A command that fails exits 1 and prints the error: one headline, then the stack trace and the cause behind it. Read the headline first. `./ctrl <action> --help` prints that action's flags.
+Every value is a flag. `--server-url` is the same URL you pass to `./client`; it falls back to `SERVER_URL` from the environment and has no default. `DATABASE_URL` is already in this process; do not write a `.env`. A command that works exits 0. A command that fails exits 1 and prints the error: one headline, then the stack trace and the cause behind it. Read the headline first. `./ctrl <action> --help` prints that action's flags.
 
 ## test start
 
-Ties your pending test result to the session you just booted. Run it once, before your first intent.
-
-```bash
-./ctrl test start --server-url <url> --session-id <id> --test-result-id <result-id>
+```
+./ctrl test start --server-url <url> --session-id <id> --test-result-id <id>
 ```
 
-`--session-id` is the id printed by `./client start`. `--test-result-id` is the result UUID from your Linear ticket. An unknown session, or a result that is missing or not pending, is a failure.
+Ties your pending test result to the session you just booted. Run it once, before your first intent. An unknown session, or a result that is missing or not pending, is a failure.
+
+- `--session-id <id>` — the id printed by `./client start`.
+- `--test-result-id <id>` — the result UUID from your Linear ticket.
+
+```bash
+./ctrl test start --server-url https://qemu.example.com --session-id 6f1c...e2a9 --test-result-id 2222...2222
+```
 
 ## test-results
 
-Closes your test result with the verdict. Run it once, after the proof is on screen and before `./client stop`.
-
-```bash
-./ctrl test-results --agent-id <agent> --server-url <url> --id <result-id> --status success
-./ctrl test-results --agent-id <agent> --server-url <url> --id <result-id> --status failed --reason "installer hung"
+```
+./ctrl test-results --agent-id <agent> --server-url <url> --id <id> --status success|failed [--reason <text>]
 ```
 
-`--agent-id` is your agent id, the same one you pass to `./client`. `--id` is the result UUID from your Linear ticket. `--status` is `success` or `failed`. `--reason` is optional text stored on the result.
+Closes your test result with the verdict. Run it once, after the proof is on screen and before `./client stop`.
+
+- `--agent-id <agent>` — your agent id, the same one you pass to `./client`.
+- `--id <id>` — the result UUID from your Linear ticket.
+- `--status <status>` — `success` or `failed`.
+- `--reason <text>` — optional text stored on the result.
+
+```bash
+./ctrl test-results --agent-id OLI-42 --server-url https://qemu.example.com --id 2222...2222 --status failed --reason "installer hung"
+```

--- a/ctrl.md
+++ b/ctrl.md
@@ -4,124 +4,164 @@ Consult this table of contents first. Read only the section you need.
 
 | Section | Line |
 |---------|-----:|
-| [Important](#important) | 19 |
-| [Environment](#environment) | 25 |
-| [Invoke](#invoke) | 29 |
-| [test](#test) | 39 |
-| [test new](#test-new) | 52 |
-| [test list](#test-list) | 63 |
-| [test run](#test-run) | 73 |
-| [test start](#test-start) | 83 |
-| [test-results](#test-results) | 93 |
-| [session list](#session-list) | 104 |
-| [session](#session) | 115 |
+| [Important](#important) | 18 |
+| [Synopsis](#synopsis) | 24 |
+| [test --list](#test---list) | 46 |
+| [test new](#test-new) | 62 |
+| [test list](#test-list) | 78 |
+| [test run](#test-run) | 90 |
+| [test start](#test-start) | 104 |
+| [test-results](#test-results) | 119 |
+| [session list](#session-list) | 136 |
+| [session](#session) | 150 |
 
 ## Important
 
-`./ctrl` is the control plane's record keeper: it creates test runs, opens their Linear tickets, spawns driving agents, ties a session to its result, closes the result, and reads a session back. It never touches a guest — that is `./client`.
+`./ctrl` is the control plane's record keeper: it creates test runs, opens their Linear tickets, spawns driving agents, ties a session to its result, closes the result, and reads sessions back. It never touches a guest — that is `./client`.
 
 If you are an agent driving a guest, you need two of these: [test start](#test-start) after `./client start`, and [test-results](#test-results) before `./client stop`. Do not look at code. Run the commands.
 
-## Environment
+## Synopsis
 
-`DATABASE_URL` is read by every action; a missing one exits 1. `test new` and `test list` also read `LINEAR_API_TOKEN`. `test run` also reads `CURSOR_API_TOKEN`. A `.env` in the current directory fills in missing variables only; already-set values win.
-
-## Invoke
-
-The action comes first. Every action takes `--server-url <url>`, the oligarchy server as a full http or https URL; it may sit anywhere after the action. When omitted, `SERVER_URL` from the environment is used. There is no default: an action with neither fails.
-
-```bash
-./ctrl <action> --server-url <url> ...
 ```
+./ctrl <action> --server-url <url> ...
+
+./ctrl test --list    [--details] [--name <definition>]
+./ctrl test new       --iso <https-url> --version <version> [--name <definition>]
+./ctrl test list
+./ctrl test run       --ticket <linear-ticket>
+./ctrl test start     --session-id <id> --test-result-id <id>
+./ctrl test-results   --agent-id <agent> --id <id> --status success|failed [--reason <text>]
+./ctrl session list   [--count <n>]
+./ctrl session        --session-id <id> --logs|--test-def|--test-results|--actions|--all
+```
+
+The action comes first. Every value is a flag; there are no positional arguments. Flags may sit in any order after the action.
+
+- `--server-url <url>` — the oligarchy server, a full http or https URL. Required on every action; falls back to `SERVER_URL` from the environment. There is no default.
+- `DATABASE_URL` — read from the environment by every action. `test new` and `test list` also read `LINEAR_API_TOKEN`; `test run` also reads `CURSOR_API_TOKEN`. A `.env` in the current directory fills in missing variables only. A missing variable means exit 1.
 
 A command that works exits 0. A command that fails exits 1 and prints the error: one headline, then the stack trace and the cause behind it. Read the headline first. `./ctrl <action> --help` prints that action's flags.
 
-## test
+## test --list
 
-Lists stored test definitions. `--list` is required. Not used while driving a guest.
-
-```bash
-./ctrl test --list
-./ctrl test --list --details
-./ctrl test --list --name lock-screen
-./ctrl test --list --details --name lock-screen
+```
+./ctrl test --list --server-url <url> [--details] [--name <definition>]
 ```
 
-`--list` prints one name per line. `--details` prints every field as JSON. `--name` limits the listing to one definition. A missing `--list` is a failure. A name that matches no definition is a failure.
+Lists stored test definitions, one name per line. Not used while driving a guest.
+
+- `--list` — required.
+- `--details` — print every field of each definition as JSON instead of the name.
+- `--name <definition>` — only this definition. A name that matches none is a failure.
+
+```bash
+./ctrl test --list --server-url https://qemu.example.com --details --name lock-screen
+```
 
 ## test new
 
-Creates one pending test run and one Linear issue per stored test definition. Pass `--name` to create a run for one existing definition instead of every definition. Not used while driving a guest. Reads `LINEAR_API_TOKEN`.
+```
+./ctrl test new --server-url <url> --iso <https-url> --version <version> [--name <definition>]
+```
+
+Creates one pending test run and one Linear issue per stored test definition, and prints them as JSON. `--server-url` is stored on the run and written into every issue as the proxy the driving agent talks to. Not used while driving a guest. Reads `LINEAR_API_TOKEN`.
+
+- `--iso <https-url>` — the ISO the agents boot. Must be HTTPS.
+- `--version <version>` — the version label attached to every issue.
+- `--name <definition>` — create a run for this one definition instead of every definition. A name that matches none is a failure.
 
 ```bash
 ./ctrl test new --server-url https://qemu.example.com --iso https://example.com/omarchy.iso --version 1.2.3
-./ctrl test new --server-url https://qemu.example.com --iso https://example.com/omarchy.iso --version 1.2.3 --name "Install Omarchy"
 ```
-
-`--iso` must be an HTTPS URL. `--server-url` (or `SERVER_URL`) is stored on the run and written into every Linear issue as the proxy the driving agent talks to. `--version` is required. `--name` is the stored definition's name. A name that matches no definition is a failure. The command prints the run and its Linear issues as JSON.
 
 ## test list
 
-Prints every Linear issue on the Oligarchy team whose status type is backlog. Not used while driving a guest. Reads `LINEAR_API_TOKEN`.
+```
+./ctrl test list --server-url <url>
+```
+
+Prints every Linear issue on the Oligarchy team whose status type is backlog, as JSON: `id`, `identifier`, `title`, `url`. An empty backlog prints `[]`. Not used while driving a guest. Reads `LINEAR_API_TOKEN`.
 
 ```bash
 ./ctrl test list --server-url https://qemu.example.com
 ```
 
-Each issue is printed as JSON: `id`, `identifier`, `title`, and `url`. An empty backlog prints `[]`.
-
 ## test run
 
-Spawns a Cursor cloud agent that drives one Linear ticket. Not used while driving a guest. Reads `CURSOR_API_TOKEN`.
+```
+./ctrl test run --server-url <url> --ticket <linear-ticket>
+```
+
+Spawns a Cursor cloud agent that drives one Linear ticket, told to pass `--server-url` on every `./client` and `./ctrl` command. Prints a link to the agent as soon as it starts; does not wait for it. Not used while driving a guest. Reads `CURSOR_API_TOKEN`.
+
+- `--ticket <linear-ticket>` — the issue identifier created by `test new`.
 
 ```bash
 ./ctrl test run --server-url https://qemu.example.com --ticket OLI-42
 ```
 
-`--ticket` is the Linear issue identifier created by `test new`. The agent is told to pass `--server-url` on every `./client` and `./ctrl` command. The command prints a link to the agent as soon as it is started and does not wait for it to finish.
-
 ## test start
 
-Ties a pending test result to the session that is running it. The result already names its definition; pass the result id and the session id only.
-
-```bash
-./ctrl test start --server-url <url> --session-id <id> --test-result-id <result-id>
+```
+./ctrl test start --server-url <url> --session-id <id> --test-result-id <id>
 ```
 
-`--session-id` is the id printed by `./client start`. `--test-result-id` is the result UUID from the Linear issue. An unknown session, or a result that is missing or not pending, is a failure.
+Ties a pending test result to the session that is running it. The result already names its definition. An unknown session, or a result that is missing or not pending, is a failure.
+
+- `--session-id <id>` — the id printed by `./client start`.
+- `--test-result-id <id>` — the result UUID from the Linear issue.
+
+```bash
+./ctrl test start --server-url https://qemu.example.com --session-id 6f1c...e2a9 --test-result-id 2222...2222
+```
 
 ## test-results
 
-Closes one pending test result. `--agent-id` is required: that agent's session is looked up and recorded on the result.
-
-```bash
-./ctrl test-results --agent-id <agent> --server-url <url> --id <result-id> --status success
-./ctrl test-results --agent-id <agent> --server-url <url> --id <result-id> --status failed --reason "installer hung"
+```
+./ctrl test-results --agent-id <agent> --server-url <url> --id <id> --status success|failed [--reason <text>]
 ```
 
-`--id` is the result UUID from the Linear issue. `--status` is `success` or `failed`. `--reason` is optional text stored on the result row.
+Closes one pending test result with the verdict.
+
+- `--agent-id <agent>` — your id; that agent's session is looked up and recorded on the result.
+- `--id <id>` — the result UUID from the Linear issue.
+- `--status <status>` — `success` or `failed`.
+- `--reason <text>` — optional text stored on the result.
+
+```bash
+./ctrl test-results --agent-id OLI-42 --server-url https://qemu.example.com --id 2222...2222 --status failed --reason "installer hung"
+```
 
 ## session list
 
-Prints the most recent sessions, newest first, as JSON. Not used while driving a guest.
-
-```bash
-./ctrl session list --server-url <url>
-./ctrl session list --server-url <url> --count 25
+```
+./ctrl session list --server-url <url> [--count <n>]
 ```
 
-`--count` is how many sessions to print, default 10; it must be at least 1. Each row is the session as stored: `id`, `config`, `status`, `reason`, `startedAt`, `endedAt`.
+Prints the most recent sessions, newest first, as JSON rows: `id`, `config`, `status`, `reason`, `startedAt`, `endedAt`. Not used while driving a guest.
+
+- `--count <n>` — how many sessions to print, at least 1. Default 10.
+
+```bash
+./ctrl session list --server-url https://qemu.example.com --count 25
+```
 
 ## session
 
-Prints stored logs, the test definition, the test result, and actions for a session. Not used while driving a guest.
-
-```bash
-./ctrl session --server-url <url> --session-id <id> --logs
-./ctrl session --server-url <url> --session-id <id> --test-def
-./ctrl session --server-url <url> --session-id <id> --test-results
-./ctrl session --server-url <url> --session-id <id> --actions
-./ctrl session --server-url <url> --session-id <id> --all
+```
+./ctrl session --server-url <url> --session-id <id> --logs|--test-def|--test-results|--actions|--all
 ```
 
-`--session-id` is required. At least one of `--logs`, `--test-def`, `--test-results`, `--actions`, or `--all` is required. A single selector prints that value as JSON. `--all` prints `{ logs, results, test_definition, actions }`. An unknown session is a failure.
+Prints what is stored for one session, as JSON. At least one selector is required; one selector prints that value, several print an object keyed by them. An unknown session is a failure. Not used while driving a guest.
+
+- `--session-id <id>` — the session.
+- `--logs` — its log lines, oldest first.
+- `--test-def` — the test definition its result ran, or `null`.
+- `--test-results` — the test result attributed to it, or `null`.
+- `--actions` — its QMP actions, oldest first.
+- `--all` — all four: `{ logs, results, test_definition, actions }`.
+
+```bash
+./ctrl session --server-url https://qemu.example.com --session-id 6f1c...e2a9 --all
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The three driving guides are restructured into man-page shape. Each begins with a synopsis of every action; then each action gets one synopsis line, each flag with a one-line description, and exactly one example. The four-examples-per-command repetition is gone.

`client.md`:

```
./client <action> --agent-id <agent> [--server-url <url>] ...

./client start      [--iso <path|url>] [--disk <path>]
./client get-image  --session-id <id> [-o <file>]
./client get-serial --session-id <id> [-o <file>]
./client send-keys  --session-id <id> --keys <keys> [--encoding <encoding>]
./client send-mouse --session-id <id> --x <0..1> --y <0..1> [--button <button>] [--clicks <n>]
./client intent start --session-id <id> --test-result-id <id> --message <text>
./client intent end   --session-id <id>
./client stop       --session-id <id> [--status succeeded|failed|aborted] [--reason <text>]
```

`Keys`, `Mouse`, and `The loop` are unchanged. `get-image` and `get-serial` keep the optional `-o` / `--output`. `ctrl.md` and `ctrl-linear.md` take the same shape. The shared flags and environment (`--agent-id`, `--server-url` / `SERVER_URL`, `OLIGARCHY_TOKEN`; `DATABASE_URL` and the per-action tokens for `ctrl`) are described once under the synopsis instead of per action.

## Verification

Docs only. TOC line numbers regenerated and every entry lands on its heading. `src/linear.test.ts`, which renders `client.md` and `ctrl-linear.md` into the Linear ticket body and asserts on their headings and on the absence of positional forms, passes (9/9). `./client --help` and `./ctrl --help` already list the same forms as the synopses.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db7d6ec6-c65a-4a25-9316-af688ddb619e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db7d6ec6-c65a-4a25-9316-af688ddb619e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

