### PR TITLE
Refine session log colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ctrl": "node --experimental-strip-types src/ctrl/index.ts",
     "session": "node --experimental-strip-types src/session/index.ts",
     "dev": "wrangler dev --remote",
-    "test": "node --test --experimental-strip-types src/client.test.ts src/ctrl.test.ts src/session.test.ts src/ctrl/actions/test.test.ts src/ctrl/actions/session.test.ts src/linear.test.ts src/cursor-agent/client.test.ts src/qmp/json-stream.test.ts src/qemu/client.test.ts src/qemu/keys.test.ts src/sentry.test.ts",
+    "test": "node --test --experimental-strip-types src/client.test.ts src/ctrl.test.ts src/session.test.ts src/ctrl/actions/test.test.ts src/ctrl/actions/session.test.ts src/db/log.test.ts src/linear.test.ts src/cursor-agent/client.test.ts src/qmp/json-stream.test.ts src/qemu/client.test.ts src/qemu/keys.test.ts src/sentry.test.ts",
     "lint": "oxlint --type-aware --type-check",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "node --experimental-strip-types src/db/migrate.ts"

--- a/src/ctrl/actions/test.ts
+++ b/src/ctrl/actions/test.ts
@@ -296,7 +296,7 @@ export async function testStartRun(argv: readonly string[]): Promise<void> {
       throw new Error(`test start: result ${args.testResultId} not found or not pending`);
     }
     log(db, {
-      text: `test result ${args.testResultId}: running; session ${args.sessionId}`,
+      text: `test result ${args.testResultId}: running`,
       sessionId: args.sessionId,
     });
   } finally {

--- a/src/db/log.test.ts
+++ b/src/db/log.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import type { Db } from "./ops.ts";
+import {
+  acquireAgentColor,
+  flushLogs,
+  log,
+  releaseAgentColor,
+} from "./log.ts";
+
+const AGENT_ID = "OLI-61";
+const SESSION_ID = "1baaad43-674b-4bdb-88d7-3f18fce50aba";
+
+const db = {
+  insert: () => ({
+    values: async () => undefined,
+  }),
+} as unknown as Db;
+
+let output: string[];
+let originalConsoleLog: typeof console.log;
+let originalForceColor: string | undefined;
+
+beforeEach(() => {
+  output = [];
+  originalConsoleLog = console.log;
+  originalForceColor = process.env.FORCE_COLOR;
+  process.env.FORCE_COLOR = "1";
+  console.log = (...values: unknown[]) => {
+    output.push(values.join(" "));
+  };
+});
+
+afterEach(() => {
+  console.log = originalConsoleLog;
+  if (originalForceColor === undefined) {
+    delete process.env.FORCE_COLOR;
+  } else {
+    process.env.FORCE_COLOR = originalForceColor;
+  }
+  releaseAgentColor(AGENT_ID);
+});
+
+describe("log output", () => {
+  it("colors only the ticket and renders the bare session id in gray", async () => {
+    acquireAgentColor(AGENT_ID);
+
+    log(db, {
+      text: `session ${SESSION_ID}: sent 9 chords in 1546ms`,
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+    });
+    await flushLogs();
+
+    assert.deepEqual(output, [
+      "\x1b[37m[\x1b[39m" +
+        "\x1b[38;2;235;111;146mOLI-61\x1b[39m" +
+        "\x1b[37m] \x1b[39m" +
+        `\x1b[90m${SESSION_ID}\x1b[39m` +
+        "\x1b[37m: sent 9 chords in 1546ms\x1b[39m",
+    ]);
+  });
+
+  it("keeps an unattributed error readable without a ticket color or session", async () => {
+    log(db, { level: "error", text: "database unavailable" });
+    await flushLogs();
+
+    assert.deepEqual(output, [
+      "\x1b[37m[\x1b[39m" +
+        "\x1b[90mglobal\x1b[39m" +
+        "\x1b[37m] error: database unavailable\x1b[39m",
+    ]);
+  });
+});

--- a/src/db/log.test.ts
+++ b/src/db/log.test.ts
@@ -46,7 +46,7 @@ describe("log output", () => {
     acquireAgentColor(AGENT_ID);
 
     log(db, {
-      text: `session ${SESSION_ID}: sent 9 chords in 1546ms`,
+      text: "sent 9 chords in 1546ms",
       sessionId: SESSION_ID,
       agentId: AGENT_ID,
     });

--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -73,14 +73,19 @@ function paint(hex: string, text: string): string {
 
 function write(line: LogEntry): void {
   const tag = line.agentId ?? "global";
-  const text = line.level === undefined || line.level === "info" ? line.text : `${line.level}: ${line.text}`;
-  const rendered = `[${tag}] ${text}`;
+  const session = line.sessionId === undefined ? "" : `session ${line.sessionId}: `;
+  const message = session !== "" ? line.text.replace(session, "") : line.text;
+  const text = line.level === undefined || line.level === "info" ? message : `${line.level}: ${message}`;
   const hex = line.agentId === undefined ? undefined : colors.get(line.agentId);
-  if (hex === undefined) {
-    console.log(styleText("gray", rendered, { stream: process.stdout }));
-    return;
-  }
-  console.log(paint(hex, rendered));
+  const ticket = hex === undefined
+    ? styleText("gray", tag, { stream: process.stdout })
+    : paint(hex, tag);
+  const rest = line.sessionId === undefined
+    ? styleText("white", `] ${text}`, { stream: process.stdout })
+    : `${styleText("white", "] ", { stream: process.stdout })}${styleText("gray", line.sessionId, { stream: process.stdout })}${styleText("white", `: ${text}`, { stream: process.stdout })}`;
+  console.log(
+    `${styleText("white", "[", { stream: process.stdout })}${ticket}${rest}`,
+  );
 }
 
 export function log(

--- a/src/db/log.ts
+++ b/src/db/log.ts
@@ -73,9 +73,7 @@ function paint(hex: string, text: string): string {
 
 function write(line: LogEntry): void {
   const tag = line.agentId ?? "global";
-  const session = line.sessionId === undefined ? "" : `session ${line.sessionId}: `;
-  const message = session !== "" ? line.text.replace(session, "") : line.text;
-  const text = line.level === undefined || line.level === "info" ? message : `${line.level}: ${message}`;
+  const text = line.level === undefined || line.level === "info" ? line.text : `${line.level}: ${line.text}`;
   const hex = line.agentId === undefined ? undefined : colors.get(line.agentId);
   const ticket = hex === undefined
     ? styleText("gray", tag, { stream: process.stdout })

--- a/src/qemu/proxy.ts
+++ b/src/qemu/proxy.ts
@@ -73,7 +73,7 @@ function emitFollow(live: LiveSession, event: FollowEvent): void {
     if (!Queue.offerUnsafe(follower, event)) {
       live.followers.delete(follower);
       Queue.endUnsafe(follower);
-      log(db, { level: "warning", text: `session ${live.qemu.id}: follower dropped; ${FOLLOW_BACKLOG} events behind`, sessionId: live.qemu.id, agentId: live.agent });
+      log(db, { level: "warning", text: `follower dropped; ${FOLLOW_BACKLOG} events behind`, sessionId: live.qemu.id, agentId: live.agent });
     }
   }
 }
@@ -337,7 +337,7 @@ function startSession(cfg: typeof StartBody.Type, started: number, display: Qemu
       },
     });
     log(db, {
-      text: `session ${qemu.id}: starting; iso ${cfg.iso}${cfg.disk === undefined ? "" : `, disk ${cfg.disk}`}`,
+      text: `starting; iso ${cfg.iso}${cfg.disk === undefined ? "" : `, disk ${cfg.disk}`}`,
       sessionId: qemu.id,
       agentId: cfg.agent,
     });
@@ -351,7 +351,7 @@ function startSession(cfg: typeof StartBody.Type, started: number, display: Qemu
     live.lastCommandAt = Date.now();
     sessions.set(qemu.id, live);
     emitFollow(live, { type: "session", status: "running" });
-    log(db, { text: `session ${qemu.id}: running; started in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: cfg.agent });
+    log(db, { text: `running; started in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: cfg.agent });
     return qemu.id;
   });
 }
@@ -428,7 +428,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
         });
         live.image = { id: imageId, png: data.toString("base64") };
         emitFollow(live, { type: "image", ...live.image });
-        log(db, { text: `session ${qemu.id}: image; ${data.length} bytes in ${Date.now() - started}ms; ${storedImageUrl(imageId)}`, sessionId: qemu.id, agentId: agent });
+        log(db, { text: `image; ${data.length} bytes in ${Date.now() - started}ms; ${storedImageUrl(imageId)}`, sessionId: qemu.id, agentId: agent });
         return HttpServerResponse.uint8Array(data, {
           contentType: "image/png",
           headers: { "x-image-url": storedImageUrl(imageId) },
@@ -475,7 +475,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
       // the body starts streaming still ends this queue rather than leaving it hanging.
       const queue = yield* Queue.dropping<FollowEvent, Cause.Done>(FOLLOW_BACKLOG);
       live.followers.add(queue);
-      log(db, { text: `session ${id}: follower attached`, sessionId: id, agentId: live.agent });
+      log(db, { text: "follower attached", sessionId: id, agentId: live.agent });
       Queue.offerUnsafe(queue, { type: "session", status: sessions.has(id) ? "running" : "pending" });
       if (live.intent !== undefined) {
         Queue.offerUnsafe(queue, { type: "intent", state: "started", message: live.intent.message });
@@ -487,7 +487,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
         Stream.map((event) => new TextEncoder().encode(`${JSON.stringify(event)}\n`)),
         Stream.ensuring(Effect.sync(() => {
           if (live.followers.delete(queue)) {
-            log(db, { text: `session ${id}: follower detached`, sessionId: id, agentId: live.agent });
+            log(db, { text: "follower detached", sessionId: id, agentId: live.agent });
           }
         })),
       );
@@ -503,7 +503,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
         try: () => readFile(qemu.serialPath),
         catch: (cause) => internal(cause, { sessionId: qemu.id, agentId: params.agent }),
       }));
-      log(db, { text: `session ${qemu.id}: serial; ${data.length} bytes in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: params.agent });
+      log(db, { text: `serial; ${data.length} bytes in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: params.agent });
       return HttpServerResponse.uint8Array(data, { contentType: "text/plain" });
     }) satisfies RouteHandler, { uninterruptible: true });
 
@@ -521,7 +521,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
         try {
           await stop(qemu);
         } catch (err) {
-          log(db, { level: "error", text: `session ${qemu.id}: stop cleanup failed: ${errorDetail(err)}`, sessionId: qemu.id, agentId: agent }, { cause: err });
+          log(db, { level: "error", text: `stop cleanup failed: ${errorDetail(err)}`, sessionId: qemu.id, agentId: agent }, { cause: err });
         }
       });
       yield* Effect.tryPromise({
@@ -533,7 +533,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
       });
       // Color is released in finishLiveSession; log first so the stopped line keeps it.
       log(db, {
-        text: `session ${qemu.id}: stopped; ${finalStatus}${reason === undefined ? "" : `; ${reason}`}`,
+        text: `stopped; ${finalStatus}${reason === undefined ? "" : `; ${reason}`}`,
         sessionId: qemu.id,
         agentId: agent,
       });
@@ -558,7 +558,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
         try: () => sendKeys(qemu, chords, record),
         catch: (err) => exchangeFailed(err, { sessionId: qemu.id, agentId: agent }),
       }));
-      log(db, { text: `session ${qemu.id}: sent ${chords.length} chords in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: agent });
+      log(db, { text: `sent ${chords.length} chords in ${Date.now() - started}ms`, sessionId: qemu.id, agentId: agent });
       return HttpServerResponse.jsonUnsafe({ ok: "true" });
     }) satisfies RouteHandler, { uninterruptible: true });
 
@@ -578,7 +578,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
         catch: (err) => exchangeFailed(err, { sessionId: qemu.id, agentId: agent }),
       }));
       log(db, {
-        text: `session ${qemu.id}: mouse ${x} ${y}${button === undefined ? "" : ` ${button}${clicks === undefined || clicks === 1 ? "" : ` ×${clicks}`}`} in ${Date.now() - started}ms`,
+        text: `mouse ${x} ${y}${button === undefined ? "" : ` ${button}${clicks === undefined || clicks === 1 ? "" : ` ×${clicks}`}`} in ${Date.now() - started}ms`,
         sessionId: qemu.id,
         agentId: agent,
       });
@@ -596,7 +596,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
       }
       live.intent = { span: startIntentSpan(live.span, live.qemu.id, agent, test_result_id, message), message };
       emitFollow(live, { type: "intent", state: "started", message });
-      log(db, { text: `session ${live.qemu.id}: intent start; ${message}`, sessionId: live.qemu.id, agentId: agent });
+      log(db, { text: `intent start; ${message}`, sessionId: live.qemu.id, agentId: agent });
       return HttpServerResponse.jsonUnsafe({ ok: "true" });
     }) satisfies RouteHandler, { uninterruptible: true });
 
@@ -607,7 +607,7 @@ const routes = (display: QemuDisplay, automation: boolean) => HttpRouter.use((ro
         return yield* Effect.fail(badRequest("no active intent", { sessionId: live.qemu.id, agentId: agent }));
       }
       finishOpenIntent(live, "completed");
-      log(db, { text: `session ${live.qemu.id}: intent end`, sessionId: live.qemu.id, agentId: agent });
+      log(db, { text: "intent end", sessionId: live.qemu.id, agentId: agent });
       return HttpServerResponse.jsonUnsafe({ ok: "true" });
     }) satisfies RouteHandler, { uninterruptible: true });
 
@@ -703,11 +703,11 @@ async function stopTimedOutSessions(): Promise<void> {
         await stop(qemu);
       } catch (err) {
         // stop() already destroyed the socket and signaled QEMU, so still close the record.
-        log(db, { level: "error", text: `session ${qemu.id}: timeout cleanup failed: ${errorDetail(err)}`, sessionId: qemu.id }, { cause: err });
+        log(db, { level: "error", text: `timeout cleanup failed: ${errorDetail(err)}`, sessionId: qemu.id }, { cause: err });
       }
       try {
         await endSession(db, qemu.id, "timed_out", SESSION_TIMEOUT_REASON);
-        log(db, { text: `session ${qemu.id}: timed out; ${SESSION_TIMEOUT_REASON}`, sessionId: qemu.id });
+        log(db, { text: `timed out; ${SESSION_TIMEOUT_REASON}`, sessionId: qemu.id });
       } finally {
         finishLiveSession(live, "timed_out");
       }
@@ -718,7 +718,7 @@ async function stopTimedOutSessions(): Promise<void> {
     if (result.status === "rejected") {
       log(db, {
         level: "error",
-        text: `session ${timedOut[i].qemu.id}: recording timeout failed: ${errorDetail(result.reason)}`,
+        text: `recording timeout failed: ${errorDetail(result.reason)}`,
         sessionId: timedOut[i].qemu.id,
       }, { cause: result.reason });
     }
@@ -757,9 +757,9 @@ const drainSessions = Layer.effectDiscard(
             await stop(qemu);
             status = "aborted";
             await endSession(db, qemu.id, "aborted", "proxy shutdown");
-            log(db, { text: `session ${qemu.id}: stopped; aborted; proxy shutdown`, sessionId: qemu.id });
+            log(db, { text: "stopped; aborted; proxy shutdown", sessionId: qemu.id });
           } catch (err) {
-            log(db, { level: "error", text: `shutdown: session ${qemu.id}: ${(err as Error).message}`, sessionId: qemu.id }, { cause: err });
+            log(db, { level: "error", text: `shutdown: ${(err as Error).message}`, sessionId: qemu.id }, { cause: err });
             throw err;
           } finally {
             finishLiveSession(live, status);
@@ -800,7 +800,7 @@ const main = (display: QemuDisplay, automation: boolean, port: number) => Layer.
         try {
           await endSession(db, live.qemu.id, "aborted", `proxy error: ${err.message}`);
         } catch (e) {
-          log(db, { level: "error", text: `shutdown: session ${live.qemu.id}: ${errorDetail(e)}`, sessionId: live.qemu.id }, { cause: e });
+          log(db, { level: "error", text: `shutdown: ${errorDetail(e)}`, sessionId: live.qemu.id }, { cause: e });
         }
         finishLiveSession(live, "aborted");
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- color only the ticket while keeping brackets and messages white
- show the bare session ID in gray and remove the redundant `session` label
- store session log messages without duplicated IDs, including test-result logs
- cover attributed and unattributed log formatting

## Testing
- focused logger tests pass
- type-aware lint passes with Node 22.18
- full suite: 131 pass, 2 pre-existing failures in unchanged prompt tests (`drivingAgentPrompt` omits the expected server URL)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f7c4b9f-226a-4866-bfdb-11e487951eb8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f7c4b9f-226a-4866-bfdb-11e487951eb8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

