### PR TITLE
install: run npm ci under Node 26 via nvm

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -7,6 +7,21 @@ if [ -z "${DATABASE_URL:-}" ]; then
   exit 1
 fi
 
+# v2 runs on Node 26 (package.json engines, CI). The base image ships Node 22, whose npm 10
+# resolves vite's optional esbuild peer differently and rejects package-lock.json under npm ci.
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+  echo "install: nvm not found at $NVM_DIR; Node 26 is required" >&2
+  exit 1
+fi
+. "$NVM_DIR/nvm.sh"
+nvm install 26
+nvm alias default 26
+# nvm use only swaps the nvm entry already in PATH; put Node 26 first so nothing shadows it.
+PATH="$(dirname "$(nvm which 26)"):$PATH"
+export PATH
+echo "install: node $(node --version), npm $(npm --version)"
+
 cd v2
 npm ci --ignore-scripts
 # The tsgo patch only affects lint; a driving agent's environment must not fail on it.

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -2,10 +2,8 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-if [ -z "${DATABASE_URL:-}" ]; then
-  echo "install: DATABASE_URL is not set" >&2
-  exit 1
-fi
+# Nothing here needs DATABASE_URL, and environment builds run install without agent secrets,
+# so it must not be required; start.sh reports it missing at boot instead.
 
 # v2 runs on Node 26 (package.json engines, CI). The base image ships Node 22, whose npm 10
 # resolves vite's optional esbuild peer differently and rejects package-lock.json under npm ci.

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# The proxy and ./ctrl read DATABASE_URL from the environment and fail without it. Warn rather
+# than fail: a developing agent runs the checks and tests against a local Postgres and never needs it.
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "start: DATABASE_URL is not set; the proxy terminal and ./ctrl will not work" >&2
+fi
+
 # The proxy runs QEMU as the agent user; open /dev/kvm when the host exposes it.
 if [ -e /dev/kvm ]; then
   sudo chmod 666 /dev/kvm


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`bash .cursor/install.sh` fails for two independent reasons, and every environment build of this repo has failed as a result.

### 1. Environment builds have no `DATABASE_URL`

Draft build `bld-20260906-373b68b0` (this branch before the second commit) shows the first failure in the real pipeline:

```
[2026-09-06T13:21:49.053Z] install: DATABASE_URL is not set
[2026-09-06T13:21:49.057Z] [INSTALL] Exit code: 1
```

Environment builds run `install` without agent secrets. The guard came in with #41, when `install.sh` still ran `npm run db:migrate`; commit `9158510` removed that step but kept the guard, and nothing left in the script reads the variable.

### 2. `npm ci` rejects the lockfile under Node 22 / npm 10

Where `DATABASE_URL` is set (agent VMs), the script gets further and fails at `npm ci`:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: esbuild@0.28.2 from lock file
npm error Missing: @esbuild/linux-x64@0.28.2 from lock file
...
```

The base image ships Node 22 (npm 10.9.7), but `v2` targets Node 26 (`package.json` `engines`, `development.md`, CI). npm 10 computes a different ideal tree for `vite`'s optional `esbuild` peer than npm 11 does, so it rejects the committed `package-lock.json`. The same lockfile installs cleanly under Node 26 / npm 11.19. Because install never completed, `v2/node_modules` was never created and the `proxy` terminal died with `ERR_MODULE_NOT_FOUND: @sentry/effect`.

## Fix

`.cursor/install.sh`:

- no longer requires `DATABASE_URL` (nothing in it needs the variable);
- installs Node 26 with nvm (a no-op when already present) and sets it as the `default` alias;
- puts the Node 26 bin dir first on `PATH` explicitly, because `nvm use` only swaps the existing nvm entry in place and a Node 22 earlier on `PATH` would still shadow it;
- fails with a clear message when nvm is missing.

`.cursor/start.sh` prints a non-fatal warning when `DATABASE_URL` is unset. It runs on every boot with secrets injected, so the original "surface a missing secret early" intent survives without blocking a developing agent, who runs checks and tests against a local Postgres and never needs it.

## Verification

In this Cloud Agent VM:

- Before: `bash .cursor/install.sh` exits 1 with the EUSAGE error above (Node 22.14 / npm 10.9.7); reproduced with nvm's Node 22.22.2 too.
- After: exits 0 in ~7 s from a shell where Node 22 is first on `PATH`, with and without `DATABASE_URL`; `npm ci` adds 351 packages and `npm run prepare` patches tsgo/oxlint.
- Rerun is idempotent (`v26.8.1 is already installed.`, exit 0).
- `NVM_DIR=/nonexistent` -> `install: nvm not found at /nonexistent; Node 26 is required`, exit 1.
- `start.sh` without `DATABASE_URL` prints the warning and exits 0; with it, exits 0 silently.
- `npm run check:fast` on the installed tree under Node 26: lint, format, types, and 689 unit tests pass.

Draft environment builds of this branch:

- `bld-20260906-373b68b0` (first commit only): `INSTALL_FAILED` at `install: DATABASE_URL is not set`, which is what exposed problem 1.
- `bld-20260906-2ec4742d` (both commits, `3279deb`): `SUCCEEDED`. Log: `Downloading and installing node v26.8.1...` -> `install: node v26.8.1, npm 11.19.0` -> `added 351 packages` -> `Patched typescript ...` -> `[INSTALL] Exit code: 0` -> `Snapshot ready.`

Fresh agent booted from `bld-20260906-2ec4742d`: `v2/node_modules` present from the snapshot (install did not re-run), `@sentry/effect` resolvable, nvm `default -> 26 (v26.8.1)`, `start.sh` exit 0, `npm run check:fast` passes (36 files, 689 tests) under Node 26, and the `proxy` terminal reaches the proxy's own preflight (the expected qemu/OVMF message below).

## Not addressed here (separate decisions)

- The `proxy` terminal still cannot run in the default image: `qemu-system-x86_64`, `qemu-img`, and OVMF are not installed (commit `9158510` deliberately removed that apt step from install), and `src/qemu/args.ts` hardcodes the Arch Linux OVMF paths. `/dev/kvm` is present in the VM.
- Cursor's exec-daemon prepends `/exec-daemon` (a Node 22.14 binary) to `PATH` in agent shells and terminals, so bare `node` there reports v22.14 even though nvm's default is 26. `./ctrl --help`, `./client --help`, and `check:fast` all work under it, but `nvm exec default ./server ...` in the terminal command would make the version explicit.
- The environment's recurring system builds all ended in `TERMINAL_FAILURE` within ~15 ms with no logs, i.e. before checkout or install ever ran; manually triggered builds run fine.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78fe6386-977a-484f-b07a-6b2580e147ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78fe6386-977a-484f-b07a-6b2580e147ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

