### PR TITLE
Add post_run_diagnosis and post_run_error_types with ctrl diagnose and error-type

### DIFF
--- a/v2/ctrl.md
+++ b/v2/ctrl.md
@@ -4,20 +4,23 @@ Consult this table of contents first. Read only the section you need.
 
 | Section | Line |
 |---------|-----:|
-| [Important](#important) | 18 |
-| [Synopsis](#synopsis) | 24 |
-| [test --list](#test---list) | 46 |
-| [test new](#test-new) | 62 |
-| [test list](#test-list) | 78 |
-| [test run](#test-run) | 90 |
-| [test start](#test-start) | 104 |
-| [test-results](#test-results) | 120 |
-| [session list](#session-list) | 137 |
-| [session](#session) | 153 |
+| [Important](#important) | 21 |
+| [Synopsis](#synopsis) | 27 |
+| [test --list](#test---list) | 52 |
+| [test new](#test-new) | 68 |
+| [test list](#test-list) | 84 |
+| [test run](#test-run) | 96 |
+| [test start](#test-start) | 110 |
+| [test-results](#test-results) | 126 |
+| [session list](#session-list) | 143 |
+| [session](#session) | 159 |
+| [error-type new](#error-type-new) | 182 |
+| [error-type list](#error-type-list) | 197 |
+| [diagnose](#diagnose) | 211 |
 
 ## Important
 
-`./ctrl` is the control plane's record keeper: it creates test runs, opens their Linear tickets, spawns driving agents, ties a session to its result, closes the result, and reads sessions back. It never touches a guest — that is `./client`.
+`./ctrl` is the control plane's record keeper: it creates test runs, opens their Linear tickets, spawns driving agents, ties a session to its result, closes the result, reads sessions back, and names the cause of a session that did not succeed. It never touches a guest — that is `./client`.
 
 If you are an agent driving a guest, you need two of these: [test start](#test-start) after `./client start`, and [test-results](#test-results) before `./client stop`. Do not look at code. Run the commands.
 
@@ -33,7 +36,10 @@ If you are an agent driving a guest, you need two of these: [test start](#test-s
 ./ctrl test start     --session-id <id> --test-result-id <id> --model <id>
 ./ctrl test-results   --agent-id <agent> --id <id> --status success|failed [--reason <text>]
 ./ctrl session list   [--count <n>] [--active] [--json]
-./ctrl session        --session-id <id> --logs|--test-def|--test-results|--actions|--debug-logs|--all|--dump
+./ctrl session        --session-id <id> --logs|--test-def|--test-results|--actions|--debug-logs|--diagnosis|--all|--dump
+./ctrl error-type new  --key <key> --description <text>
+./ctrl error-type list [--json]
+./ctrl diagnose       --session-id <id> --type <key> --summary <text> --model <id>
 ```
 
 The action comes first. Every value is a flag; there are no positional arguments. Flags may sit in any order after the action.
@@ -153,7 +159,7 @@ Prints the most recent sessions, newest first, one per line: the status, colored
 ## session
 
 ```
-./ctrl session --server-url <url> --session-id <id> --logs|--test-def|--test-results|--actions|--debug-logs|--all|--dump
+./ctrl session --server-url <url> --session-id <id> --logs|--test-def|--test-results|--actions|--debug-logs|--diagnosis|--all|--dump
 ```
 
 Prints what is stored for one session, as JSON. At least one selector is required; one selector prints that value, several print an object keyed by them. An unknown session is a failure. Not used while driving a guest.
@@ -164,10 +170,57 @@ Prints what is stored for one session, as JSON. At least one selector is require
 - `--test-results` — the test result attributed to it, or `null`.
 - `--actions` — its QMP actions, oldest first.
 - `--debug-logs` — the debug log the proxy saved when the session ended any way but `succeeded` (a `failed` or `aborted` stop, the ten-minute timeout, a proxy shutdown), or `null`. `{ sessionId, sources: { serial, proxy, qemu, actions }, createdAt }`: `serial` is everything the guest wrote to `/dev/ttyS0`, `proxy` the session's log lines as `created_at level text`, `qemu` the last 4 KiB of QEMU's stderr, `actions` the QMP exchanges as `created_at id state request[ response]`. Each is capped at 1 MiB, keeping the end.
-- `--all` — all five: `{ logs, results, test_definition, actions, debug_log }`.
+- `--diagnosis` — the post-run diagnosis written with [diagnose](#diagnose), or `null` when nobody has diagnosed the session. `{ sessionId, errorType, summary, model, createdAt }`.
+- `--all` — all six: `{ logs, results, test_definition, actions, debug_log, diagnosis }`.
 - `--dump` — the session's serial console, printed raw, not as JSON. Asks the proxy at `--server-url`: a session running there answers with the console as it stands; a session it no longer holds still answers when its directory survived on the proxy host — a proxy that died mid-session never removed it — with everything the guest wrote to `/dev/ttyS0` up to the end. A session that is neither is a failure: `session "<id>" has no console on this proxy`. Does not combine with the other selectors; redirect stdout to keep it (`> console.txt`). Reads `OLIGARCHY_TOKEN`.
 
 ```bash
 ./ctrl session --server-url https://qemu.example.com --session-id 6f1c...e2a9 --all
 ./ctrl session --server-url https://qemu.example.com --session-id 6f1c...e2a9 --dump > console.txt
+```
+
+## error-type new
+
+```
+./ctrl error-type new --server-url <url> --key <key> --description <text>
+```
+
+Adds one error type to the vocabulary diagnoses are written in. The table starts empty and grows one type per distinct cause, the first time that cause is seen; there is no `other` or `unclassified`. A key that already exists is a failure: `error-type new: <key> already exists`. Not used while driving a guest.
+
+- `--key <key>` — the identifier a diagnosis carries: snake_case, `a-z`, `0-9` and `_`, starting with a letter (`guest_boot_hang`). Anything else is refused before the database is touched.
+- `--description <text>` — what a failure of this type looks like, so the next reader picks the same key for the same cause.
+
+```bash
+./ctrl error-type new --server-url https://qemu.example.com --key guest_boot_hang --description "The guest never reached the login screen; the serial console stops during boot"
+```
+
+## error-type list
+
+```
+./ctrl error-type list --server-url <url> [--json]
+```
+
+Prints every error type, ordered by key, one per line: the key, two spaces, the description, keys padded so the descriptions line up. An empty table prints nothing. Not used while driving a guest.
+
+- `--json` — print the rows as a JSON array of `{ key, description, createdAt }` instead; an empty table prints `[]`.
+
+```bash
+./ctrl error-type list --server-url https://qemu.example.com
+```
+
+## diagnose
+
+```
+./ctrl diagnose --server-url <url> --session-id <id> --type <key> --summary <text> --model <id>
+```
+
+Records the cause of one session that ended any way but `succeeded`: a `failed` or `aborted` stop, or the ten-minute timeout. Read the evidence first (`session --debug-logs`, `--actions`, the images), then name the cause with a type from [error-type list](#error-type-list); when no type fits, create one with [error-type new](#error-type-new) and diagnose with it. One diagnosis per session: a second is a failure and the first stands. Not used while driving a guest.
+
+- `--session-id <id>` — the session. Unknown, still running or downloading, or `succeeded` is a failure (`diagnose: session <id> succeeded; nothing to diagnose`).
+- `--type <key>` — an existing error type key. A key that is not in the table is a failure: `diagnose: no error type <key>; create it with ./ctrl error-type new`.
+- `--summary <text>` — what happened, in the reader's words, from the evidence.
+- `--model <id>` — the Cursor model id that is writing this diagnosis.
+
+```bash
+./ctrl diagnose --server-url https://qemu.example.com --session-id 6f1c...e2a9 --type guest_boot_hang --summary "Serial stops after 'Waiting for root device'; the ISO never mounted" --model <the Cursor model id you are running as>
 ```

--- a/v2/development.md
+++ b/v2/development.md
@@ -1242,15 +1242,17 @@ needs, and a type can be renamed or, once nothing carries it, deleted.
   a sentence from the command, not a constraint name; `listErrorTypes` orders by key;
   `findErrorType(key)` and `getDiagnosis(sessionId)` are `Option`s. An unknown type or session in
   `saveDiagnosis` is the foreign key's `DatabaseError`; the command checks both first.
-- `ctrl error-type new --key <key> --description <text>` logs `error type <key> created` and
-  prints nothing; a taken key is `error-type new: <key> already exists`. `ctrl error-type list
-  [--json]` prints `<key padded to the longest>  <description>` per row, or the rows as JSON;
-  an empty table prints nothing, or `[]`. Bare `ctrl error-type` prints help and exits 0.
+- `ctrl error-type new --key <key> --description <text>` logs `error type created; <key>`; its
+  only output is that line's stdout copy (`[global] error type created; <key>`). A taken key is
+  `error-type new: <key> already exists`. `ctrl error-type list [--json]` prints `<key padded to
+  the longest>  <description>` per row, or the rows as JSON; an empty table prints nothing, or
+  `[]`. Bare `ctrl error-type` prints help and exits 0.
 - `ctrl diagnose --session-id <id> --type <key> --summary <text> --model <id>` refuses, in this
   order: `diagnose: no session <id>`, `diagnose: session <id> succeeded; nothing to diagnose`,
   `diagnose: session <id> is still running|downloading`, `diagnose: no error type <key>; create it
   with ./ctrl error-type new`, `diagnose: session <id> already has a diagnosis`; then it logs
-  `diagnosed; <key>; <model>` attributed to the session and prints nothing. All are
+  `diagnosed; <key>; <model>` attributed to the session, and that line's stdout copy
+  (`[global] <session id>: diagnosed; <key>; <model>`) is its only output. All refusals are
   `CommandError`s.
 - `ctrl session --diagnosis` prints the row (`{ sessionId, errorType, summary, model, createdAt
   }`) or `null`; `--all` includes it last as `diagnosis`.

--- a/v2/development.md
+++ b/v2/development.md
@@ -118,7 +118,8 @@ src/
 ├── shared/      domain.ts  errors.ts  contract.ts  api.ts
 ├── config.ts    external-failure.ts
 ├── observability/  dsn.ts  instrument.ts  sentry.ts  log.ts  render.ts
-├── db/          schema.ts  client.ts  sessions.ts  actions.ts  logs.ts  debug-logs.ts  tests.ts  migrate.ts
+├── db/          schema.ts  client.ts  sessions.ts  actions.ts  logs.ts  debug-logs.ts  diagnosis.ts
+│                tests.ts  migrate.ts
 ├── qmp/         framing.ts  socket.ts  client.ts
 ├── qemu/        keys.ts  args.ts  host.ts  process.ts  qemu.ts  iso.ts  stats.ts
 ├── proxy/       sessions.ts  middleware.ts  handlers.ts  command.ts  main.ts
@@ -534,8 +535,9 @@ export class ProxyConfig extends Context.Service<ProxyConfig>()("@oligarchy/conf
   are refused by their flag schemas.
 - Ctrl: `--server-url` is required (no default, `server-url must be a valid http or https url`) on
   every action but `test run`, where it is an unrecognised flag; `iso must be a valid https url`;
-  `count must be at least 1`; `--status` is `Flag.choiceWithValue` mapping `success` to `passed`;
-  refusals are `CommandError`s. `makeCtrlCommand(deps)` takes the layer factories (`database(url)`,
+  `count must be at least 1`; `--key` and `--type` are `Domain.ErrorTypeKey` (`key must be
+  snake_case: a-z, 0-9 and _, starting with a letter`); `--status` is `Flag.choiceWithValue`
+  mapping `success` to `passed`; refusals are `CommandError`s. `makeCtrlCommand(deps)` takes the layer factories (`database(url)`,
   `linear(token)`, `cursor(apiKey)`, `proxy(options)`), `live` by default, so a test substitutes
   fakes. The proxy's `makeProxyCommand({ missingHostRequirements, serve, serverFailed })` takes the
   host check, the server as `serve(display, automation, port)` and the `Deferred` a server error
@@ -1037,13 +1039,16 @@ const prepare = Effect.fn("Qemu.prepare")(function* (id: string, disk: string | 
 - `normalizeDatabaseUrl` guards with `URL.canParse` (`db: DATABASE_URL is not a valid url`, and the
   password never lands in a message), drops `sslrootcert=system` (node-postgres reads it as a file
   path) and keeps `sslmode=verify-full`.
-- Repositories are `Context.Service`s (`SessionStore`, `ActionStore`, `LogStore`, `DebugLogStore`, `TestStore`)
-  whose methods are `Effect.fn("db.<name>")` functions that `yield* Database` once in `make`.
-  Drizzle-typed columns are trusted; the `jsonb` columns (`sessions.config`, `actions.request`,
-  `actions.response`) are written from schema-typed values and read back as Drizzle types them.
-- `src/db/schema.ts` is v1's schema formatted by oxfmt, plus `debug_logs` (v2-only). The v1
-  tables stay semantically identical, not byte-identical. Its `pgEnum` lists and the `Schema.Literals`
-  in `domain.ts` are maintained by hand together. Row
+- Repositories are `Context.Service`s (`SessionStore`, `ActionStore`, `LogStore`, `DebugLogStore`,
+  `DiagnosisStore`, `TestStore`) whose methods are `Effect.fn("db.<name>")` functions that
+  `yield* Database` once in `make`. Drizzle-typed columns are trusted; the `jsonb` columns
+  (`sessions.config`, `actions.request`, `actions.response`) are written from schema-typed values
+  and read back as Drizzle types them.
+- `src/db/schema.ts` is v1's schema formatted by oxfmt, plus `debug_logs`, `post_run_error_types`
+  and `post_run_diagnosis` (v2-only). The v1 tables stay semantically identical, not
+  byte-identical. Its `pgEnum` lists and the `Schema.Literals` in `domain.ts` are maintained by
+  hand together; `post_run_error_types` is the one vocabulary that is data, not an enum (see
+  Post-run diagnosis). Row
   stamps come from Postgres `now()` in the statement; Effect-side time from
   `Clock.currentTimeMillis`. `registerAgent`'s primary key makes one session per agent; a second
   registration is a `DatabaseError` by design. `TestStore.closeResult(resultId, status, reason,
@@ -1112,8 +1117,9 @@ statement inside with `Client.attempt("endSession", () => tx.update(...))`.
 - Replay is `actions WHERE session_id ORDER BY created_at, id`; the identity id breaks timestamp
   ties. `sessions.config` holds the effective launch config so a replay boots an identical machine.
 - The tables: `sessions`, `agent_runs`, `actions`, `images`, `logs`, `debug_logs`,
-  `test_definitions`, `test_base_prompts`, `test_runs`, `test_results`, declared in
-  `src/db/schema.ts`. v1 declared every table except `debug_logs`. `test_results.model` is the
+  `post_run_error_types`, `post_run_diagnosis`, `test_definitions`, `test_base_prompts`,
+  `test_runs`, `test_results`, declared in `src/db/schema.ts`. v1 declared every table except
+  `debug_logs`, `post_run_error_types` and `post_run_diagnosis`. `test_results.model` is the
   Cursor model id that result's agent used, or null until `test start` writes it. One run can
   mix models. `test_results.session_id` is unique when set, so one session cannot belong to two
   results.
@@ -1176,7 +1182,7 @@ vanish with the machine, plus the control-plane lines already offered for that s
 verdict included. `sources` is a jsonb map so each chunk is labeled by origin. There is no
 `journalctl` key — that stream is not separately available. `ctrl session --debug-logs` prints
 the row (`null` when the session succeeded or predates the table); `--all` includes it as
-`debug_log`.
+`debug_log`. The cause it shows is named afterwards in `post_run_diagnosis` (Post-run diagnosis).
 
 - `serial` is the guest UART (`/dev/ttyS0` → `<session-dir>/serial.log`; see Operating loop).
   The guest journal, dmesg, user-session journal, coredumps and compositor crash folders live
@@ -1206,6 +1212,48 @@ the row (`null` when the session succeeded or predates the table); `--all` inclu
   session ends once, so each writes at most once. A succeeded stop does not write a row — there
   is nothing to explain.
 - The columns: `session_id` (primary key, references `sessions.id`), `sources`, `created_at`.
+
+## Post-run diagnosis
+
+A diagnosis names the cause of a session that ended any way but `succeeded` (`failed`,
+`aborted`, `timed_out`), written after the run by whoever read the evidence (`debug_logs`,
+`actions`, `images`). Its vocabulary is data, not an enum: `post_run_error_types` starts empty and
+grows one row per distinct cause the moment that cause is first seen, through `ctrl error-type
+new`, never through a migration. Why: a `pgEnum` value can be added only by a code change and a
+migration and can never be removed; a lookup table is an insert, carries the description the key
+needs, and a type can be renamed or, once nothing carries it, deleted.
+
+- `post_run_error_types`: `key` (primary key, `text`), `description`, `created_at`. `key` is a
+  `Domain.ErrorTypeKey`, `^[a-z][a-z0-9_]*$`, refused at the flag with `key must be snake_case:
+  a-z, 0-9 and _, starting with a letter`; the table itself has no check, the CLI is the boundary.
+  There is no seeded row, no `unclassified` or `other`: a failure that cannot be named yet is not
+  diagnosed yet.
+- `post_run_diagnosis`: `session_id` (primary key, references `sessions.id`), `error_type`
+  (`NOT NULL`, references `post_run_error_types.key`, `ON UPDATE CASCADE`), `summary`, `model`,
+  `created_at`, plus an index on `error_type` for the per-type counts. No column is nullable and
+  no row exists until someone diagnoses: a session without a row is one nobody has diagnosed.
+  `model` is the Cursor model id that wrote the diagnosis, as `test_results.model` is the one that
+  drove the session. The key is the session: a second diagnosis is refused and the first stands.
+  Renaming a key follows into the diagnoses that carry it; deleting a type in use is a
+  `DatabaseError` from the foreign key.
+- `DiagnosisStore` (`src/db/diagnosis.ts`): `createErrorType(key, description)` and
+  `saveDiagnosis({ sessionId, errorType, summary, model })` are `insert … on conflict do nothing
+  returning` and answer `false` when the key or the session already has its row, so a duplicate is
+  a sentence from the command, not a constraint name; `listErrorTypes` orders by key;
+  `findErrorType(key)` and `getDiagnosis(sessionId)` are `Option`s. An unknown type or session in
+  `saveDiagnosis` is the foreign key's `DatabaseError`; the command checks both first.
+- `ctrl error-type new --key <key> --description <text>` logs `error type <key> created` and
+  prints nothing; a taken key is `error-type new: <key> already exists`. `ctrl error-type list
+  [--json]` prints `<key padded to the longest>  <description>` per row, or the rows as JSON;
+  an empty table prints nothing, or `[]`. Bare `ctrl error-type` prints help and exits 0.
+- `ctrl diagnose --session-id <id> --type <key> --summary <text> --model <id>` refuses, in this
+  order: `diagnose: no session <id>`, `diagnose: session <id> succeeded; nothing to diagnose`,
+  `diagnose: session <id> is still running|downloading`, `diagnose: no error type <key>; create it
+  with ./ctrl error-type new`, `diagnose: session <id> already has a diagnosis`; then it logs
+  `diagnosed; <key>; <model>` attributed to the session and prints nothing. All are
+  `CommandError`s.
+- `ctrl session --diagnosis` prints the row (`{ sessionId, errorType, summary, model, createdAt
+  }`) or `null`; `--all` includes it last as `diagnosis`.
 
 ## Dashboard
 

--- a/v2/drizzle/0002_post_run_diagnosis.sql
+++ b/v2/drizzle/0002_post_run_diagnosis.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "post_run_diagnosis" (
+	"session_id" uuid PRIMARY KEY NOT NULL,
+	"error_type" text NOT NULL,
+	"summary" text NOT NULL,
+	"model" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "post_run_error_types" (
+	"key" text PRIMARY KEY NOT NULL,
+	"description" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "post_run_diagnosis" ADD CONSTRAINT "post_run_diagnosis_session_id_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."sessions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "post_run_diagnosis" ADD CONSTRAINT "post_run_diagnosis_error_type_post_run_error_types_key_fk" FOREIGN KEY ("error_type") REFERENCES "public"."post_run_error_types"("key") ON DELETE no action ON UPDATE cascade;--> statement-breakpoint
+CREATE INDEX "post_run_diagnosis_error_type_idx" ON "post_run_diagnosis" USING btree ("error_type");

--- a/v2/drizzle/meta/0002_snapshot.json
+++ b/v2/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,972 @@
+{
+  "id": "d8cfe425-dc91-4adc-b0b1-43fb441efaa2",
+  "prevId": "330abe02-d793-4eec-8b15-a6151fc32ca0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "actions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "action_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "actions_session_id_idx": {
+          "name": "actions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_session_id_sessions_id_fk": {
+          "name": "actions_session_id_sessions_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actions_agent_id_agent_runs_agent_id_fk": {
+          "name": "actions_agent_id_agent_runs_agent_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_runs_session_id_idx": {
+          "name": "agent_runs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_session_id_sessions_id_fk": {
+          "name": "agent_runs_session_id_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debug_logs_session_id_sessions_id_fk": {
+          "name": "debug_logs_session_id_sessions_id_fk",
+          "tableFrom": "debug_logs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "images_id_idx": {
+          "name": "images_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_action_id_actions_id_fk": {
+          "name": "images_action_id_actions_id_fk",
+          "tableFrom": "images",
+          "tableTo": "actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_session_id_idx": {
+          "name": "logs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_run_diagnosis": {
+      "name": "post_run_diagnosis",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_run_diagnosis_error_type_idx": {
+          "name": "post_run_diagnosis_error_type_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_run_diagnosis_session_id_sessions_id_fk": {
+          "name": "post_run_diagnosis_session_id_sessions_id_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_run_diagnosis_error_type_post_run_error_types_key_fk": {
+          "name": "post_run_diagnosis_error_type_post_run_error_types_key_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "post_run_error_types",
+          "columnsFrom": [
+            "error_type"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_run_error_types": {
+      "name": "post_run_error_types",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_base_prompts": {
+      "name": "test_base_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_base_prompts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_base_prompts_name_idx": {
+          "name": "test_base_prompts_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_definitions": {
+      "name": "test_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_definitions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_definitions_name_idx": {
+          "name": "test_definitions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_results": {
+      "name": "test_results",
+      "schema": "",
+      "columns": {
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "test_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_results_run_definition_idx": {
+          "name": "test_results_run_definition_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_session_id_idx": {
+          "name": "test_results_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_results_run_id_test_runs_id_fk": {
+          "name": "test_results_run_id_test_runs_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_definition_id_test_definitions_id_fk": {
+          "name": "test_results_definition_id_test_definitions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_session_id_sessions_id_fk": {
+          "name": "test_results_session_id_sessions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso": {
+          "name": "iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "test_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.action_state": {
+      "name": "action_state",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_result_status": {
+      "name": "test_result_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_run_status": {
+      "name": "test_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/v2/drizzle/meta/_journal.json
+++ b/v2/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1788710030568,
       "tag": "0001_init",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1788717628281,
+      "tag": "0002_post_run_diagnosis",
+      "breakpoints": true
     }
   ]
 }

--- a/v2/src/ctrl/command.ts
+++ b/v2/src/ctrl/command.ts
@@ -429,7 +429,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
         () => refuse(`error-type new: ${input.key} already exists`),
       ),
     );
-    yield* log.info(`error type ${input.key} created`);
+    yield* log.info(`error type created; ${input.key}`);
   });
 
   // error-type list [--json]
@@ -437,7 +437,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     readonly json: boolean;
   }) {
     const diagnosis = yield* Diagnosis.DiagnosisStore;
-    const rows = yield* diagnosis.listErrorTypes;
+    const rows = yield* diagnosis.listErrorTypes();
     yield* printLines(Render.renderErrorTypes(rows, input.json));
   });
 

--- a/v2/src/ctrl/command.ts
+++ b/v2/src/ctrl/command.ts
@@ -17,10 +17,12 @@ import * as Config from "../config.ts";
 import * as Actions from "../db/actions.ts";
 import * as DebugLogs from "../db/debug-logs.ts";
 import * as Client from "../db/client.ts";
+import * as Diagnosis from "../db/diagnosis.ts";
 import * as Logs from "../db/logs.ts";
 import * as Sessions from "../db/sessions.ts";
 import * as Tests from "../db/tests.ts";
 import * as Log from "../observability/log.ts";
+import * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 import * as Cursor from "./cursor.ts";
 import * as Linear from "./linear.ts";
@@ -35,6 +37,7 @@ export type Stores =
   | Actions.ActionStore
   | Logs.LogStore
   | DebugLogs.DebugLogStore
+  | Diagnosis.DiagnosisStore
   | Tests.TestStore
   | Log.Log;
 
@@ -65,6 +68,7 @@ const databaseLayers = (url: Redacted.Redacted): Layer.Layer<Stores, Errors.Data
     Sessions.SessionStore.layer,
     Tests.TestStore.layer,
     DebugLogs.DebugLogStore.layer,
+    Diagnosis.DiagnosisStore.layer,
     Log.Log.layer,
   ).pipe(
     Layer.provideMerge(Actions.ActionStore.layer),
@@ -134,6 +138,15 @@ const nameFlag = (description: string) =>
     Flag.optional,
     Flag.withDescription(description),
   );
+
+const modelFlag = (description: string) =>
+  Flag.string("model").pipe(
+    Flag.withSchema(Schema.NonEmptyString),
+    Flag.withDescription(description),
+  );
+
+const errorTypeKeyFlag = (name: string, description: string) =>
+  Flag.string(name).pipe(Flag.withSchema(Domain.ErrorTypeKey), Flag.withDescription(description));
 
 const toggle = (name: string, description: string) =>
   Flag.boolean(name).pipe(Flag.withDefault(false), Flag.withDescription(description));
@@ -403,6 +416,73 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     );
   });
 
+  // error-type new --key <key> --description <text>
+  const errorTypeNew = Effect.fn("ctrl.error-type.new")(function* (input: {
+    readonly key: string;
+    readonly description: string;
+  }) {
+    const diagnosis = yield* Diagnosis.DiagnosisStore;
+    const log = yield* Log.Log;
+    yield* diagnosis.createErrorType(input.key, input.description).pipe(
+      Effect.filterOrFail(
+        (created) => created,
+        () => refuse(`error-type new: ${input.key} already exists`),
+      ),
+    );
+    yield* log.info(`error type ${input.key} created`);
+  });
+
+  // error-type list [--json]
+  const errorTypeList = Effect.fn("ctrl.error-type.list")(function* (input: {
+    readonly json: boolean;
+  }) {
+    const diagnosis = yield* Diagnosis.DiagnosisStore;
+    const rows = yield* diagnosis.listErrorTypes;
+    yield* printLines(Render.renderErrorTypes(rows, input.json));
+  });
+
+  // diagnose --session-id <id> --type <key> --summary <text> --model <id>
+  const diagnose = Effect.fn("ctrl.diagnose")(function* (input: {
+    readonly sessionId: string;
+    readonly type: string;
+    readonly summary: string;
+    readonly model: string;
+  }) {
+    const sessions = yield* Sessions.SessionStore;
+    const diagnosis = yield* Diagnosis.DiagnosisStore;
+    const log = yield* Log.Log;
+    const status = yield* orRefuse(
+      sessions.getSessionStatus(input.sessionId),
+      `diagnose: no session ${input.sessionId}`,
+    );
+    if (status === "succeeded") {
+      return yield* refuse(`diagnose: session ${input.sessionId} succeeded; nothing to diagnose`);
+    }
+    if (status === "running" || status === "downloading") {
+      return yield* refuse(`diagnose: session ${input.sessionId} is still ${status}`);
+    }
+    yield* orRefuse(
+      diagnosis.findErrorType(input.type),
+      `diagnose: no error type ${input.type}; create it with ./ctrl error-type new`,
+    );
+    yield* diagnosis
+      .saveDiagnosis({
+        sessionId: input.sessionId,
+        errorType: input.type,
+        summary: input.summary,
+        model: input.model,
+      })
+      .pipe(
+        Effect.filterOrFail(
+          (saved) => saved,
+          () => refuse(`diagnose: session ${input.sessionId} already has a diagnosis`),
+        ),
+      );
+    return yield* log.info(`diagnosed; ${input.type}; ${input.model}`, {
+      sessionId: input.sessionId,
+    });
+  });
+
   // session list [--count <n>] [--active] [--json]
   const sessionList = Effect.fn("ctrl.session.list")(function* (input: {
     readonly count: number;
@@ -433,6 +513,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     readonly testResults: boolean;
     readonly actions: boolean;
     readonly debugLogs: boolean;
+    readonly diagnosis: boolean;
     readonly all: boolean;
   };
 
@@ -442,6 +523,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     const tests = yield* Tests.TestStore;
     const actions = yield* Actions.ActionStore;
     const debugLogs = yield* DebugLogs.DebugLogStore;
+    const diagnosis = yield* Diagnosis.DiagnosisStore;
     yield* orRefuse(sessions.sessionExists(id), `session: no session ${id}`);
 
     const parts: Array<readonly [string, unknown]> = [];
@@ -475,12 +557,15 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     if (input.all || input.debugLogs) {
       parts.push(["debug_log", Option.getOrNull(yield* debugLogs.getDebugLog(id))]);
     }
+    if (input.all || input.diagnosis) {
+      parts.push(["diagnosis", Option.getOrNull(yield* diagnosis.getDiagnosis(id))]);
+    }
     // One selector prints its bare value; several print an object keyed by selector.
     const single = parts.length === 1 ? parts[0] : undefined;
     yield* printJson(single === undefined ? Object.fromEntries(parts) : single[1]);
   });
 
-  // session --session-id <id> --logs|--test-def|--test-results|--actions|--debug-logs|--all|--dump
+  // session --session-id <id> --logs|--test-def|--test-results|--actions|--debug-logs|--diagnosis|--all|--dump
   const sessionInspect = Effect.fn("ctrl.session.inspect")(function* (
     input: Selectors & {
       readonly serverUrl: string;
@@ -494,15 +579,16 @@ export const makeCtrlCommand = (deps: Deps = live) => {
       input.testResults ||
       input.actions ||
       input.debugLogs ||
+      input.diagnosis ||
       input.all;
     if (!inspecting && !input.dump) {
       return yield* refuse(
-        "session: --logs, --test-def, --test-results, --actions, --debug-logs, --all, or --dump is required",
+        "session: --logs, --test-def, --test-results, --actions, --debug-logs, --diagnosis, --all, or --dump is required",
       );
     }
     if (inspecting && input.dump) {
       return yield* refuse(
-        "session: --dump does not combine with --logs, --test-def, --test-results, --actions, --debug-logs, or --all",
+        "session: --dump does not combine with --logs, --test-def, --test-results, --actions, --debug-logs, --diagnosis, or --all",
       );
     }
     return yield* input.dump
@@ -558,10 +644,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
         Flag.withSchema(Schema.NonEmptyString),
         Flag.withDescription("Test result id from the Linear ticket"),
       ),
-      model: Flag.string("model").pipe(
-        Flag.withSchema(Schema.NonEmptyString),
-        Flag.withDescription("Cursor model id that is running this result"),
-      ),
+      model: modelFlag("Cursor model id that is running this result"),
     },
     testStart,
   ).pipe(
@@ -638,7 +721,11 @@ export const makeCtrlCommand = (deps: Deps = live) => {
         "debug-logs",
         "Print the session's debug log (serial, proxy, qemu, actions), saved when it did not succeed",
       ),
-      all: toggle("all", "Print logs, test definition, test results, actions, and debug log"),
+      diagnosis: toggle("diagnosis", "Print the session's post-run diagnosis, written by diagnose"),
+      all: toggle(
+        "all",
+        "Print logs, test definition, test results, actions, debug log, and diagnosis",
+      ),
       dump: toggle(
         "dump",
         "Print the session's serial console from the proxy: the running machine's, or what a dead one left on disk",
@@ -647,16 +734,73 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     sessionInspect,
   ).pipe(
     Command.withDescription(
-      "session --session-id <id> --logs|--test-def|--test-results|--actions|--debug-logs|--all|--dump; or list",
+      "session --session-id <id> --logs|--test-def|--test-results|--actions|--debug-logs|--diagnosis|--all|--dump; or list",
     ),
     Command.provide(withDb),
     Command.withSubcommands([sessionListCommand]),
+  );
+
+  const errorTypeNewCommand = Command.make(
+    "new",
+    {
+      serverUrl: serverUrlFlag,
+      key: errorTypeKeyFlag("key", "snake_case key the diagnoses of this type carry"),
+      description: Flag.string("description").pipe(
+        Flag.withSchema(Schema.NonEmptyString),
+        Flag.withDescription("What a failure of this type looks like"),
+      ),
+    },
+    errorTypeNew,
+  ).pipe(
+    Command.withDescription("Add an error type to the diagnosis vocabulary"),
+    Command.provide(withDb),
+  );
+
+  const errorTypeListCommand = Command.make(
+    "list",
+    {
+      serverUrl: serverUrlFlag,
+      json: toggle("json", "Print the types as a JSON array"),
+    },
+    errorTypeList,
+  ).pipe(
+    Command.withDescription("Print every error type with its description, ordered by key"),
+    Command.provide(withDb),
+  );
+
+  const errorTypeCommand = Command.make("error-type").pipe(
+    Command.withDescription("error-type new --key <key> --description <text>; or list"),
+    Command.withSubcommands([errorTypeNewCommand, errorTypeListCommand]),
+  );
+
+  const diagnoseCommand = Command.make(
+    "diagnose",
+    {
+      serverUrl: serverUrlFlag,
+      sessionId: sessionIdFlag,
+      type: errorTypeKeyFlag("type", "Error type key; error-type list prints them"),
+      summary: Flag.string("summary").pipe(
+        Flag.withSchema(Schema.NonEmptyString),
+        Flag.withDescription("What happened, read from the evidence"),
+      ),
+      model: modelFlag("Cursor model id that is writing this diagnosis"),
+    },
+    diagnose,
+  ).pipe(
+    Command.withDescription("Record the cause of a session that ended any way but succeeded"),
+    Command.provide(withDb),
   );
 
   return Command.make("ctrl").pipe(
     Command.withDescription(
       "Record and inspect Oligarchy test runs. Every action reads DATABASE_URL; every action but test run takes --server-url (or SERVER_URL).",
     ),
-    Command.withSubcommands([testCommand, testResultsCommand, sessionCommand]),
+    Command.withSubcommands([
+      testCommand,
+      testResultsCommand,
+      sessionCommand,
+      errorTypeCommand,
+      diagnoseCommand,
+    ]),
   );
 };

--- a/v2/src/ctrl/render.ts
+++ b/v2/src/ctrl/render.ts
@@ -62,7 +62,6 @@ export const renderTestDefinitions = (
   details: boolean,
 ): ReadonlyArray<string> => (details ? [json(rows)] : rows.map((row) => row.name));
 
-// Keys padded to the longest so the descriptions line up in one column.
 export const renderErrorTypes = (
   rows: ReadonlyArray<ErrorTypeRow>,
   asJson: boolean,

--- a/v2/src/ctrl/render.ts
+++ b/v2/src/ctrl/render.ts
@@ -8,6 +8,7 @@ export type SessionRow = {
 };
 
 export type TestDefinitionRow = typeof DbSchema.testDefinitions.$inferSelect;
+export type ErrorTypeRow = typeof DbSchema.postRunErrorTypes.$inferSelect;
 
 export const STATUS_COLOR: Readonly<Record<Domain.SessionStatus, string>> = {
   downloading: "\x1b[90m",
@@ -60,6 +61,18 @@ export const renderTestDefinitions = (
   rows: ReadonlyArray<TestDefinitionRow>,
   details: boolean,
 ): ReadonlyArray<string> => (details ? [json(rows)] : rows.map((row) => row.name));
+
+// Keys padded to the longest so the descriptions line up in one column.
+export const renderErrorTypes = (
+  rows: ReadonlyArray<ErrorTypeRow>,
+  asJson: boolean,
+): ReadonlyArray<string> => {
+  if (asJson) {
+    return [json(rows)];
+  }
+  const width = Math.max(0, ...rows.map((row) => row.key.length));
+  return rows.map((row) => `${row.key.padEnd(width)}  ${row.description}`);
+};
 
 export const agentLink = (url: string): string =>
   `Agent here, go check it out for more information: ${url}`;

--- a/v2/src/db/diagnosis.ts
+++ b/v2/src/db/diagnosis.ts
@@ -1,0 +1,81 @@
+import { eq } from "drizzle-orm";
+import { Array as Arr, Context, Effect, Layer } from "effect";
+import * as Client from "./client.ts";
+import * as DbSchema from "./schema.ts";
+
+export type ErrorTypeRow = typeof DbSchema.postRunErrorTypes.$inferSelect;
+export type DiagnosisRow = typeof DbSchema.postRunDiagnosis.$inferSelect;
+
+export type DiagnosisInput = {
+  readonly sessionId: string;
+  readonly errorType: string;
+  readonly summary: string;
+  readonly model: string;
+};
+
+export class DiagnosisStore extends Context.Service<DiagnosisStore>()(
+  "@oligarchy/db/DiagnosisStore",
+  {
+    make: Effect.gen(function* () {
+      const database = yield* Client.Database;
+
+      // false when the key is already taken: the primary key decides, and a conflict is an
+      // answer the command reads, not a database error.
+      const createErrorType = Effect.fn("db.createErrorType")(function* (
+        key: string,
+        description: string,
+      ) {
+        const rows = yield* database.run("createErrorType", (db) =>
+          db
+            .insert(DbSchema.postRunErrorTypes)
+            .values({ key, description })
+            .onConflictDoNothing()
+            .returning({ key: DbSchema.postRunErrorTypes.key }),
+        );
+        return rows.length > 0;
+      });
+
+      const listErrorTypes = database.run("listErrorTypes", (db) =>
+        db.select().from(DbSchema.postRunErrorTypes).orderBy(DbSchema.postRunErrorTypes.key),
+      );
+
+      const findErrorType = Effect.fn("db.findErrorType")(function* (key: string) {
+        const rows = yield* database.run("findErrorType", (db) =>
+          db
+            .select()
+            .from(DbSchema.postRunErrorTypes)
+            .where(eq(DbSchema.postRunErrorTypes.key, key)),
+        );
+        return Arr.head(rows);
+      });
+
+      // false when the session already has its diagnosis: the first one stands. An unknown
+      // type or session is a DatabaseError from the foreign keys; the command checks both
+      // first so the operator reads a sentence, not a constraint name.
+      const saveDiagnosis = Effect.fn("db.saveDiagnosis")(function* (input: DiagnosisInput) {
+        const rows = yield* database.run("saveDiagnosis", (db) =>
+          db
+            .insert(DbSchema.postRunDiagnosis)
+            .values(input)
+            .onConflictDoNothing()
+            .returning({ sessionId: DbSchema.postRunDiagnosis.sessionId }),
+        );
+        return rows.length > 0;
+      });
+
+      const getDiagnosis = Effect.fn("db.getDiagnosis")(function* (sessionId: string) {
+        const rows = yield* database.run("getDiagnosis", (db) =>
+          db
+            .select()
+            .from(DbSchema.postRunDiagnosis)
+            .where(eq(DbSchema.postRunDiagnosis.sessionId, sessionId)),
+        );
+        return Arr.head(rows);
+      });
+
+      return { createErrorType, listErrorTypes, findErrorType, saveDiagnosis, getDiagnosis };
+    }),
+  },
+) {
+  static readonly layer = Layer.effect(this)(this.make);
+}

--- a/v2/src/db/diagnosis.ts
+++ b/v2/src/db/diagnosis.ts
@@ -19,8 +19,7 @@ export class DiagnosisStore extends Context.Service<DiagnosisStore>()(
     make: Effect.gen(function* () {
       const database = yield* Client.Database;
 
-      // false when the key is already taken: the primary key decides, and a conflict is an
-      // answer the command reads, not a database error.
+      // false when the key is taken: a conflict is an answer the command reads, not an error.
       const createErrorType = Effect.fn("db.createErrorType")(function* (
         key: string,
         description: string,
@@ -35,9 +34,11 @@ export class DiagnosisStore extends Context.Service<DiagnosisStore>()(
         return rows.length > 0;
       });
 
-      const listErrorTypes = database.run("listErrorTypes", (db) =>
-        db.select().from(DbSchema.postRunErrorTypes).orderBy(DbSchema.postRunErrorTypes.key),
-      );
+      const listErrorTypes = Effect.fn("db.listErrorTypes")(function* () {
+        return yield* database.run("listErrorTypes", (db) =>
+          db.select().from(DbSchema.postRunErrorTypes).orderBy(DbSchema.postRunErrorTypes.key),
+        );
+      });
 
       const findErrorType = Effect.fn("db.findErrorType")(function* (key: string) {
         const rows = yield* database.run("findErrorType", (db) =>
@@ -49,9 +50,7 @@ export class DiagnosisStore extends Context.Service<DiagnosisStore>()(
         return Arr.head(rows);
       });
 
-      // false when the session already has its diagnosis: the first one stands. An unknown
-      // type or session is a DatabaseError from the foreign keys; the command checks both
-      // first so the operator reads a sentence, not a constraint name.
+      // false when the session already has its diagnosis: the first one stands.
       const saveDiagnosis = Effect.fn("db.saveDiagnosis")(function* (input: DiagnosisInput) {
         const rows = yield* database.run("saveDiagnosis", (db) =>
           db

--- a/v2/src/db/schema.ts
+++ b/v2/src/db/schema.ts
@@ -135,6 +135,38 @@ export const debugLogs = pgTable("debug_logs", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
+// The vocabulary a diagnosis is written in. It is data, not an enum, so a new kind of
+// failure is an insert the moment it is first seen, never a migration; it starts empty and
+// grows one row per distinct cause. key is the value a diagnosis carries, so a diagnosis
+// reads without a join; a rename cascades into the diagnoses that carry it, and a type in
+// use cannot be deleted.
+export const postRunErrorTypes = pgTable("post_run_error_types", {
+  key: text("key").primaryKey(),
+  description: text("description").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+// One diagnosis per session that ended any way but succeeded, written after the run by
+// whoever read the evidence (debug_logs, actions, images). session_id is the key: a second
+// diagnosis is refused, and a session without a row is one nobody has diagnosed yet — there
+// is no placeholder type and no nullable column. model is the Cursor model id that wrote
+// the diagnosis, as test_results.model is the one that drove the session.
+export const postRunDiagnosis = pgTable(
+  "post_run_diagnosis",
+  {
+    sessionId: uuid("session_id")
+      .primaryKey()
+      .references(() => sessions.id),
+    errorType: text("error_type")
+      .notNull()
+      .references(() => postRunErrorTypes.key, { onUpdate: "cascade" }),
+    summary: text("summary").notNull(),
+    model: text("model").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("post_run_diagnosis_error_type_idx").on(table.errorType)],
+);
+
 // A definition is the stored mission an agent is handed — what it is about, what to
 // do, and the proof that closes it. Rows are edited in place; name is the lookup key.
 export const testDefinitions = pgTable(

--- a/v2/src/db/schema.ts
+++ b/v2/src/db/schema.ts
@@ -135,22 +135,16 @@ export const debugLogs = pgTable("debug_logs", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
-// The vocabulary a diagnosis is written in. It is data, not an enum, so a new kind of
-// failure is an insert the moment it is first seen, never a migration; it starts empty and
-// grows one row per distinct cause. key is the value a diagnosis carries, so a diagnosis
-// reads without a join; a rename cascades into the diagnoses that carry it, and a type in
-// use cannot be deleted.
+// The diagnosis vocabulary as data, not an enum: a new kind of failure is an insert the
+// moment it is first seen, never a migration. Starts empty; a rename cascades.
 export const postRunErrorTypes = pgTable("post_run_error_types", {
   key: text("key").primaryKey(),
   description: text("description").notNull(),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
-// One diagnosis per session that ended any way but succeeded, written after the run by
-// whoever read the evidence (debug_logs, actions, images). session_id is the key: a second
-// diagnosis is refused, and a session without a row is one nobody has diagnosed yet — there
-// is no placeholder type and no nullable column. model is the Cursor model id that wrote
-// the diagnosis, as test_results.model is the one that drove the session.
+// One diagnosis per session that did not succeed, keyed by the session: a row absent is a
+// session nobody has diagnosed; no placeholder type, no nullable column. model wrote it.
 export const postRunDiagnosis = pgTable(
   "post_run_diagnosis",
   {

--- a/v2/src/shared/domain.ts
+++ b/v2/src/shared/domain.ts
@@ -20,6 +20,17 @@ export const ImageId = Schema.String.check(Schema.isUUID())
   .annotate({ identifier: "@oligarchy/shared/domain/ImageId" });
 export type ImageId = typeof ImageId.Type;
 
+// The key of a post-run error type: what a diagnosis carries and an operator types. snake_case
+// so it reads in a table, a shell and a GROUP BY without quoting.
+export const ErrorTypeKey = Schema.String.check(
+  Schema.isPattern(/^[a-z][a-z0-9_]*$/, {
+    message: "key must be snake_case: a-z, 0-9 and _, starting with a letter",
+  }),
+)
+  .pipe(Schema.brand("ErrorTypeKey"))
+  .annotate({ identifier: "@oligarchy/shared/domain/ErrorTypeKey" });
+export type ErrorTypeKey = typeof ErrorTypeKey.Type;
+
 export const SessionStatus = Schema.Literals([
   "downloading",
   "running",

--- a/v2/test/ctrl/command.unit.test.ts
+++ b/v2/test/ctrl/command.unit.test.ts
@@ -1169,6 +1169,440 @@ describe("session list", () => {
 });
 
 // ---------------------------------------------------------------------------
+// error-type new / list
+// ---------------------------------------------------------------------------
+
+type ErrorTypeRow = typeof DbSchema.postRunErrorTypes.$inferSelect;
+type DiagnosisRow = typeof DbSchema.postRunDiagnosis.$inferSelect;
+
+const bootHang: ErrorTypeRow = {
+  key: "guest_boot_hang",
+  description: "The guest never reached the login screen",
+  createdAt: new Date("2026-09-02T00:00:00Z"),
+};
+
+const misread: ErrorTypeRow = {
+  key: "agent_misread_screen",
+  description: "The agent acted on a screen it described wrongly",
+  createdAt: new Date("2026-09-02T00:00:01Z"),
+};
+
+const diagnosis: DiagnosisRow = {
+  sessionId: SESSION_ID,
+  errorType: bootHang.key,
+  summary: "Serial shows the kernel waiting on the root device; the ISO never mounted",
+  model: MODEL,
+  createdAt: new Date("2026-09-03T00:00:05Z"),
+};
+
+const NEW_TYPE = [
+  "error-type",
+  "new",
+  "--key",
+  bootHang.key,
+  "--description",
+  bootHang.description,
+  "--server-url",
+  SERVER,
+];
+
+describe("error-type new", () => {
+  it.effect("stores the key and description and logs the creation (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      const exit = yield* h.run(NEW_TYPE);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(h.stores.diagnosis.errorTypes).toHaveLength(1);
+      expect(h.stores.diagnosis.errorTypes[0]).toMatchObject({
+        key: bootHang.key,
+        description: bootHang.description,
+      });
+      expect(h.stores.diagnosis.errorTypes[0]?.createdAt).toBeInstanceOf(Date);
+      expect(h.log.lines).toEqual([
+        {
+          level: "info",
+          text: `error type ${bootHang.key} created`,
+          sessionId: undefined,
+          agentId: undefined,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+      expect(yield* stdout).toEqual([]);
+      expect(h.touched).toEqual(["database"]);
+    }),
+  );
+
+  it.effect("refuses a key that already exists and leaves the stored description (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.diagnosis.errorTypes.push(bootHang);
+      const exit = yield* h.run([
+        "error-type",
+        "new",
+        "--key",
+        bootHang.key,
+        "--description",
+        "a second meaning",
+        "--server-url",
+        SERVER,
+      ]);
+      expect(failure(exit)).toMatchObject({
+        _tag: "CommandError",
+        message: `error-type new: ${bootHang.key} already exists`,
+      });
+      expect(h.stores.diagnosis.errorTypes).toEqual([bootHang]);
+      expect(h.log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("refuses a key that is not snake_case before touching the database (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      for (const key of ["Guest Boot Hang", "guest-boot-hang", "7_days", ""]) {
+        const exit = yield* h.run([
+          "error-type",
+          "new",
+          "--key",
+          key,
+          "--description",
+          "d",
+          "--server-url",
+          SERVER,
+        ]);
+        expect(helpErrors(exit).join("\n"), key).toMatch(
+          /key must be snake_case: a-z, 0-9 and _, starting with a letter/,
+        );
+      }
+      expect(h.touched).toEqual([]);
+    }),
+  );
+
+  it.effect("requires --key and a non-empty --description (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      const noKey = yield* h.run([
+        "error-type",
+        "new",
+        "--description",
+        "d",
+        "--server-url",
+        SERVER,
+      ]);
+      expect(helpErrors(noKey).join("\n")).toMatch(/Missing required flag: --key/);
+      const noDescription = yield* h.run([
+        "error-type",
+        "new",
+        "--key",
+        bootHang.key,
+        "--server-url",
+        SERVER,
+      ]);
+      expect(helpErrors(noDescription).join("\n")).toMatch(/Missing required flag: --description/);
+      const empty = yield* h.run([
+        "error-type",
+        "new",
+        "--key",
+        bootHang.key,
+        "--description",
+        "",
+        "--server-url",
+        SERVER,
+      ]);
+      expect(helpErrors(empty).join("\n")).toMatch(/--description.*length of at least 1/s);
+      expect(h.touched).toEqual([]);
+    }),
+  );
+});
+
+describe("error-type list", () => {
+  it.effect("prints key and description columns ordered by key (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.diagnosis.errorTypes.push(bootHang, misread);
+      const exit = yield* h.run(["error-type", "list", "--server-url", SERVER]);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* stdout).toEqual([
+        `agent_misread_screen  ${misread.description}`,
+        `guest_boot_hang       ${bootHang.description}`,
+      ]);
+      expect(h.touched).toEqual(["database"]);
+    }),
+  );
+
+  it.effect("--json prints the rows as a JSON array (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.diagnosis.errorTypes.push(bootHang);
+      const exit = yield* h.run(["error-type", "list", "--json", "--server-url", SERVER]);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* lastJson).toEqual([
+        { ...bootHang, createdAt: bootHang.createdAt.toISOString() },
+      ]);
+    }),
+  );
+
+  it.effect("prints nothing as text and [] as JSON when there are no types (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      expect(Exit.isSuccess(yield* h.run(["error-type", "list", "--server-url", SERVER]))).toBe(
+        true,
+      );
+      expect(
+        Exit.isSuccess(yield* h.run(["error-type", "list", "--json", "--server-url", SERVER])),
+      ).toBe(true);
+      expect(yield* stdout).toEqual(["[]"]);
+    }),
+  );
+
+  it.effect("bare error-type prints help and touches nothing (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      const exit = yield* h.run(["error-type"], {});
+      expect(helpErrors(exit)).toEqual([]);
+      expect(h.touched).toEqual([]);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// diagnose
+// ---------------------------------------------------------------------------
+
+const DIAGNOSE = [
+  "diagnose",
+  "--session-id",
+  SESSION_ID,
+  "--type",
+  bootHang.key,
+  "--summary",
+  diagnosis.summary,
+  "--model",
+  MODEL,
+  "--server-url",
+  SERVER,
+];
+
+describe("diagnose", () => {
+  it.effect("writes one diagnosis for a failed session and logs it (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.sessions.sessions.push(session(SESSION_ID, "failed", ago(500)));
+      h.stores.diagnosis.errorTypes.push(bootHang);
+      const exit = yield* h.run(DIAGNOSE);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(h.stores.diagnosis.diagnoses).toHaveLength(1);
+      expect(h.stores.diagnosis.diagnoses[0]).toMatchObject({
+        sessionId: SESSION_ID,
+        errorType: bootHang.key,
+        summary: diagnosis.summary,
+        model: MODEL,
+      });
+      expect(h.stores.diagnosis.diagnoses[0]?.createdAt).toBeInstanceOf(Date);
+      expect(h.log.lines).toEqual([
+        {
+          level: "info",
+          text: `diagnosed; ${bootHang.key}; ${MODEL}`,
+          sessionId: SESSION_ID,
+          agentId: undefined,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+      expect(h.log.acquired).toEqual([]);
+      expect(yield* stdout).toEqual([]);
+      expect(h.touched).toEqual(["database"]);
+    }),
+  );
+
+  it.effect("accepts aborted and timed_out sessions: every end but succeeded (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.sessions.sessions.push(
+        session(SESSION_ID, "aborted", ago(500)),
+        session(OTHER_SESSION_ID, "timed_out", ago(400)),
+      );
+      h.stores.diagnosis.errorTypes.push(bootHang);
+      expect(Exit.isSuccess(yield* h.run(DIAGNOSE))).toBe(true);
+      expect(
+        Exit.isSuccess(
+          yield* h.run([
+            "diagnose",
+            "--session-id",
+            OTHER_SESSION_ID,
+            "--type",
+            bootHang.key,
+            "--summary",
+            "the sweep closed it",
+            "--model",
+            MODEL,
+            "--server-url",
+            SERVER,
+          ]),
+        ),
+      ).toBe(true);
+      expect(h.stores.diagnosis.diagnoses.map((row) => row.sessionId)).toEqual([
+        SESSION_ID,
+        OTHER_SESSION_ID,
+      ]);
+    }),
+  );
+
+  it.effect("rejects an unknown session before touching the types (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.diagnosis.errorTypes.push(bootHang);
+      const exit = yield* h.run(DIAGNOSE);
+      expect(failure(exit)).toMatchObject({
+        _tag: "CommandError",
+        message: `diagnose: no session ${SESSION_ID}`,
+      });
+      expect(h.stores.diagnosis.diagnoses).toEqual([]);
+      expect(h.log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects a session that succeeded: there is nothing to diagnose (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.sessions.sessions.push(session(SESSION_ID, "succeeded", ago(500)));
+      h.stores.diagnosis.errorTypes.push(bootHang);
+      const exit = yield* h.run(DIAGNOSE);
+      expect(failure(exit)).toMatchObject({
+        _tag: "CommandError",
+        message: `diagnose: session ${SESSION_ID} succeeded; nothing to diagnose`,
+      });
+      expect(h.stores.diagnosis.diagnoses).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects a session that is still running or downloading (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.sessions.sessions.push(
+        session(SESSION_ID, "running", ago(5)),
+        session(OTHER_SESSION_ID, "downloading", ago(5)),
+      );
+      h.stores.diagnosis.errorTypes.push(bootHang);
+      expect(failure(yield* h.run(DIAGNOSE))).toMatchObject({
+        message: `diagnose: session ${SESSION_ID} is still running`,
+      });
+      const downloading = yield* h.run([
+        "diagnose",
+        "--session-id",
+        OTHER_SESSION_ID,
+        "--type",
+        bootHang.key,
+        "--summary",
+        "s",
+        "--model",
+        MODEL,
+        "--server-url",
+        SERVER,
+      ]);
+      expect(failure(downloading)).toMatchObject({
+        message: `diagnose: session ${OTHER_SESSION_ID} is still downloading`,
+      });
+      expect(h.stores.diagnosis.diagnoses).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects an error type that does not exist and names the fix (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.sessions.sessions.push(session(SESSION_ID, "failed", ago(500)));
+      const exit = yield* h.run(DIAGNOSE);
+      expect(failure(exit)).toMatchObject({
+        _tag: "CommandError",
+        message: `diagnose: no error type ${bootHang.key}; create it with ./ctrl error-type new`,
+      });
+      expect(h.stores.diagnosis.diagnoses).toEqual([]);
+      expect(h.log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects a second diagnosis for the same session and keeps the first (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.sessions.sessions.push(session(SESSION_ID, "failed", ago(500)));
+      h.stores.diagnosis.errorTypes.push(bootHang, misread);
+      expect(Exit.isSuccess(yield* h.run(DIAGNOSE))).toBe(true);
+      const second = yield* h.run([
+        "diagnose",
+        "--session-id",
+        SESSION_ID,
+        "--type",
+        misread.key,
+        "--summary",
+        "on reflection",
+        "--model",
+        MODEL,
+        "--server-url",
+        SERVER,
+      ]);
+      expect(failure(second)).toMatchObject({
+        _tag: "CommandError",
+        message: `diagnose: session ${SESSION_ID} already has a diagnosis`,
+      });
+      expect(h.stores.diagnosis.diagnoses).toHaveLength(1);
+      expect(h.stores.diagnosis.diagnoses[0]?.errorType).toBe(bootHang.key);
+      expect(h.log.lines.map((line) => line.text)).toEqual([
+        `diagnosed; ${bootHang.key}; ${MODEL}`,
+      ]);
+    }),
+  );
+
+  it.effect("refuses a bad --type, and a missing or empty --summary or --model (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      const badType = yield* h.run([
+        "diagnose",
+        "--session-id",
+        SESSION_ID,
+        "--type",
+        "Guest Boot",
+        "--summary",
+        "s",
+        "--model",
+        MODEL,
+        "--server-url",
+        SERVER,
+      ]);
+      expect(helpErrors(badType).join("\n")).toMatch(
+        /key must be snake_case: a-z, 0-9 and _, starting with a letter/,
+      );
+      const noSummary = yield* h.run([
+        "diagnose",
+        "--session-id",
+        SESSION_ID,
+        "--type",
+        bootHang.key,
+        "--model",
+        MODEL,
+        "--server-url",
+        SERVER,
+      ]);
+      expect(helpErrors(noSummary).join("\n")).toMatch(/Missing required flag: --summary/);
+      const emptyModel = yield* h.run([
+        "diagnose",
+        "--session-id",
+        SESSION_ID,
+        "--type",
+        bootHang.key,
+        "--summary",
+        "s",
+        "--model",
+        "",
+        "--server-url",
+        SERVER,
+      ]);
+      expect(helpErrors(emptyModel).join("\n")).toMatch(/--model.*length of at least 1/s);
+      expect(h.touched).toEqual([]);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
 // session inspect
 // ---------------------------------------------------------------------------
 
@@ -1285,35 +1719,97 @@ describe("session inspect", () => {
     }),
   );
 
-  it.effect("--all prints { logs, results, test_definition, actions, debug_log } (happy)", () =>
+  it.effect(
+    "--all prints { logs, results, test_definition, actions, debug_log, diagnosis } (happy)",
+    () =>
+      Effect.gen(function* () {
+        const h = harness();
+        seedInspect(h);
+        h.stores.tests.results.push(result(RESULT_ID, "passed", SESSION_ID));
+        h.stores.debugLogs.rows.set(SESSION_ID, debugLog);
+        h.stores.diagnosis.errorTypes.push(bootHang);
+        h.stores.diagnosis.diagnoses.push(diagnosis);
+        const exit = yield* h.run([
+          "session",
+          "--session-id",
+          SESSION_ID,
+          "--all",
+          "--server-url",
+          SERVER,
+        ]);
+        expect(Exit.isSuccess(exit)).toBe(true);
+        const printed = yield* lastJson;
+        expect(Object.keys(printed)).toEqual([
+          "logs",
+          "results",
+          "test_definition",
+          "actions",
+          "debug_log",
+          "diagnosis",
+        ]);
+        expect(printed.test_definition).toMatchObject({ name: "Install Omarchy" });
+        expect(printed.actions).toHaveLength(1);
+        expect(printed.debug_log).toEqual({
+          ...debugLog,
+          createdAt: debugLog.createdAt.toISOString(),
+        });
+        expect(printed.diagnosis).toEqual({
+          ...diagnosis,
+          createdAt: diagnosis.createdAt.toISOString(),
+        });
+      }),
+  );
+
+  it.effect("--diagnosis prints the bare diagnosis row, null when there is none (happy)", () =>
     Effect.gen(function* () {
       const h = harness();
       seedInspect(h);
-      h.stores.tests.results.push(result(RESULT_ID, "passed", SESSION_ID));
-      h.stores.debugLogs.rows.set(SESSION_ID, debugLog);
-      const exit = yield* h.run([
+      const none = yield* h.run([
         "session",
         "--session-id",
         SESSION_ID,
-        "--all",
+        "--diagnosis",
         "--server-url",
         SERVER,
       ]);
-      expect(Exit.isSuccess(exit)).toBe(true);
-      const printed = yield* lastJson;
-      expect(Object.keys(printed)).toEqual([
-        "logs",
-        "results",
-        "test_definition",
-        "actions",
-        "debug_log",
+      expect(Exit.isSuccess(none)).toBe(true);
+      expect(yield* stdout).toEqual(["null"]);
+      h.stores.diagnosis.errorTypes.push(bootHang);
+      h.stores.diagnosis.diagnoses.push(diagnosis);
+      const some = yield* h.run([
+        "session",
+        "--session-id",
+        SESSION_ID,
+        "--diagnosis",
+        "--server-url",
+        SERVER,
       ]);
-      expect(printed.test_definition).toMatchObject({ name: "Install Omarchy" });
-      expect(printed.actions).toHaveLength(1);
-      expect(printed.debug_log).toEqual({
-        ...debugLog,
-        createdAt: debugLog.createdAt.toISOString(),
+      expect(Exit.isSuccess(some)).toBe(true);
+      expect(yield* lastJson).toEqual({
+        ...diagnosis,
+        createdAt: diagnosis.createdAt.toISOString(),
       });
+      expect(h.proxy.calls).toEqual([]);
+    }),
+  );
+
+  it.effect("--diagnosis on an unknown session is a failure (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      seedInspect(h);
+      const exit = yield* h.run([
+        "session",
+        "--session-id",
+        OTHER_SESSION_ID,
+        "--diagnosis",
+        "--server-url",
+        SERVER,
+      ]);
+      expect(failure(exit)).toMatchObject({
+        _tag: "CommandError",
+        message: `session: no session ${OTHER_SESSION_ID}`,
+      });
+      expect(yield* stdout).toEqual([]);
     }),
   );
 
@@ -1398,7 +1894,7 @@ describe("session inspect", () => {
       expect(failure(exit)).toMatchObject({
         _tag: "CommandError",
         message:
-          "session: --logs, --test-def, --test-results, --actions, --debug-logs, --all, or --dump is required",
+          "session: --logs, --test-def, --test-results, --actions, --debug-logs, --diagnosis, --all, or --dump is required",
       });
     }),
   );
@@ -1407,7 +1903,7 @@ describe("session inspect", () => {
     Effect.gen(function* () {
       const h = harness();
       seedInspect(h);
-      for (const selector of ["--logs", "--all"]) {
+      for (const selector of ["--logs", "--diagnosis", "--all"]) {
         const exit = yield* h.run(
           ["session", "--session-id", SESSION_ID, "--dump", selector, "--server-url", SERVER],
           {
@@ -1417,7 +1913,7 @@ describe("session inspect", () => {
         );
         expect(failure(exit)).toMatchObject({
           message:
-            "session: --dump does not combine with --logs, --test-def, --test-results, --actions, --debug-logs, or --all",
+            "session: --dump does not combine with --logs, --test-def, --test-results, --actions, --debug-logs, --diagnosis, or --all",
         });
       }
       expect(h.proxy.calls).toEqual([]);
@@ -1678,6 +2174,9 @@ describe("environment order", () => {
           ],
           ["session", "list", "--server-url", SERVER],
           ["session", "--session-id", SESSION_ID, "--logs", "--server-url", SERVER],
+          NEW_TYPE,
+          ["error-type", "list", "--server-url", SERVER],
+          DIAGNOSE,
         ]) {
           const exit = yield* h.run(args, {
             DATABASE_URL: "",
@@ -1704,6 +2203,9 @@ describe("--server-url", () => {
     ["test-results", "--agent-id", "a", "--id", RESULT_ID, "--status", "success"],
     ["session", "list"],
     ["session", "--session-id", SESSION_ID, "--logs"],
+    NEW_TYPE.slice(0, -2),
+    ["error-type", "list"],
+    DIAGNOSE.slice(0, -2),
   ];
 
   it.effect("is required on every action but test run (unhappy)", () =>
@@ -1769,6 +2271,10 @@ describe("--help", () => {
           ["test-results", "--help"],
           ["session", "--help"],
           ["session", "list", "--help"],
+          ["error-type", "--help"],
+          ["error-type", "new", "--help"],
+          ["error-type", "list", "--help"],
+          ["diagnose", "--help"],
         ]) {
           // The built-in --help renders and succeeds; runMain exits 0.
           const exit = yield* h.run(args, {});
@@ -1779,6 +2285,8 @@ describe("--help", () => {
         const printed = (yield* stdout).join("\n");
         expect(printed).toMatch(/test-results/);
         expect(printed).toMatch(/session/);
+        expect(printed).toMatch(/error-type/);
+        expect(printed).toMatch(/diagnose/);
       }),
   );
 

--- a/v2/test/ctrl/command.unit.test.ts
+++ b/v2/test/ctrl/command.unit.test.ts
@@ -152,12 +152,16 @@ const harness = (
   // A later layer's service wins the merge, so the fake FileSystem replaces Node's.
   const services =
     options.fs === undefined ? NodeServices.layer : Layer.merge(NodeServices.layer, options.fs);
-  const run = (args: ReadonlyArray<string>, env: Record<string, string> = WITH_DB) =>
+  const program = (args: ReadonlyArray<string>, env: Record<string, string>) =>
     Command.runWith(command, { version: Api.VERSION })(args).pipe(
       Effect.provide(Layer.mergeAll(services, stdio.layer, Config.withEnv(env), FakeHttp.die)),
-      Effect.exit,
     );
-  return { stores, log, linear, cursor, proxy, touched, stdio, run };
+  const run = (args: ReadonlyArray<string>, env: Record<string, string> = WITH_DB) =>
+    Effect.exit(program(args, env));
+  // The failure itself, for a command refused after parsing.
+  const fail = (args: ReadonlyArray<string>, env: Record<string, string> = WITH_DB) =>
+    Effect.flip(program(args, env));
+  return { stores, log, linear, cursor, proxy, touched, stdio, run, fail };
 };
 
 const DRIVING_AGENT_PATH = /\/prompts\/driving-agent\.html$/;
@@ -1221,7 +1225,7 @@ describe("error-type new", () => {
       expect(h.log.lines).toEqual([
         {
           level: "info",
-          text: `error type ${bootHang.key} created`,
+          text: `error type created; ${bootHang.key}`,
           sessionId: undefined,
           agentId: undefined,
           skipSentry: false,
@@ -1237,7 +1241,7 @@ describe("error-type new", () => {
     Effect.gen(function* () {
       const h = harness();
       h.stores.diagnosis.errorTypes.push(bootHang);
-      const exit = yield* h.run([
+      const error = yield* h.fail([
         "error-type",
         "new",
         "--key",
@@ -1247,7 +1251,7 @@ describe("error-type new", () => {
         "--server-url",
         SERVER,
       ]);
-      expect(failure(exit)).toMatchObject({
+      expect(error).toMatchObject({
         _tag: "CommandError",
         message: `error-type new: ${bootHang.key} already exists`,
       });
@@ -1452,8 +1456,7 @@ describe("diagnose", () => {
     Effect.gen(function* () {
       const h = harness();
       h.stores.diagnosis.errorTypes.push(bootHang);
-      const exit = yield* h.run(DIAGNOSE);
-      expect(failure(exit)).toMatchObject({
+      expect(yield* h.fail(DIAGNOSE)).toMatchObject({
         _tag: "CommandError",
         message: `diagnose: no session ${SESSION_ID}`,
       });
@@ -1467,8 +1470,7 @@ describe("diagnose", () => {
       const h = harness();
       h.stores.sessions.sessions.push(session(SESSION_ID, "succeeded", ago(500)));
       h.stores.diagnosis.errorTypes.push(bootHang);
-      const exit = yield* h.run(DIAGNOSE);
-      expect(failure(exit)).toMatchObject({
+      expect(yield* h.fail(DIAGNOSE)).toMatchObject({
         _tag: "CommandError",
         message: `diagnose: session ${SESSION_ID} succeeded; nothing to diagnose`,
       });
@@ -1484,10 +1486,11 @@ describe("diagnose", () => {
         session(OTHER_SESSION_ID, "downloading", ago(5)),
       );
       h.stores.diagnosis.errorTypes.push(bootHang);
-      expect(failure(yield* h.run(DIAGNOSE))).toMatchObject({
+      expect(yield* h.fail(DIAGNOSE)).toMatchObject({
+        _tag: "CommandError",
         message: `diagnose: session ${SESSION_ID} is still running`,
       });
-      const downloading = yield* h.run([
+      const downloading = yield* h.fail([
         "diagnose",
         "--session-id",
         OTHER_SESSION_ID,
@@ -1500,7 +1503,8 @@ describe("diagnose", () => {
         "--server-url",
         SERVER,
       ]);
-      expect(failure(downloading)).toMatchObject({
+      expect(downloading).toMatchObject({
+        _tag: "CommandError",
         message: `diagnose: session ${OTHER_SESSION_ID} is still downloading`,
       });
       expect(h.stores.diagnosis.diagnoses).toEqual([]);
@@ -1511,8 +1515,7 @@ describe("diagnose", () => {
     Effect.gen(function* () {
       const h = harness();
       h.stores.sessions.sessions.push(session(SESSION_ID, "failed", ago(500)));
-      const exit = yield* h.run(DIAGNOSE);
-      expect(failure(exit)).toMatchObject({
+      expect(yield* h.fail(DIAGNOSE)).toMatchObject({
         _tag: "CommandError",
         message: `diagnose: no error type ${bootHang.key}; create it with ./ctrl error-type new`,
       });
@@ -1527,7 +1530,7 @@ describe("diagnose", () => {
       h.stores.sessions.sessions.push(session(SESSION_ID, "failed", ago(500)));
       h.stores.diagnosis.errorTypes.push(bootHang, misread);
       expect(Exit.isSuccess(yield* h.run(DIAGNOSE))).toBe(true);
-      const second = yield* h.run([
+      const second = yield* h.fail([
         "diagnose",
         "--session-id",
         SESSION_ID,
@@ -1540,7 +1543,7 @@ describe("diagnose", () => {
         "--server-url",
         SERVER,
       ]);
-      expect(failure(second)).toMatchObject({
+      expect(second).toMatchObject({
         _tag: "CommandError",
         message: `diagnose: session ${SESSION_ID} already has a diagnosis`,
       });
@@ -1797,7 +1800,7 @@ describe("session inspect", () => {
     Effect.gen(function* () {
       const h = harness();
       seedInspect(h);
-      const exit = yield* h.run([
+      const error = yield* h.fail([
         "session",
         "--session-id",
         OTHER_SESSION_ID,
@@ -1805,7 +1808,7 @@ describe("session inspect", () => {
         "--server-url",
         SERVER,
       ]);
-      expect(failure(exit)).toMatchObject({
+      expect(error).toMatchObject({
         _tag: "CommandError",
         message: `session: no session ${OTHER_SESSION_ID}`,
       });

--- a/v2/test/integration/ctrl.integration.test.ts
+++ b/v2/test/integration/ctrl.integration.test.ts
@@ -3,7 +3,9 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
+import * as DbSchema from "../../src/db/schema.ts";
 import * as Postgres from "../support/postgres.ts";
 import * as StubCursor from "../support/stub-cursor.ts";
 import * as StubProxy from "../support/stub-proxy.ts";
@@ -769,10 +771,15 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
     const client = new Client({ connectionString: Postgres.getDbUrl() });
     await client.connect();
     try {
-      await client.query(
-        `insert into sessions (id, config, status, reason, ended_at) values ($1, '{"iso":"x"}', 'failed', 'installer hung', now())`,
-        [sessionId],
-      );
+      await drizzle({ client })
+        .insert(DbSchema.sessions)
+        .values({
+          id: sessionId,
+          config: { iso: "x" },
+          status: "failed",
+          reason: "installer hung",
+          endedAt: new Date(),
+        });
     } finally {
       await client.end();
     }

--- a/v2/test/integration/ctrl.integration.test.ts
+++ b/v2/test/integration/ctrl.integration.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { Client } from "pg";
 import * as Postgres from "../support/postgres.ts";
 import * as StubCursor from "../support/stub-cursor.ts";
 import * as StubProxy from "../support/stub-proxy.ts";
@@ -678,7 +679,8 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
     ]);
     expect(created.stderr).toBe("");
     expect(created.code).toBe(0);
-    expect(created.stdout).toBe("");
+    // The Log service's stdout copy of the logs row; no agent, so [global].
+    expect(created.stdout).toBe(`[global] error type ${key} created\n`);
 
     const listed = await runCtrl(["error-type", "list", "--server-url", SERVER]);
     expect(listed.stderr).toBe("");
@@ -759,6 +761,86 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
     expect(result.stderr).toBe("");
     expect(result.code).toBe(0);
     expect(result.stdout).toBe("null\n");
+  });
+
+  it("diagnose writes the row for a failed session once; session --diagnosis prints it", async () => {
+    // No ctrl action ends a session, so the failed session is seeded straight into the container.
+    const sessionId = randomUUID();
+    const client = new Client({ connectionString: Postgres.getDbUrl() });
+    await client.connect();
+    try {
+      await client.query(
+        `insert into sessions (id, config, status, reason, ended_at) values ($1, '{"iso":"x"}', 'failed', 'installer hung', now())`,
+        [sessionId],
+      );
+    } finally {
+      await client.end();
+    }
+    const key = `installer_hang_${randomUUID().replaceAll("-", "_")}`;
+    expect(
+      (
+        await runCtrl([
+          "error-type",
+          "new",
+          "--key",
+          key,
+          "--description",
+          "the installer never finished",
+          "--server-url",
+          SERVER,
+        ])
+      ).code,
+    ).toBe(0);
+
+    const diagnose = (type: string, summary: string) =>
+      runCtrl([
+        "diagnose",
+        "--session-id",
+        sessionId,
+        "--type",
+        type,
+        "--summary",
+        summary,
+        "--model",
+        "composer-2.5",
+        "--server-url",
+        SERVER,
+      ]);
+    const first = await diagnose(key, "serial stops after the partition step");
+    expect(first.stderr).toBe("");
+    expect(first.code).toBe(0);
+    expect(first.stdout).toBe(`[global] ${sessionId}: diagnosed; ${key}; composer-2.5\n`);
+
+    const second = await diagnose(key, "on reflection");
+    expect(second.code).toBe(1);
+    expect(second.stdout).toBe("");
+    expect(firstLine(second.stderr)).toBe(`diagnose: session ${sessionId} already has a diagnosis`);
+
+    const printed = await runCtrl([
+      "session",
+      "--session-id",
+      sessionId,
+      "--diagnosis",
+      "--server-url",
+      SERVER,
+    ]);
+    expect(printed.stderr).toBe("");
+    expect(printed.code).toBe(0);
+    const row: { sessionId: string; errorType: string; summary: string; model: string } =
+      JSON.parse(printed.stdout);
+    expect(row).toMatchObject({
+      sessionId,
+      errorType: key,
+      summary: "serial stops after the partition step",
+      model: "composer-2.5",
+    });
+    expect(Object.keys(row).sort()).toEqual([
+      "createdAt",
+      "errorType",
+      "model",
+      "sessionId",
+      "summary",
+    ]);
   });
 
   it("session requires a selector and rejects an unknown session", async () => {

--- a/v2/test/integration/ctrl.integration.test.ts
+++ b/v2/test/integration/ctrl.integration.test.ts
@@ -245,6 +245,21 @@ describe("./ctrl without a database", () => {
       ["test", "run", "--ticket", "OLI-42"],
       ["session", "list", "--server-url", SERVER],
       ["session", "--session-id", SUCCEEDED_ID, "--logs", "--server-url", SERVER],
+      ["error-type", "new", "--key", "k", "--description", "d", "--server-url", SERVER],
+      ["error-type", "list", "--server-url", SERVER],
+      [
+        "diagnose",
+        "--session-id",
+        SUCCEEDED_ID,
+        "--type",
+        "k",
+        "--summary",
+        "s",
+        "--model",
+        "m",
+        "--server-url",
+        SERVER,
+      ],
     ]) {
       const result = await runCtrl(args, {
         DATABASE_URL: "",
@@ -392,6 +407,48 @@ describe("./ctrl without a database", () => {
       [
         ["session", "--session-id", randomUUID(), "--logs", "--count", "3", "--server-url", SERVER],
         /Unrecognized flag: --count/,
+        env,
+      ],
+      [
+        ["error-type", "new", "--key", "Guest Boot", "--description", "d", "--server-url", SERVER],
+        /key must be snake_case: a-z, 0-9 and _, starting with a letter/,
+        env,
+      ],
+      [
+        ["error-type", "new", "--key", "guest_boot_hang", "--server-url", SERVER],
+        /Missing required flag: --description/,
+        env,
+      ],
+      [
+        [
+          "diagnose",
+          "--session-id",
+          randomUUID(),
+          "--type",
+          "guest-boot-hang",
+          "--summary",
+          "s",
+          "--model",
+          "m",
+          "--server-url",
+          SERVER,
+        ],
+        /key must be snake_case: a-z, 0-9 and _, starting with a letter/,
+        env,
+      ],
+      [
+        [
+          "diagnose",
+          "--session-id",
+          randomUUID(),
+          "--type",
+          "k",
+          "--model",
+          "m",
+          "--server-url",
+          SERVER,
+        ],
+        /Missing required flag: --summary/,
         env,
       ],
     ];
@@ -579,7 +636,7 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
     expect(stub.requests).toEqual([]);
   });
 
-  it("session --all prints { logs, results, test_definition, actions } for a seeded session", async () => {
+  it("session --all prints { logs, results, test_definition, actions, debug_log, diagnosis } for a seeded session", async () => {
     const result = await runCtrl([
       "session",
       "--session-id",
@@ -591,11 +648,117 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
     expect(result.stderr).toBe("");
     expect(result.code).toBe(0);
     const printed: Record<string, unknown> = JSON.parse(result.stdout);
-    expect(Object.keys(printed)).toEqual(["logs", "results", "test_definition", "actions"]);
+    expect(Object.keys(printed)).toEqual([
+      "logs",
+      "results",
+      "test_definition",
+      "actions",
+      "debug_log",
+      "diagnosis",
+    ]);
     expect(Array.isArray(printed.logs)).toBe(true);
     expect(Array.isArray(printed.actions)).toBe(true);
     expect(printed.results).toBeNull();
     expect(printed.test_definition).toBeNull();
+    expect(printed.debug_log).toBeNull();
+    expect(printed.diagnosis).toBeNull();
+  });
+
+  it("error-type new stores a type that error-type list prints, and refuses the key twice", async () => {
+    const key = `guest_boot_hang_${randomUUID().replaceAll("-", "_")}`;
+    const created = await runCtrl([
+      "error-type",
+      "new",
+      "--key",
+      key,
+      "--description",
+      "never reached login",
+      "--server-url",
+      SERVER,
+    ]);
+    expect(created.stderr).toBe("");
+    expect(created.code).toBe(0);
+    expect(created.stdout).toBe("");
+
+    const listed = await runCtrl(["error-type", "list", "--server-url", SERVER]);
+    expect(listed.stderr).toBe("");
+    expect(listed.code).toBe(0);
+    expect(lines(listed.stdout).some((line) => line.startsWith(`${key} `))).toBe(true);
+    expect(lines(listed.stdout).some((line) => line.endsWith("  never reached login"))).toBe(true);
+
+    const asJson = await runCtrl(["error-type", "list", "--json"], { SERVER_URL: SERVER });
+    expect(asJson.code).toBe(0);
+    const rows: Array<{ key: string; description: string; createdAt: string }> = JSON.parse(
+      asJson.stdout,
+    );
+    expect(rows.find((row) => row.key === key)).toMatchObject({
+      description: "never reached login",
+    });
+
+    const again = await runCtrl([
+      "error-type",
+      "new",
+      "--key",
+      key,
+      "--description",
+      "a second meaning",
+      "--server-url",
+      SERVER,
+    ]);
+    expect(again.code).toBe(1);
+    expect(again.stdout).toBe("");
+    expect(firstLine(again.stderr)).toBe(`error-type new: ${key} already exists`);
+    expect(again.stderr).toMatch(/CommandError/);
+  });
+
+  it("diagnose refuses an unknown session, a succeeded session, and an unknown type", async () => {
+    const sessionId = randomUUID();
+    const diagnose = (id: string, type: string) =>
+      runCtrl([
+        "diagnose",
+        "--session-id",
+        id,
+        "--type",
+        type,
+        "--summary",
+        "the kernel waited on the root device",
+        "--model",
+        "composer-2.5",
+        "--server-url",
+        SERVER,
+      ]);
+    const unknown = await diagnose(sessionId, "guest_boot_hang");
+    expect(unknown.code).toBe(1);
+    expect(unknown.stdout).toBe("");
+    expect(firstLine(unknown.stderr)).toBe(`diagnose: no session ${sessionId}`);
+
+    const succeeded = await diagnose(SUCCEEDED_ID, "guest_boot_hang");
+    expect(succeeded.code).toBe(1);
+    expect(firstLine(succeeded.stderr)).toBe(
+      `diagnose: session ${SUCCEEDED_ID} succeeded; nothing to diagnose`,
+    );
+
+    const running = await diagnose(RUNNING_ID, "guest_boot_hang");
+    expect(running.code).toBe(1);
+    expect(firstLine(running.stderr)).toBe(`diagnose: session ${RUNNING_ID} is still running`);
+
+    const missing = await diagnose(sessionId, `never_${randomUUID().replaceAll("-", "_")}`);
+    expect(missing.code).toBe(1);
+    expect(firstLine(missing.stderr)).toBe(`diagnose: no session ${sessionId}`);
+  });
+
+  it("session --diagnosis prints null for a session without one", async () => {
+    const result = await runCtrl([
+      "session",
+      "--session-id",
+      SUCCEEDED_ID,
+      "--diagnosis",
+      "--server-url",
+      SERVER,
+    ]);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("null\n");
   });
 
   it("session requires a selector and rejects an unknown session", async () => {
@@ -609,7 +772,7 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
     ]);
     expect(noSelector.code).toBe(1);
     expect(firstLine(noSelector.stderr)).toBe(
-      "session: --logs, --test-def, --test-results, --actions, --all, or --dump is required",
+      "session: --logs, --test-def, --test-results, --actions, --debug-logs, --diagnosis, --all, or --dump is required",
     );
     expect(noSelector.stderr).toMatch(/CommandError/);
     expect(noSelector.stderr).not.toMatch(/at sessionInspectRun/);
@@ -686,7 +849,7 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
 
   it("session --dump does not combine with the JSON selectors", async () => {
     const stub = await proxy();
-    for (const selector of ["--logs", "--all"]) {
+    for (const selector of ["--logs", "--diagnosis", "--all"]) {
       const result = await runCtrl([
         "session",
         "--session-id",
@@ -699,7 +862,7 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
       expect(result.code).toBe(1);
       expect(result.stdout).toBe("");
       expect(firstLine(result.stderr)).toBe(
-        "session: --dump does not combine with --logs, --test-def, --test-results, --actions, or --all",
+        "session: --dump does not combine with --logs, --test-def, --test-results, --actions, --debug-logs, --diagnosis, or --all",
       );
     }
     expect(stub.requests).toEqual([]);

--- a/v2/test/integration/ctrl.integration.test.ts
+++ b/v2/test/integration/ctrl.integration.test.ts
@@ -69,6 +69,27 @@ const runCtrl = (args: ReadonlyArray<string>, env: Record<string, string> = {}):
 
 const firstLine = (text: string): string => text.split("\n")[0] ?? "";
 
+// No ctrl action ends a session, so a failed one is seeded straight into the container.
+const seedFailedSession = async (): Promise<string> => {
+  const sessionId = randomUUID();
+  const client = new Client({ connectionString: Postgres.getDbUrl() });
+  await client.connect();
+  try {
+    await drizzle({ client })
+      .insert(DbSchema.sessions)
+      .values({
+        id: sessionId,
+        config: { iso: "x" },
+        status: "failed",
+        reason: "installer hung",
+        endedAt: new Date(),
+      });
+  } finally {
+    await client.end();
+  }
+  return sessionId;
+};
+
 const lines = (text: string): ReadonlyArray<string> =>
   text.split("\n").filter((line) => line !== "");
 
@@ -682,7 +703,7 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
     expect(created.stderr).toBe("");
     expect(created.code).toBe(0);
     // The Log service's stdout copy of the logs row; no agent, so [global].
-    expect(created.stdout).toBe(`[global] error type ${key} created\n`);
+    expect(created.stdout).toBe(`[global] error type created; ${key}\n`);
 
     const listed = await runCtrl(["error-type", "list", "--server-url", SERVER]);
     expect(listed.stderr).toBe("");
@@ -746,9 +767,15 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
     expect(running.code).toBe(1);
     expect(firstLine(running.stderr)).toBe(`diagnose: session ${RUNNING_ID} is still running`);
 
-    const missing = await diagnose(sessionId, `never_${randomUUID().replaceAll("-", "_")}`);
+    const failed = await seedFailedSession();
+    const key = `never_${randomUUID().replaceAll("-", "_")}`;
+    const missing = await diagnose(failed, key);
     expect(missing.code).toBe(1);
-    expect(firstLine(missing.stderr)).toBe(`diagnose: no session ${sessionId}`);
+    expect(missing.stdout).toBe("");
+    expect(firstLine(missing.stderr)).toBe(
+      `diagnose: no error type ${key}; create it with ./ctrl error-type new`,
+    );
+    expect(missing.stderr).toMatch(/CommandError/);
   });
 
   it("session --diagnosis prints null for a session without one", async () => {
@@ -766,23 +793,7 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
   });
 
   it("diagnose writes the row for a failed session once; session --diagnosis prints it", async () => {
-    // No ctrl action ends a session, so the failed session is seeded straight into the container.
-    const sessionId = randomUUID();
-    const client = new Client({ connectionString: Postgres.getDbUrl() });
-    await client.connect();
-    try {
-      await drizzle({ client })
-        .insert(DbSchema.sessions)
-        .values({
-          id: sessionId,
-          config: { iso: "x" },
-          status: "failed",
-          reason: "installer hung",
-          endedAt: new Date(),
-        });
-    } finally {
-      await client.end();
-    }
+    const sessionId = await seedFailedSession();
     const key = `installer_hang_${randomUUID().replaceAll("-", "_")}`;
     expect(
       (

--- a/v2/test/integration/db.integration.test.ts
+++ b/v2/test/integration/db.integration.test.ts
@@ -6,6 +6,7 @@ import { TestConsole } from "effect/testing";
 import * as Actions from "../../src/db/actions.ts";
 import * as Client from "../../src/db/client.ts";
 import * as DebugLogs from "../../src/db/debug-logs.ts";
+import * as Diagnosis from "../../src/db/diagnosis.ts";
 import * as Logs from "../../src/db/logs.ts";
 import * as Migrate from "../../src/db/migrate.ts";
 import * as DbSchema from "../../src/db/schema.ts";
@@ -17,6 +18,9 @@ import * as Support from "../support/config.ts";
 import * as Postgres from "../support/postgres.ts";
 
 const uuid = (): string => crypto.randomUUID();
+
+// A fresh snake_case key per test: the container's tables outlive each test body.
+const errorKey = (stem: string): string => `${stem}_${uuid().replaceAll("-", "_")}`;
 
 const SEEDED_SUCCEEDED = "11111111-1111-4111-8111-111111111111";
 const SEEDED_RUNNING = "22222222-2222-4222-8222-222222222222";
@@ -389,6 +393,167 @@ Postgres.describeWithDatabase("database", () => {
         expect(saved?.sources.proxy).toBe("");
         expect(saved?.sources.actions).toBe("");
       }),
+    );
+
+    scoped.effect("DiagnosisStore creates, lists and finds error types; a taken key is false", () =>
+      Effect.gen(function* () {
+        const diagnosis = yield* Diagnosis.DiagnosisStore;
+        const boot = errorKey("guest_boot_hang");
+        const misread = errorKey("agent_misread_screen");
+        expect(yield* diagnosis.createErrorType(boot, "never reached login")).toBe(true);
+        expect(yield* diagnosis.createErrorType(misread, "acted on a misread screen")).toBe(true);
+        expect(yield* diagnosis.createErrorType(boot, "a second meaning")).toBe(false);
+
+        const listed = yield* diagnosis.listErrorTypes;
+        const keys = listed.map((row) => row.key);
+        expect(keys).toContain(boot);
+        expect(keys).toContain(misread);
+        expect(keys).toEqual([...keys].sort((left, right) => left.localeCompare(right)));
+        expect(listed.find((row) => row.key === boot)?.description).toBe("never reached login");
+        expect(listed.find((row) => row.key === boot)?.createdAt).toBeInstanceOf(Date);
+
+        const found = yield* diagnosis.findErrorType(boot);
+        expect(Option.getOrThrow(found)).toMatchObject({
+          key: boot,
+          description: "never reached login",
+        });
+        expect(yield* diagnosis.findErrorType(errorKey("nope"))).toEqual(Option.none());
+      }),
+    );
+
+    scoped.effect("DiagnosisStore writes one diagnosis per session and reads it back", () =>
+      Effect.gen(function* () {
+        const sessions = yield* Sessions.SessionStore;
+        const diagnosis = yield* Diagnosis.DiagnosisStore;
+        const database = yield* Client.Database;
+        const sessionId = uuid();
+        const boot = errorKey("guest_boot_hang");
+        const misread = errorKey("agent_misread_screen");
+        yield* sessions.insertSession(sessionId, { iso: "x" }, "running");
+        yield* sessions.endSession(sessionId, "failed", "installer hung");
+        yield* diagnosis.createErrorType(boot, "never reached login");
+        yield* diagnosis.createErrorType(misread, "acted on a misread screen");
+
+        expect(
+          yield* diagnosis.saveDiagnosis({
+            sessionId,
+            errorType: boot,
+            summary: "the kernel waited on the root device",
+            model: "composer-2.5",
+          }),
+        ).toBe(true);
+        // The key is the session: a second diagnosis is a false and the first stands.
+        expect(
+          yield* diagnosis.saveDiagnosis({
+            sessionId: sessionId.toUpperCase(),
+            errorType: misread,
+            summary: "on reflection",
+            model: "grok-4.6",
+          }),
+        ).toBe(false);
+
+        const read = Option.getOrThrow(yield* diagnosis.getDiagnosis(sessionId));
+        expect(read).toMatchObject({
+          sessionId,
+          errorType: boot,
+          summary: "the kernel waited on the root device",
+          model: "composer-2.5",
+        });
+        expect(read.createdAt).toBeInstanceOf(Date);
+        expect(Object.keys(read).sort()).toEqual([
+          "createdAt",
+          "errorType",
+          "model",
+          "sessionId",
+          "summary",
+        ]);
+        expect(yield* diagnosis.getDiagnosis(uuid())).toEqual(Option.none());
+        const rows = yield* database.run("select", (db) =>
+          db
+            .select()
+            .from(DbSchema.postRunDiagnosis)
+            .where(eq(DbSchema.postRunDiagnosis.sessionId, sessionId)),
+        );
+        expect(rows).toHaveLength(1);
+      }),
+    );
+
+    scoped.effect("DiagnosisStore refuses a diagnosis naming an unknown type or session", () =>
+      Effect.gen(function* () {
+        const sessions = yield* Sessions.SessionStore;
+        const diagnosis = yield* Diagnosis.DiagnosisStore;
+        const sessionId = uuid();
+        yield* sessions.insertSession(sessionId, { iso: "x" }, "running");
+        yield* sessions.endSession(sessionId, "failed", null);
+        const unknownType = yield* Effect.flip(
+          diagnosis.saveDiagnosis({
+            sessionId,
+            errorType: errorKey("never_created"),
+            summary: "s",
+            model: "composer-2.5",
+          }),
+        );
+        expect(unknownType._tag).toBe("DatabaseError");
+        expect(unknownType.operation).toBe("saveDiagnosis");
+        expect(unknownType.message).toContain("Failed query");
+        expect(String(unknownType.cause)).toMatch(/foreign key/);
+        expect(yield* diagnosis.getDiagnosis(sessionId)).toEqual(Option.none());
+
+        const boot = errorKey("guest_boot_hang");
+        yield* diagnosis.createErrorType(boot, "never reached login");
+        const unknownSession = yield* Effect.flip(
+          diagnosis.saveDiagnosis({
+            sessionId: uuid(),
+            errorType: boot,
+            summary: "s",
+            model: "composer-2.5",
+          }),
+        );
+        expect(unknownSession._tag).toBe("DatabaseError");
+        expect(unknownSession.operation).toBe("saveDiagnosis");
+        expect(String(unknownSession.cause)).toMatch(/foreign key/);
+      }),
+    );
+
+    scoped.effect(
+      "renaming an error type follows into its diagnoses; deleting one in use is refused",
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.SessionStore;
+          const diagnosis = yield* Diagnosis.DiagnosisStore;
+          const database = yield* Client.Database;
+          const sessionId = uuid();
+          const before = errorKey("guest_boot_hang");
+          const after = errorKey("guest_boot_stall");
+          yield* sessions.insertSession(sessionId, { iso: "x" }, "running");
+          yield* sessions.endSession(sessionId, "timed_out", null);
+          yield* diagnosis.createErrorType(before, "never reached login");
+          yield* diagnosis.saveDiagnosis({
+            sessionId,
+            errorType: before,
+            summary: "s",
+            model: "composer-2.5",
+          });
+
+          const refused = yield* Effect.flip(
+            database.run("delete", (db) =>
+              db
+                .delete(DbSchema.postRunErrorTypes)
+                .where(eq(DbSchema.postRunErrorTypes.key, before)),
+            ),
+          );
+          expect(refused._tag).toBe("DatabaseError");
+          expect(String(refused.cause)).toMatch(/foreign key/);
+
+          yield* database.run("rename", (db) =>
+            db
+              .update(DbSchema.postRunErrorTypes)
+              .set({ key: after })
+              .where(eq(DbSchema.postRunErrorTypes.key, before)),
+          );
+          expect(Option.getOrThrow(yield* diagnosis.getDiagnosis(sessionId)).errorType).toBe(after);
+          expect(yield* diagnosis.findErrorType(before)).toEqual(Option.none());
+        }),
     );
 
     scoped.effect("TestStore reads the seeded definitions and prompts", () =>

--- a/v2/test/integration/db.integration.test.ts
+++ b/v2/test/integration/db.integration.test.ts
@@ -404,7 +404,7 @@ Postgres.describeWithDatabase("database", () => {
         expect(yield* diagnosis.createErrorType(misread, "acted on a misread screen")).toBe(true);
         expect(yield* diagnosis.createErrorType(boot, "a second meaning")).toBe(false);
 
-        const listed = yield* diagnosis.listErrorTypes;
+        const listed = yield* diagnosis.listErrorTypes();
         const keys = listed.map((row) => row.key);
         expect(keys).toContain(boot);
         expect(keys).toContain(misread);
@@ -493,9 +493,11 @@ Postgres.describeWithDatabase("database", () => {
             model: "composer-2.5",
           }),
         );
-        expect(unknownType._tag).toBe("DatabaseError");
-        expect(unknownType.operation).toBe("saveDiagnosis");
-        expect(unknownType.message).toContain("Failed query");
+        expect(unknownType).toMatchObject({
+          _tag: "DatabaseError",
+          operation: "saveDiagnosis",
+          message: expect.stringContaining("Failed query"),
+        });
         expect(String(unknownType.cause)).toMatch(/foreign key/);
         expect(yield* diagnosis.getDiagnosis(sessionId)).toEqual(Option.none());
 
@@ -509,8 +511,11 @@ Postgres.describeWithDatabase("database", () => {
             model: "composer-2.5",
           }),
         );
-        expect(unknownSession._tag).toBe("DatabaseError");
-        expect(unknownSession.operation).toBe("saveDiagnosis");
+        expect(unknownSession).toMatchObject({
+          _tag: "DatabaseError",
+          operation: "saveDiagnosis",
+          message: expect.stringContaining("Failed query"),
+        });
         expect(String(unknownSession.cause)).toMatch(/foreign key/);
       }),
     );
@@ -542,7 +547,11 @@ Postgres.describeWithDatabase("database", () => {
                 .where(eq(DbSchema.postRunErrorTypes.key, before)),
             ),
           );
-          expect(refused._tag).toBe("DatabaseError");
+          expect(refused).toMatchObject({
+            _tag: "DatabaseError",
+            operation: "delete",
+            message: expect.stringContaining("Failed query"),
+          });
           expect(String(refused.cause)).toMatch(/foreign key/);
 
           yield* database.run("rename", (db) =>

--- a/v2/test/shared/domain.unit.test.ts
+++ b/v2/test/shared/domain.unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Effect, Exit, Schema } from "effect";
+import { Cause, Effect, Exit, Schema } from "effect";
 import * as Domain from "../../src/shared/domain.ts";
 
 const SESSION_ID = "1baaad43-674b-4bdb-88d7-3f18fce50aba";
@@ -55,6 +55,29 @@ describe("brands", () => {
   it("refuses an empty AgentId", () => {
     expect(Schema.is(Domain.AgentId)("OLI-61")).toBe(true);
     expect(Schema.is(Domain.AgentId)("")).toBe(false);
+  });
+
+  it("accepts a snake_case ErrorTypeKey and refuses anything else", () => {
+    const is = Schema.is(Domain.ErrorTypeKey);
+    expect(is("guest_boot_hang")).toBe(true);
+    expect(is("timeout")).toBe(true);
+    expect(is("http_502")).toBe(true);
+    expect(is("")).toBe(false);
+    expect(is("Guest Boot Hang")).toBe(false);
+    expect(is("guest-boot-hang")).toBe(false);
+    expect(is("7_days")).toBe(false);
+    expect(is("_leading")).toBe(false);
+    expect(is("GUEST")).toBe(false);
+  });
+
+  it("names the key rule in the ErrorTypeKey decode failure", () => {
+    const exit = Schema.decodeUnknownExit(Domain.ErrorTypeKey)("Guest Boot");
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(String(Cause.squash(exit.cause))).toMatch(
+        /key must be snake_case: a-z, 0-9 and _, starting with a letter/,
+      );
+    }
   });
 });
 

--- a/v2/test/support/postgres.ts
+++ b/v2/test/support/postgres.ts
@@ -3,6 +3,7 @@ import { Layer, Redacted } from "effect";
 import * as Actions from "../../src/db/actions.ts";
 import * as Client from "../../src/db/client.ts";
 import * as DebugLogs from "../../src/db/debug-logs.ts";
+import * as Diagnosis from "../../src/db/diagnosis.ts";
 import * as Logs from "../../src/db/logs.ts";
 import * as Sessions from "../../src/db/sessions.ts";
 import * as Tests from "../../src/db/tests.ts";
@@ -23,10 +24,12 @@ export const migratedLayer: Layer.Layer<
   | Actions.ActionStore
   | Logs.LogStore
   | DebugLogs.DebugLogStore
+  | Diagnosis.DiagnosisStore
   | Tests.TestStore
 > = Layer.mergeAll(
   Sessions.SessionStore.layer,
   DebugLogs.DebugLogStore.layer,
+  Diagnosis.DiagnosisStore.layer,
   Tests.TestStore.layer,
 ).pipe(
   Layer.provideMerge(Actions.ActionStore.layer),

--- a/v2/test/support/stores.ts
+++ b/v2/test/support/stores.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer, Option } from "effect";
 import * as Actions from "../../src/db/actions.ts";
 import * as DebugLogs from "../../src/db/debug-logs.ts";
+import * as Diagnosis from "../../src/db/diagnosis.ts";
 import * as Logs from "../../src/db/logs.ts";
 import * as DbSchema from "../../src/db/schema.ts";
 import * as Sessions from "../../src/db/sessions.ts";
@@ -260,6 +261,54 @@ export const fakeDebugLogStore = (
 };
 
 // ---------------------------------------------------------------------------
+// DiagnosisStore
+// ---------------------------------------------------------------------------
+
+export type FakeDiagnosisStore = {
+  readonly errorTypes: Array<Diagnosis.ErrorTypeRow>;
+  readonly diagnoses: Array<Diagnosis.DiagnosisRow>;
+  readonly layer: Layer.Layer<Diagnosis.DiagnosisStore>;
+};
+
+// Keys are unique and a session is diagnosed once: the second write is a false, as the real
+// store's `on conflict do nothing` answers.
+export const fakeDiagnosisStore = (
+  overrides: Partial<typeof Diagnosis.DiagnosisStore.Service> = {},
+): FakeDiagnosisStore => {
+  const errorTypes: Array<Diagnosis.ErrorTypeRow> = [];
+  const diagnoses: Array<Diagnosis.DiagnosisRow> = [];
+  const findType = (key: string) => errorTypes.find((row) => row.key === key);
+  const service = Diagnosis.DiagnosisStore.of({
+    createErrorType: (key, description) =>
+      Effect.sync(() => {
+        if (findType(key) !== undefined) {
+          return false;
+        }
+        errorTypes.push({ key, description, createdAt: new Date() });
+        return true;
+      }),
+    listErrorTypes: Effect.sync(() =>
+      [...errorTypes].sort((left, right) => left.key.localeCompare(right.key)),
+    ),
+    findErrorType: (key) => Effect.sync(() => Option.fromUndefinedOr(findType(key))),
+    saveDiagnosis: (input) =>
+      Effect.sync(() => {
+        if (diagnoses.some((row) => sameId(row.sessionId, input.sessionId))) {
+          return false;
+        }
+        diagnoses.push({ ...input, createdAt: new Date() });
+        return true;
+      }),
+    getDiagnosis: (sessionId) =>
+      Effect.sync(() =>
+        Option.fromUndefinedOr(diagnoses.find((row) => sameId(row.sessionId, sessionId))),
+      ),
+    ...overrides,
+  });
+  return { errorTypes, diagnoses, layer: Layer.succeed(Diagnosis.DiagnosisStore)(service) };
+};
+
+// ---------------------------------------------------------------------------
 // TestStore
 // ---------------------------------------------------------------------------
 
@@ -396,12 +445,21 @@ export const fakeStores = () => {
   const logs = fakeLogStore();
   const tests = fakeTestStore();
   const debugLogs = fakeDebugLogStore();
+  const diagnosis = fakeDiagnosisStore();
   return {
     sessions,
     actions,
     logs,
     tests,
     debugLogs,
-    layer: Layer.mergeAll(sessions.layer, actions.layer, logs.layer, tests.layer, debugLogs.layer),
+    diagnosis,
+    layer: Layer.mergeAll(
+      sessions.layer,
+      actions.layer,
+      logs.layer,
+      tests.layer,
+      debugLogs.layer,
+      diagnosis.layer,
+    ),
   };
 };

--- a/v2/test/support/stores.ts
+++ b/v2/test/support/stores.ts
@@ -287,9 +287,8 @@ export const fakeDiagnosisStore = (
         errorTypes.push({ key, description, createdAt: new Date() });
         return true;
       }),
-    listErrorTypes: Effect.sync(() =>
-      [...errorTypes].sort((left, right) => left.key.localeCompare(right.key)),
-    ),
+    listErrorTypes: () =>
+      Effect.sync(() => [...errorTypes].sort((left, right) => left.key.localeCompare(right.key))),
     findErrorType: (key) => Effect.sync(() => Option.fromUndefinedOr(findType(key))),
     saveDiagnosis: (input) =>
       Effect.sync(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A diagnosis names the cause of a session that ended any way but `succeeded`, written after the run. Its vocabulary is data, not an enum:

- `post_run_error_types` (`key` text PK, `description`, `created_at`): starts empty, grows one row per distinct cause through `ctrl error-type new`; never a migration. No seeded `unclassified`/`other` row.
- `post_run_diagnosis` (`session_id` PK → `sessions.id`, `error_type` NOT NULL → `post_run_error_types.key` ON UPDATE CASCADE, `summary`, `model`, `created_at`): no nullable column and no row until someone diagnoses. `model` is the Cursor model id that wrote the diagnosis, mirroring `test_results.model`.
- `Domain.ErrorTypeKey` brand: `^[a-z][a-z0-9_]*$`, refused at the flag.
- `DiagnosisStore` (`src/db/diagnosis.ts`): every method an `Effect.fn("db.…")`; `createErrorType`/`saveDiagnosis` are `insert … on conflict do nothing returning` and answer `false` on a taken key / already-diagnosed session; `listErrorTypes`, `findErrorType`, `getDiagnosis`.
- `ctrl error-type new|list [--json]`, `ctrl diagnose --session-id --type --summary --model`, `ctrl session --diagnosis` (also in `--all`). Refusals, in order: no session, succeeded, still running/downloading, unknown type (names the fix), already diagnosed. Each write's only output is its log line's stdout copy (`[global] error type created; <key>`, `[global] <session id>: diagnosed; <key>; <model>`).
- Migration `drizzle/0002_post_run_diagnosis.sql`, generated by `npm run db:generate --name post_run_diagnosis`.
- Docs: a "Post-run diagnosis" section in `development.md`; `ctrl.md` sections and TOC.

## Tests (written first)

- Unit: `ErrorTypeKey` brand; `fakeDiagnosisStore`; `error-type new/list`, `diagnose`, `session --diagnosis`, `--all`, help, `--server-url` and `DATABASE_URL` ordering, every happy and unhappy path; domain failures read through `Effect.flip` and matched on `_tag` + `message`.
- Integration (Postgres): `DiagnosisStore` create/duplicate/list/find, one diagnosis per session, FK refusals for unknown type/session, rename cascades and delete-in-use refused.
- Process (`./ctrl`): exit codes and first stderr line for every refusal (unknown session, succeeded, running, unknown type on a seeded failed session); the happy path type → diagnose → `session --diagnosis`. Also updated the stale `--all` key list and selector message that predate `--debug-logs`.

## Verification

- `npm run check:fast`: lint, format, types, 715 unit tests green.
- Integration lane run against a local PostgreSQL 16 (Docker is unavailable in this environment; the Testcontainers setup was pointed at it via an uncommitted local patch): `db.integration.test.ts` 27/28 (the one failure, `TestStore refuses a second result…`, is pre-existing: it asserts an index name in `error.message` where it lives in the cause), `ctrl.integration.test.ts` 31/31.
- End-to-end walkthrough against a freshly migrated database:

[ctrl-diagnose-walkthrough.log](https://cursor.com/agents/bc-9cc4885e-92f8-4914-b9b7-46681a1fd135/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fctrl-diagnose-walkthrough.log)

## Review

Reviewed twice by GPT-5.6 Sol subagents per `development.md` (the second on max mode, checking line by line against the Effect style guide). All findings applied in the last commit: `listErrorTypes` traced as `Effect.fn`, the creation log line made a fixed sentence (`error type created; <key>`), command failure tests flipped and matched on `_tag` + `message`, database failure assertions consolidated, the process test's unknown-type case exercised on a real failed session, table/store comments cut to two lines, docs naming the exact stdout line. The reviewer confirmed every finding resolved and no remaining violations.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cc4885e-92f8-4914-b9b7-46681a1fd135?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cc4885e-92f8-4914-b9b7-46681a1fd135&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

