### PR TITLE
ctrl test run: drop the unused --server-url; declare the server-url flag per action

### DIFF
--- a/ctrl.md
+++ b/ctrl.md
@@ -38,7 +38,7 @@ If you are an agent driving a guest, you need two of these: [test start](#test-s
 
 The action comes first. Every value is a flag; there are no positional arguments. Flags may sit in any order after the action.
 
-- `--server-url <url>` — the oligarchy server, a full http or https URL. Required on every action; falls back to `SERVER_URL` from the environment. There is no default.
+- `--server-url <url>` — the oligarchy server, a full http or https URL. Required on every action but `test run`; falls back to `SERVER_URL` from the environment. There is no default.
 - `DATABASE_URL` — read from the environment by every action. `test new` and `test list` also read `LINEAR_API_TOKEN`; `test run` also reads `CURSOR_API_TOKEN`. A `.env` in the current directory fills in missing variables only. A missing variable means exit 1.
 
 A command that works exits 0. A command that fails exits 1 and prints the error: one headline, then the stack trace and the cause behind it. Read the headline first. `./ctrl <action> --help` prints that action's flags.
@@ -90,15 +90,15 @@ Prints every Linear issue on the Oligarchy team whose status type is backlog, as
 ## test run
 
 ```
-./ctrl test run --server-url <url> --ticket <linear-ticket>
+./ctrl test run --ticket <linear-ticket>
 ```
 
-Spawns a Cursor cloud agent that drives one Linear ticket, told to pass `--server-url` on every `./client` and `./ctrl` command. Prints a link to the agent as soon as it starts; does not wait for it. Not used while driving a guest. Reads `CURSOR_API_TOKEN`.
+Spawns a Cursor cloud agent that drives one Linear ticket. The ticket carries the proxy URL, so this is the one action that takes no `--server-url`. Prints a link to the agent as soon as it starts; does not wait for it. Not used while driving a guest. Reads `CURSOR_API_TOKEN`.
 
 - `--ticket <linear-ticket>` — the issue identifier created by `test new`.
 
 ```bash
-./ctrl test run --server-url https://qemu.example.com --ticket OLI-42
+./ctrl test run --ticket OLI-42
 ```
 
 ## test start

--- a/field-guide/cli.md
+++ b/field-guide/cli.md
@@ -16,7 +16,7 @@ Three TypeScript executables share one shape. `./client` (`src/client/index.ts`)
 ./ctrl test --list [--details] [--name <definition>] --server-url <url>
 ./ctrl test new --iso <https-url> --version <version> [--name <definition>] --server-url <url>
 ./ctrl test list --server-url <url>
-./ctrl test run --ticket <linear-ticket> --server-url <url>
+./ctrl test run --ticket <linear-ticket>
 ./ctrl test start --session-id <id> --test-result-id <result-id> --server-url <url>
 ./ctrl test-results --agent-id <agent> --id <result-id> --status success|failed [--reason <text>] --server-url <url>
 ./ctrl session list [--count <n>] [--active] [--json] --server-url <url>
@@ -29,11 +29,11 @@ The action is always the first argument; flags follow in any order, and Effect a
 
 ## Parsing: `parseClientArgs` and `parseCtrlArgs`
 
-Each executable has one parser, `src/client/parse-args.ts` and `src/ctrl/parse-args.ts`, and every action calls it first. The parser is generic over the action's flag config: the action declares its flags with `Flag`, derives its arg type from that declaration (`ClientArgs<typeof flags>`, `CtrlArgs<typeof spec>`), and gets back one object holding the parsed flags and the environment together. Under the hood the parser builds a `Command` from the shared flags plus the action's, runs it with `Command.runWith` so Effect does the parsing, help, and error rendering, then reads the environment through Effect's `Config`. `--help` and `--version` render and exit 0 before anything else happens. A parse failure is rendered by Effect (the action's usage plus the error) and exits 1. A `.env` in the working directory fills in missing variables only.
+Each executable has one parser, `src/client/parse-args.ts` and `src/ctrl/parse-args.ts`, and every action calls it first. The parser is generic over the action's flag config: the action declares its flags with `Flag`, derives its arg type from that declaration (`ClientArgs<typeof flags>`, `CtrlArgs<typeof spec>`), and gets back one object holding the parsed flags and the environment together. Under the hood the parser builds a `Command` from the action's flags, runs it with `Command.runWith` so Effect does the parsing, help, and error rendering, then reads the environment through Effect's `Config`. `--help` and `--version` render and exit 0 before anything else happens. A parse failure is rendered by Effect (the action's usage plus the error) and exits 1. A `.env` in the working directory fills in missing variables only.
 
 The client's shared surface, added to every action: `--agent-id` (required, non-empty), `--server-url` (a full URL used exactly as given; falls back to `SERVER_URL`, then `http://127.0.0.1:42069`), and `OLIGARCHY_TOKEN` from the environment, sent as `Authorization: Bearer <token>` on every request. A missing token is `OLIGARCHY_TOKEN is not set`.
 
-The ctrl's shared surface: `--server-url` (falls back to `SERVER_URL`; must be http or https; no default, because the URL ends up in Linear tickets and agent prompts where `localhost` is never right) and `DATABASE_URL` from the environment. An action's spec names the further variables it needs — `LINEAR_API_TOKEN` for `test new` and `test list`, `CURSOR_API_TOKEN` for `test run` — and the parser reads them the same way, so a missing one is `LINEAR_API_TOKEN is not set` before any work starts. The parsed `databaseUrl` goes to `connectDatabase(url)`; the parsed token goes to `prompt(apiKey, text)`. Nothing below the parser reads `process.env`.
+The ctrl's shared surface is `DATABASE_URL` from the environment, read for every action. `--server-url` (falls back to `SERVER_URL`; must be http or https; no default, because the URL ends up in Linear tickets where `localhost` is never right) is one exported flag, `serverUrl` in `src/ctrl/parse-args.ts`, that every action but `test run` puts in its own flag config — `test run` names no proxy, its driver reads the URL from the ticket. An action's spec names the further variables it needs — `LINEAR_API_TOKEN` for `test new` and `test list`, `CURSOR_API_TOKEN` for `test run` — and the parser reads them the same way, so a missing one is `LINEAR_API_TOKEN is not set` before any work starts. The parsed `databaseUrl` goes to `connectDatabase(url)`; the parsed token goes to `prompt(apiKey, text)`. Nothing below the parser reads `process.env`.
 
 ## Client actions
 

--- a/src/ctrl.test.ts
+++ b/src/ctrl.test.ts
@@ -155,7 +155,7 @@ describe("./ctrl happy path", () => {
     assert.ok(address !== null && typeof address !== "string");
 
     try {
-      const result = await runCtrl(["test", "run", "--ticket", "OLI-42", "--server-url", SERVER], {
+      const result = await runCtrl(["test", "run", "--ticket", "OLI-42"], {
         CURSOR_API_TOKEN: "test-token",
         CURSOR_BACKEND_URL: `http://127.0.0.1:${address.port}`,
       });
@@ -186,16 +186,15 @@ describe("./ctrl happy path", () => {
     }
   });
 
-  it("test run accepts --server-url before or after --ticket", async () => {
-    const equals = await runCtrl(["test", "run", "--ticket", "OLI-42", `--server-url=${SERVER}`], { CURSOR_API_TOKEN: "" });
-    assert.notEqual(equals.code, 0);
-    assert.match(equals.stderr, /CURSOR_API_TOKEN is not set/);
+  it("test run takes no server URL: the ticket alone parses, and --server-url is unrecognized", async () => {
+    const ticketOnly = await runCtrl(["test", "run", "--ticket", "OLI-42"], { CURSOR_API_TOKEN: "" });
+    assert.notEqual(ticketOnly.code, 0);
+    assert.match(ticketOnly.stderr, /CURSOR_API_TOKEN is not set/);
 
-    const spaced = await runCtrl(["test", "run", "--server-url", "http://127.0.0.1:42069", "--ticket", "OLI-42"], {
-      CURSOR_API_TOKEN: "",
-    });
-    assert.notEqual(spaced.code, 0);
-    assert.match(spaced.stderr, /CURSOR_API_TOKEN is not set/);
+    const withServer = await runCtrl(["test", "run", "--ticket", "OLI-42", `--server-url=${SERVER}`], { CURSOR_API_TOKEN: "test-token" });
+    assert.notEqual(withServer.code, 0);
+    assert.equal(withServer.stdout.includes("Agent here"), false);
+    assert.match(withServer.stderr, /Unrecognized flag: --server-url/);
   });
 
   it("prints the actions for --help", async () => {
@@ -363,30 +362,16 @@ describe("./ctrl unhappy path", () => {
     assert.match(result.stderr, /DATABASE_URL is not set/);
   });
 
-  it("rejects test run without a ticket or a server URL", async () => {
-    const missingTicket = await runCtrl(["test", "run", "--server-url", SERVER], { CURSOR_API_TOKEN: "test-token" });
+  it("rejects test run without a ticket", async () => {
+    const missingTicket = await runCtrl(["test", "run"], { CURSOR_API_TOKEN: "test-token" });
     assert.notEqual(missingTicket.code, 0);
     assert.equal(missingTicket.stdout.includes("Agent here"), false);
     assert.match(missingTicket.stderr, /Missing required flag: --ticket/);
 
-    const emptyTicket = await runCtrl(["test", "run", "--ticket", "", "--server-url", SERVER], { CURSOR_API_TOKEN: "test-token" });
+    const emptyTicket = await runCtrl(["test", "run", "--ticket", ""], { CURSOR_API_TOKEN: "test-token" });
     assert.notEqual(emptyTicket.code, 0);
     assert.equal(emptyTicket.stdout.includes("Agent here"), false);
     assert.match(emptyTicket.stderr, /--ticket.*length of at least 1/);
-
-    const missingServer = await runCtrl(["test", "run", "--ticket", "OLI-42"], { CURSOR_API_TOKEN: "test-token" });
-    assert.notEqual(missingServer.code, 0);
-    assert.equal(missingServer.stdout.includes("Agent here"), false);
-    assert.match(missingServer.stderr, /Missing required flag: --server-url/);
-  });
-
-  it("rejects a test run server URL outside HTTP and HTTPS", async () => {
-    const result = await runCtrl(["test", "run", "--ticket", "OLI-42", "--server-url=ssh://qemu.example.com"], {
-      CURSOR_API_TOKEN: "test-token",
-    });
-    assert.notEqual(result.code, 0);
-    assert.equal(result.stdout.includes("Agent here"), false);
-    assert.match(result.stderr, /server-url must be a valid http or https url/);
   });
 
   it("rejects test without --list", async () => {

--- a/src/ctrl/actions/session.ts
+++ b/src/ctrl/actions/session.ts
@@ -3,7 +3,7 @@ import { Schema } from "effect";
 import { Flag } from "effect/unstable/cli";
 import { closeDatabase, connectDatabase } from "../../db/ops.ts";
 import { actions, logs, sessions, testDefinitions, testResults } from "../../db/schema.ts";
-import { type CtrlArgs, parseCtrlArgs } from "../parse-args.ts";
+import { type CtrlArgs, parseCtrlArgs, serverUrl } from "../parse-args.ts";
 
 const DEFAULT_COUNT = 10;
 
@@ -15,6 +15,7 @@ Every form takes --server-url <url> (or SERVER_URL). ctrl session list --help an
 const listSpec = {
   env: {},
   flags: {
+    serverUrl,
     count: Flag.integer("count").pipe(
       Flag.withSchema(Schema.Number.check(Schema.isGreaterThanOrEqualTo(1, { message: "count must be at least 1" }))),
       Flag.withDefault(DEFAULT_COUNT),
@@ -31,6 +32,7 @@ const listSpec = {
 const inspectSpec = {
   env: {},
   flags: {
+    serverUrl,
     sessionId: Flag.string("session-id").pipe(Flag.withSchema(Schema.NonEmptyString), Flag.withDescription("Session id")),
     logs: Flag.boolean("logs").pipe(Flag.withDefault(false), Flag.withDescription("Print session logs")),
     testDef: Flag.boolean("test-def").pipe(Flag.withDefault(false), Flag.withDescription("Print the session's test definition")),

--- a/src/ctrl/actions/test-results.ts
+++ b/src/ctrl/actions/test-results.ts
@@ -4,11 +4,12 @@ import { Flag } from "effect/unstable/cli";
 import { acquireAgentColor, flushLogs, log } from "../../db/log.ts";
 import { closeDatabase, connectDatabase } from "../../db/ops.ts";
 import { agentRuns, testResults } from "../../db/schema.ts";
-import { type CtrlArgs, parseCtrlArgs } from "../parse-args.ts";
+import { type CtrlArgs, parseCtrlArgs, serverUrl } from "../parse-args.ts";
 
 const spec = {
   env: {},
   flags: {
+    serverUrl,
     agentId: Flag.string("agent-id").pipe(Flag.withSchema(Schema.NonEmptyString), Flag.withDescription("Calling agent's id")),
     id: Flag.string("id").pipe(Flag.withSchema(Schema.NonEmptyString), Flag.withDescription("Test result id")),
     status: Flag.choiceWithValue("status", [

--- a/src/ctrl/actions/test.ts
+++ b/src/ctrl/actions/test.ts
@@ -16,7 +16,7 @@ import {
   type LinearTicket,
   listLinearBacklog,
 } from "../../linear.ts";
-import { type CtrlArgs, parseCtrlArgs } from "../parse-args.ts";
+import { type CtrlArgs, parseCtrlArgs, serverUrl } from "../parse-args.ts";
 
 const HttpsUrl = Schema.String.check(
   Schema.makeFilter(
@@ -34,6 +34,7 @@ const HttpsUrl = Schema.String.check(
 const definitionsSpec = {
   env: {},
   flags: {
+    serverUrl,
     list: Flag.boolean("list").pipe(Flag.withDescription("List stored test definitions")),
     details: Flag.boolean("details").pipe(Flag.withDefault(false), Flag.withDescription("Print every field as JSON")),
     name: Flag.string("name").pipe(
@@ -47,6 +48,7 @@ const definitionsSpec = {
 const newSpec = {
   env: { linearToken: "LINEAR_API_TOKEN" },
   flags: {
+    serverUrl,
     iso: Flag.string("iso").pipe(Flag.withSchema(HttpsUrl), Flag.withDescription("HTTPS URL of the ISO")),
     version: Flag.string("version").pipe(
       Flag.withSchema(Schema.NonEmptyString),
@@ -62,7 +64,7 @@ const newSpec = {
 
 const listSpec = {
   env: { linearToken: "LINEAR_API_TOKEN" },
-  flags: {},
+  flags: { serverUrl },
 };
 
 const runSpec = {
@@ -78,6 +80,7 @@ const runSpec = {
 const startSpec = {
   env: {},
   flags: {
+    serverUrl,
     sessionId: Flag.string("session-id").pipe(Flag.withSchema(Schema.NonEmptyString), Flag.withDescription("Session id")),
     testResultId: Flag.string("test-result-id").pipe(
       Flag.withSchema(Schema.NonEmptyString),
@@ -100,7 +103,7 @@ const USAGE = `usage: ctrl test --list [--details] [--name <definition>]
        ctrl test run --ticket <linear-ticket>
        ctrl test start --session-id <id> --test-result-id <id>
 
-Every form takes --server-url <url> (or SERVER_URL). ctrl test <verb> --help prints that verb's flags.`;
+Every form but run takes --server-url <url> (or SERVER_URL). ctrl test <verb> --help prints that verb's flags.`;
 
 export async function testRun(argv: readonly string[]): Promise<void> {
   const [verb, ...rest] = argv;

--- a/src/ctrl/index.ts
+++ b/src/ctrl/index.ts
@@ -16,7 +16,7 @@ actions:
   session list [--count <n>] [--active] [--json]
   session --session-id <id> --logs|--test-def|--test-results|--actions|--all
 
-Every action reads DATABASE_URL and takes --server-url (or SERVER_URL).
+Every action reads DATABASE_URL; every action but test run takes --server-url (or SERVER_URL).
 ctrl <action> --help prints that action's flags.`;
 
 const [action, ...argv] = process.argv.slice(2);

--- a/src/ctrl/parse-args.ts
+++ b/src/ctrl/parse-args.ts
@@ -19,13 +19,13 @@ const HttpUrl = Schema.String.check(
   ),
 );
 
-const shared = {
-  serverUrl: Flag.string("server-url").pipe(
-    Flag.withFallbackConfig(Config.string("SERVER_URL")),
-    Flag.withSchema(HttpUrl),
-    Flag.withDescription("Oligarchy server URL; SERVER_URL when omitted"),
-  ),
-};
+// Declared by every action that talks about a proxy; test run does not, its driver reads
+// the url from the ticket.
+export const serverUrl = Flag.string("server-url").pipe(
+  Flag.withFallbackConfig(Config.string("SERVER_URL")),
+  Flag.withSchema(HttpUrl),
+  Flag.withDescription("Oligarchy server URL; SERVER_URL when omitted"),
+);
 
 export type CtrlSpec = {
   env: Record<string, string>;
@@ -35,7 +35,6 @@ export type CtrlSpec = {
 export type CtrlArgs<Spec extends CtrlSpec> = Command.Command.Config.Infer<Spec["flags"]> & {
   [Key in keyof Spec["env"]]: string;
 } & {
-  serverUrl: string;
   databaseUrl: string;
 };
 
@@ -53,8 +52,8 @@ export function parseCtrlArgs<const Env extends Record<string, string>, const Fl
   }
   return Effect.runPromise(
     Effect.gen(function* () {
-      let parsed: Command.Command.Config.Infer<typeof shared & Flags> | undefined;
-      const command = Command.make(name, { ...shared, ...spec.flags }, (input) =>
+      let parsed: Command.Command.Config.Infer<Flags> | undefined;
+      const command = Command.make(name, spec.flags, (input) =>
         Effect.sync(() => {
           parsed = input;
         }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #76, taking the remaining note from its review pass: `test run` still required `--server-url` although it no longer used it (the driving-agent prompt is rendered from the ticket alone since #76).

## Change

- `src/ctrl/parse-args.ts` no longer merges a shared `--server-url` into every action's `Command`. The flag is one exported value, `serverUrl`, and each action puts it in its own flag config. `parseCtrlArgs` is now purely the action's flags plus the environment; `CtrlArgs` drops the hard-coded `serverUrl: string` (it comes from the flag config when declared).
- `test --list`, `test new`, `test list`, `test start`, `test-results`, `session list`, and `session` declare `serverUrl` and behave exactly as before.
- `test run` does not: `./ctrl test run --ticket <id>` is the whole command, and `--server-url` on it is `Unrecognized flag: --server-url`. `DATABASE_URL` is still read for every action.
- Usage text (`ctrl/index.ts`, `test.ts`), `ctrl.md`, and `field-guide/cli.md` updated.

## Tests (written first, failing before the change)

- `src/ctrl.test.ts`: `test run --ticket OLI-42` parses and fails only on the missing `CURSOR_API_TOKEN`; `test run --ticket OLI-42 --server-url=...` is rejected as unrecognized; the Cursor-API kickoff test no longer passes a server url; the ticket-validation test drops its server-url cases.

`tsc` clean; `npm test` 154/154 on the combined tree.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e311d33-0f0e-40b1-95a0-95e821b5f904?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e311d33-0f0e-40b1-95a0-95e821b5f904&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

