### PR TITLE
ctrl session list: colored status, relative age, and id per line instead of JSON

### DIFF
--- a/ctrl.md
+++ b/ctrl.md
@@ -139,7 +139,7 @@ Closes one pending test result with the verdict.
 ./ctrl session list --server-url <url> [--count <n>]
 ```
 
-Prints the most recent sessions, newest first, as JSON rows: `id`, `config`, `status`, `reason`, `startedAt`, `endedAt`. Not used while driving a guest.
+Prints the most recent sessions, newest first, one per line: the status, colored (green `succeeded`, red `failed`, yellow `running`, gray `downloading`, bright red `aborted`, magenta `timed_out`); how long ago it started (`45s ago`, `12m ago`, `1h30m ago`, `3d5h ago`); then the session id. Not used while driving a guest.
 
 - `--count <n>` — how many sessions to print, at least 1. Default 10.
 

--- a/field-guide/cli.md
+++ b/field-guide/cli.md
@@ -125,7 +125,7 @@ Closes one pending test result. `--id` is the result UUID printed on the Linear 
 
 ### session list
 
-Prints the most recent sessions as JSON, newest first: `SELECT * FROM sessions ORDER BY started_at DESC, id DESC LIMIT <count>`. `--count` defaults to 10 and must be at least 1. `session.ts` exports `sessionRun`, a switch like `testRun`'s: `list` goes to `sessionListRun`, anything else to `sessionInspectRun` below.
+Prints the most recent sessions for a human, newest first: `SELECT id, status, started_at FROM sessions ORDER BY started_at DESC, id DESC LIMIT <count>`, one line each. The status comes first, padded to a column and colored by ANSI SGR code — green `succeeded`, red `failed`, yellow `running`, gray `downloading`, bright red `aborted`, magenta `timed_out` — then how long ago the session started, then the id in the terminal's default color. The age is a plain calculation, not a package: seconds under a minute (`45s ago`), minutes under an hour (`12m ago`), hours with leftover minutes under a day (`1h30m ago`, `2h ago`), else days with leftover hours (`3d5h ago`). It is clamped at `0s ago`, because the row's clock is the database's and can sit a few seconds ahead of the machine running `ctrl`. `--count` defaults to 10 and must be at least 1. `session.ts` exports `sessionRun`, a switch like `testRun`'s: `list` goes to `sessionListRun`, anything else to `sessionInspectRun` below.
 
 ### session
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ctrl": "node --experimental-strip-types src/ctrl/index.ts",
     "session": "node --experimental-strip-types src/session/index.ts",
     "dev": "wrangler dev --remote",
-    "test": "node --test --experimental-strip-types src/client.test.ts src/ctrl.test.ts src/session.test.ts src/ctrl/actions/test.test.ts src/linear.test.ts src/cursor-agent/client.test.ts src/qmp/json-stream.test.ts src/qemu/client.test.ts src/qemu/keys.test.ts src/sentry.test.ts",
+    "test": "node --test --experimental-strip-types src/client.test.ts src/ctrl.test.ts src/session.test.ts src/ctrl/actions/test.test.ts src/ctrl/actions/session.test.ts src/linear.test.ts src/cursor-agent/client.test.ts src/qmp/json-stream.test.ts src/qemu/client.test.ts src/qemu/keys.test.ts src/sentry.test.ts",
     "lint": "oxlint --type-aware --type-check",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "node --experimental-strip-types src/db/migrate.ts"

--- a/src/ctrl.test.ts
+++ b/src/ctrl.test.ts
@@ -206,21 +206,26 @@ describe("./ctrl happy path", () => {
     assert.match(result.stdout, /session --session-id/);
   });
 
-  it("session list prints the last ten sessions, newest first, as JSON", async () => {
+  it("session list prints the last ten sessions as colored status, age, and id lines, newest first", async () => {
     const result = await runCtrl(["session", "list", "--server-url", SERVER]);
     assert.equal(result.stderr, "");
     assert.equal(result.code, 0);
-    const rows = JSON.parse(result.stdout) as { id: string; status: string; startedAt: string; config: unknown }[];
-    assert.ok(Array.isArray(rows));
-    assert.ok(rows.length <= 10);
-    for (const row of rows) {
-      assert.match(row.id, /^[0-9a-f-]{36}$/);
-      assert.equal(typeof row.status, "string");
-      assert.ok(row.config !== undefined);
-      assert.ok(Number.isFinite(Date.parse(row.startedAt)));
+    assert.equal(result.stdout.includes("{"), false);
+    const lines = result.stdout.split("\n").filter((line) => line !== "");
+    assert.ok(lines.length <= 10);
+    const ages: number[] = [];
+    for (const line of lines) {
+      const [status, rest, ...extra] = line.split("\x1b[0m");
+      assert.deepEqual(extra, [], `unexpected session list line: ${JSON.stringify(line)}`);
+      assert.ok(status.startsWith("\x1b["), `status is not colored: ${JSON.stringify(line)}`);
+      assert.match(status.slice(status.indexOf("m") + 1), /^(downloading|running|succeeded|failed|aborted|timed_out) *$/);
+      const match = rest.match(/^ {2}((?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)? ago) *  ([0-9a-f-]{36})$/);
+      assert.ok(match !== null, `unexpected session list line: ${JSON.stringify(line)}`);
+      const [, , days = "0", hours = "0", minutes = "0", seconds = "0"] = match;
+      ages.push(((Number(days) * 24 + Number(hours)) * 60 + Number(minutes)) * 60 + Number(seconds));
     }
-    for (let i = 1; i < rows.length; i++) {
-      assert.ok(Date.parse(rows[i - 1].startedAt) >= Date.parse(rows[i].startedAt));
+    for (let i = 1; i < ages.length; i++) {
+      assert.ok(ages[i - 1] <= ages[i]);
     }
   });
 
@@ -228,12 +233,12 @@ describe("./ctrl happy path", () => {
     const two = await runCtrl(["session", "list", "--count", "2", "--server-url", SERVER]);
     assert.equal(two.stderr, "");
     assert.equal(two.code, 0);
-    assert.ok((JSON.parse(two.stdout) as unknown[]).length <= 2);
+    assert.ok(two.stdout.split("\n").filter((line) => line !== "").length <= 2);
 
     const one = await runCtrl(["session", "list", "--count=1"], { SERVER_URL: SERVER });
     assert.equal(one.stderr, "");
     assert.equal(one.code, 0);
-    assert.ok((JSON.parse(one.stdout) as unknown[]).length <= 1);
+    assert.ok(one.stdout.split("\n").filter((line) => line !== "").length <= 1);
   });
 
   it("session --help names both forms", async () => {
@@ -429,7 +434,7 @@ describe("./ctrl unhappy path", () => {
   it("session list rejects a count below one, a non-integer count, and the inspect flags", async () => {
     const zero = await runCtrl(["session", "list", "--count", "0", "--server-url", SERVER]);
     assert.notEqual(zero.code, 0);
-    assert.equal(zero.stdout.startsWith("["), false);
+    assert.doesNotMatch(zero.stdout, / ago {2,}[0-9a-f-]{36}$/m);
     assert.match(zero.stderr, /Invalid value for flag --count: "0".*count must be at least 1/);
 
     const word = await runCtrl(["session", "list", "--count", "ten", "--server-url", SERVER]);

--- a/src/ctrl/actions/session.test.ts
+++ b/src/ctrl/actions/session.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it, mock } from "node:test";
+import { printSessions } from "./session.ts";
+
+afterEach(() => mock.restoreAll());
+
+const NOW = Date.parse("2026-09-04T12:00:00Z");
+const RESET = "\x1b[0m";
+
+function ago(seconds: number): Date {
+  return new Date(NOW - seconds * 1000);
+}
+
+function printed(rows: Parameters<typeof printSessions>[0]): string[] {
+  mock.method(Date, "now", () => NOW);
+  const log = mock.method(console, "log", () => undefined);
+  printSessions(rows);
+  return log.mock.calls.map((call) => call.arguments.join(" "));
+}
+
+describe("printSessions happy path", () => {
+  it("prints one line per session in the order given: colored status, age, then the plain id", () => {
+    const lines = printed([
+      { id: "d889e62f-212a-4ee4-a299-7e21b02b5308", status: "running", startedAt: ago(5) },
+      { id: "ff88a0b1-0851-47a7-91d3-acbfb20b8673", status: "succeeded", startedAt: ago(90) },
+    ]);
+    assert.deepEqual(lines, [
+      `\x1b[33mrunning    ${RESET}  5s ago       d889e62f-212a-4ee4-a299-7e21b02b5308`,
+      `\x1b[32msucceeded  ${RESET}  1m ago       ff88a0b1-0851-47a7-91d3-acbfb20b8673`,
+    ]);
+  });
+
+  it("colors every status: green succeeded, red failed, yellow running, gray downloading, bright red aborted, magenta timed_out", () => {
+    const lines = printed([
+      { id: "00000000-0000-4000-8000-000000000001", status: "succeeded", startedAt: ago(1) },
+      { id: "00000000-0000-4000-8000-000000000002", status: "failed", startedAt: ago(1) },
+      { id: "00000000-0000-4000-8000-000000000003", status: "running", startedAt: ago(1) },
+      { id: "00000000-0000-4000-8000-000000000004", status: "downloading", startedAt: ago(1) },
+      { id: "00000000-0000-4000-8000-000000000005", status: "aborted", startedAt: ago(1) },
+      { id: "00000000-0000-4000-8000-000000000006", status: "timed_out", startedAt: ago(1) },
+    ]);
+    assert.deepEqual(
+      lines.map((line) => line.slice(0, line.indexOf(RESET))),
+      [
+        "\x1b[32msucceeded  ",
+        "\x1b[31mfailed     ",
+        "\x1b[33mrunning    ",
+        "\x1b[90mdownloading",
+        "\x1b[91maborted    ",
+        "\x1b[35mtimed_out  ",
+      ],
+    );
+    for (const line of lines) {
+      assert.match(line.slice(line.indexOf(RESET) + RESET.length), /^  1s ago       00000000-0000-4000-8000-00000000000\d$/);
+    }
+  });
+
+  it("renders the age as seconds, minutes, hours with minutes, whole hours, and days with hours", () => {
+    const lines = printed([
+      { id: "00000000-0000-4000-8000-000000000001", status: "running", startedAt: ago(0) },
+      { id: "00000000-0000-4000-8000-000000000002", status: "running", startedAt: ago(59) },
+      { id: "00000000-0000-4000-8000-000000000003", status: "running", startedAt: ago(60) },
+      { id: "00000000-0000-4000-8000-000000000004", status: "running", startedAt: ago(59 * 60 + 59) },
+      { id: "00000000-0000-4000-8000-000000000005", status: "running", startedAt: ago(60 * 60) },
+      { id: "00000000-0000-4000-8000-000000000006", status: "running", startedAt: ago(90 * 60) },
+      { id: "00000000-0000-4000-8000-000000000007", status: "running", startedAt: ago(23 * 60 * 60 + 59 * 60) },
+      { id: "00000000-0000-4000-8000-000000000008", status: "running", startedAt: ago(24 * 60 * 60) },
+      { id: "00000000-0000-4000-8000-000000000009", status: "running", startedAt: ago(3 * 24 * 60 * 60 + 5 * 60 * 60 + 40 * 60) },
+    ]);
+    assert.deepEqual(
+      lines.map((line) => line.slice(line.indexOf(RESET) + RESET.length + 2, line.lastIndexOf("  "))),
+      ["0s ago     ", "59s ago    ", "1m ago     ", "59m ago    ", "1h ago     ", "1h30m ago  ", "23h59m ago ", "1d ago     ", "3d5h ago   "],
+    );
+  });
+});
+
+describe("printSessions unhappy path", () => {
+  it("prints nothing for no sessions", () => {
+    assert.deepEqual(printed([]), []);
+  });
+
+  it("renders a session started ahead of this clock as 0s ago, never a negative age", () => {
+    const lines = printed([{ id: "00000000-0000-4000-8000-000000000001", status: "downloading", startedAt: ago(-45) }]);
+    assert.deepEqual(lines, [`\x1b[90mdownloading${RESET}  0s ago       00000000-0000-4000-8000-000000000001`]);
+  });
+});

--- a/src/ctrl/actions/session.ts
+++ b/src/ctrl/actions/session.ts
@@ -62,10 +62,52 @@ export async function sessionListRun(argv: readonly string[]): Promise<void> {
   const args: SessionListArgs = await parseCtrlArgs("session list", listSpec, argv);
   const db = connectDatabase(args.databaseUrl);
   try {
-    const rows = await db.select().from(sessions).orderBy(desc(sessions.startedAt), desc(sessions.id)).limit(args.count);
-    console.log(JSON.stringify(rows));
+    const rows = await db
+      .select({ id: sessions.id, status: sessions.status, startedAt: sessions.startedAt })
+      .from(sessions)
+      .orderBy(desc(sessions.startedAt), desc(sessions.id))
+      .limit(args.count);
+    printSessions(rows);
   } finally {
     await closeDatabase(db);
+  }
+}
+
+type SessionRow = Pick<typeof sessions.$inferSelect, "id" | "status" | "startedAt">;
+
+const STATUS_COLOR: Record<SessionRow["status"], string> = {
+  downloading: "\x1b[90m",
+  running: "\x1b[33m",
+  succeeded: "\x1b[32m",
+  failed: "\x1b[31m",
+  aborted: "\x1b[91m",
+  timed_out: "\x1b[35m",
+};
+
+const RESET = "\x1b[0m";
+const STATUS_WIDTH = "downloading".length;
+const AGE_WIDTH = "23h59m ago".length + 1;
+
+export function printSessions(rows: SessionRow[]): void {
+  const now = Date.now();
+  for (const row of rows) {
+    // The row's clock is the database's; a few seconds ahead of ours is normal and must not read as negative.
+    const seconds = Math.max(0, Math.floor((now - row.startedAt.getTime()) / 1000));
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+    let age: string;
+    if (seconds < 60) {
+      age = `${seconds}s ago`;
+    } else if (minutes < 60) {
+      age = `${minutes}m ago`;
+    } else if (hours < 24) {
+      age = minutes % 60 === 0 ? `${hours}h ago` : `${hours}h${minutes % 60}m ago`;
+    } else {
+      age = hours % 24 === 0 ? `${days}d ago` : `${days}d${hours % 24}h ago`;
+    }
+    const status = `${STATUS_COLOR[row.status]}${row.status.padEnd(STATUS_WIDTH)}${RESET}`;
+    console.log(`${status}  ${age.padEnd(AGE_WIDTH)}  ${row.id}`);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`./ctrl session list` now prints one human-readable line per session instead of a JSON array:

```
<status>  <age>  <id>
```

- **status** — padded to a column and colored: green `succeeded`, red `failed`, yellow `running`, gray `downloading` (the pre-running state; sessions have no `pending`), bright red `aborted`, magenta `timed_out`.
- **age** — a plain relative offset with no dependency: `45s ago`, `12m ago`, `1h30m ago`, `2h ago`, `3d5h ago`. Clamped at `0s ago` because `started_at` is the database's clock and can sit a few seconds ahead of the machine running `ctrl`.
- **id** — in the terminal's default color.

Ordering is unchanged: newest first (`started_at DESC, id DESC`). `--count` behaves as before. The query now selects only `id`, `status`, `started_at`.

[ctrl session list output: real sessions from the database plus a sample of every status color](https://cursor.com/agents/bc-5e5c2492-763d-4554-8427-8683a5c9ac8a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fctrl-session-list.png)

## Tests

Written first, then the implementation.

- `src/ctrl/actions/session.test.ts` (new, added to `npm test`): `printSessions` colors every status and pads columns; age boundaries (0s, 59s, 1m, 59m, 1h, 1h30m, 23h59m, 1d, 3d5h); empty list prints nothing; a `startedAt` ahead of the clock renders `0s ago`.
- `src/ctrl.test.ts`: the three `session list` cases now assert the line format and newest-first order by parsing the ages, count lines for `--count`, and check that a rejected `--count` prints no session lines.

`node --test` on `src/ctrl.test.ts` + `src/ctrl/actions/session.test.ts`: 32/33 pass; the one failure (`test run` prompt text) is pre-existing on `master` and unrelated. `tsc --noEmit` clean; oxlint clean (run with `NODE_OPTIONS=--experimental-strip-types` since this VM's Node 22.14 predates oxlint's TS-config requirement).

## Docs

`ctrl.md` and `field-guide/cli.md` describe the new line format.

## Review

Sol review (`gpt-5.6-sol-high`) returned no must-fix or should-fix findings. Its one nit — the id column shifts for ages ≥ 1000 days — is declined: a newest-first listing never puts a three-year-old session at the top, and widening the column for it is ceremony.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e5c2492-763d-4554-8427-8683a5c9ac8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e5c2492-763d-4554-8427-8683a5c9ac8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

