### PR TITLE
v2: stacked model success/failure bars on the test definitions page

### DIFF
--- a/v2/development.md
+++ b/v2/development.md
@@ -1271,6 +1271,13 @@ and drizzle, the same tables the Effect `TestStore` writes. It does not call `Pr
 - `definitionStats` folds those 50 rows by definition name: succeeded, failed, and every other
   session status as `other`, plus the distinct `test_results.model` values. Sessions that are not
   tied to a definition are omitted from the table, not counted as a row.
+- The test-definitions page lists every `test_definitions` row and, separately,
+  `listTestResultOutcomes` (every `test_results` row joined to its definition: name, model,
+  status). `modelStats` folds those outcomes by `test_results.model`: `passed` is succeeded,
+  `failed` is failed. A null model, and every status that is not `passed` or `failed`, is omitted;
+  a model that then has no counts is omitted. Each definition card draws one stacked bar per
+  remaining model (name on the left, succeeded green and failed red, counts inside the segments).
+  If the outcomes query fails, the definitions still render and the charts are omitted.
 - Route failures are `Sentry.captureException` on `@sentry/cloudflare` (`withSentry` wraps the
   app, `SENTRY_DSN` from `dsn.ts`). Effect's `ErrorReporter` is not installed here; that is the
   one place `captureException` is called outside `observability/`.

--- a/v2/development.md
+++ b/v2/development.md
@@ -1277,7 +1277,8 @@ and drizzle, the same tables the Effect `TestStore` writes. It does not call `Pr
   `failed` is failed. A null model, and every status that is not `passed` or `failed`, is omitted;
   a model that then has no counts is omitted. Each definition card draws one stacked bar per
   remaining model (name on the left, succeeded green and failed red, counts inside the segments).
-  If the outcomes query fails, the definitions still render and the charts are omitted.
+  The two queries run together; a failure of either is the same route error as a failed
+  definition list.
 - Route failures are `Sentry.captureException` on `@sentry/cloudflare` (`withSentry` wraps the
   app, `SENTRY_DSN` from `dsn.ts`). Effect's `ErrorReporter` is not installed here; that is the
   one place `captureException` is called outside `observability/`.

--- a/v2/public/dashboard.css
+++ b/v2/public/dashboard.css
@@ -478,6 +478,53 @@ main {
   white-space: pre-wrap;
 }
 
+.model-chart {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.model-chart__row {
+  display: grid;
+  grid-template-columns: minmax(6.5rem, 9.5rem) 1fr;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.model-chart__name {
+  color: var(--terminal-white);
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.model-chart__bar {
+  display: flex;
+  min-height: 1.6rem;
+  overflow: hidden;
+  background: rgb(122 162 247 / 12%);
+}
+
+.model-chart__ok,
+.model-chart__failed {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.6em;
+  padding-inline: 0.35em;
+  color: var(--background-night);
+  font-weight: 700;
+}
+
+.model-chart__ok {
+  background: var(--green);
+}
+
+.model-chart__failed {
+  background: var(--failed);
+}
+
 .empty-state {
   display: grid;
   min-height: 14rem;

--- a/v2/src/dashboard/dashboard.tsx
+++ b/v2/src/dashboard/dashboard.tsx
@@ -8,10 +8,14 @@ import {
   listSessions,
   listTestBasePrompts,
   listTestDefinitions,
+  listTestResultOutcomes,
+  modelStats,
   type DefinitionStat,
+  type ModelStat,
   type Session,
   type TestBasePrompt,
   type TestDefinition,
+  type TestResultOutcome,
 } from "./query.ts";
 import { clickerPage } from "./clicker.ts";
 import { SENTRY_DSN } from "../observability/dsn.ts";
@@ -63,6 +67,36 @@ const SessionStatus: FC<SessionStatusProps> = ({ sessions, outOfBand = false }) 
     )}
   </span>
 );
+
+const ModelChart: FC<{ stats: ReadonlyArray<ModelStat> }> = ({ stats }) =>
+  stats.length === 0 ? null : (
+    <div class="record__field">
+      <h3>Results by model</h3>
+      <ul class="model-chart">
+        {stats.map((row) => (
+          <li class="model-chart__row">
+            <span class="model-chart__name">{row.model}</span>
+            <div
+              class="model-chart__bar"
+              role="img"
+              aria-label={`${row.model}: ${String(row.succeeded)} succeeded, ${String(row.failed)} failed`}
+            >
+              {row.succeeded > 0 ? (
+                <span class="model-chart__ok" style={{ flexGrow: row.succeeded, flexBasis: 0 }}>
+                  {row.succeeded}
+                </span>
+              ) : null}
+              {row.failed > 0 ? (
+                <span class="model-chart__failed" style={{ flexGrow: row.failed, flexBasis: 0 }}>
+                  {row.failed}
+                </span>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 
 const DefinitionScoreboard: FC<{ stats: ReadonlyArray<DefinitionStat> }> = ({ stats }) =>
   stats.length === 0 ? null : (
@@ -244,9 +278,10 @@ const Home: FC<HomeProps> = ({ sessions }) => (
 
 type DefinitionsProps = {
   definitions: TestDefinition[] | null;
+  outcomes: TestResultOutcome[] | null;
 };
 
-const Definitions: FC<DefinitionsProps> = ({ definitions }) => (
+const Definitions: FC<DefinitionsProps> = ({ definitions, outcomes }) => (
   <Shell page="definitions">
     <section class="records" aria-labelledby="definitions-heading">
       <div class="sessions__heading">
@@ -271,6 +306,13 @@ const Definitions: FC<DefinitionsProps> = ({ definitions }) => (
                   <time dateTime={definition.createdAt.toISOString()}>
                     {dateTime.format(definition.createdAt)}
                   </time>
+                  {outcomes === null ? null : (
+                    <ModelChart
+                      stats={modelStats(
+                        outcomes.filter((row) => row.definitionName === definition.name),
+                      )}
+                    />
+                  )}
                   <div class="record__field">
                     <h3>Description</h3>
                     <p>{definition.description}</p>
@@ -377,12 +419,19 @@ app.get("/", async (context) => {
 app.get("/definitions", async (context) => {
   try {
     const definitions = await listTestDefinitions(context.env.HYPERDRIVE.connectionString);
-    return context.render(<Definitions definitions={definitions} />);
+    try {
+      const outcomes = await listTestResultOutcomes(context.env.HYPERDRIVE.connectionString);
+      return context.render(<Definitions definitions={definitions} outcomes={outcomes} />);
+    } catch (error) {
+      Sentry.captureException(error);
+      console.error("dashboard: listing test result outcomes:", errorMessage(error));
+      return context.render(<Definitions definitions={definitions} outcomes={null} />);
+    }
   } catch (error) {
     Sentry.captureException(error);
     console.error("dashboard: listing test definitions:", errorMessage(error));
     context.status(500);
-    return context.render(<Definitions definitions={null} />);
+    return context.render(<Definitions definitions={null} outcomes={null} />);
   }
 });
 

--- a/v2/src/dashboard/dashboard.tsx
+++ b/v2/src/dashboard/dashboard.tsx
@@ -278,7 +278,7 @@ const Home: FC<HomeProps> = ({ sessions }) => (
 
 type DefinitionsProps = {
   definitions: TestDefinition[] | null;
-  outcomes: TestResultOutcome[] | null;
+  outcomes: TestResultOutcome[];
 };
 
 const Definitions: FC<DefinitionsProps> = ({ definitions, outcomes }) => (
@@ -306,13 +306,11 @@ const Definitions: FC<DefinitionsProps> = ({ definitions, outcomes }) => (
                   <time dateTime={definition.createdAt.toISOString()}>
                     {dateTime.format(definition.createdAt)}
                   </time>
-                  {outcomes === null ? null : (
-                    <ModelChart
-                      stats={modelStats(
-                        outcomes.filter((row) => row.definitionName === definition.name),
-                      )}
-                    />
-                  )}
+                  <ModelChart
+                    stats={modelStats(
+                      outcomes.filter((row) => row.definitionName === definition.name),
+                    )}
+                  />
                   <div class="record__field">
                     <h3>Description</h3>
                     <p>{definition.description}</p>
@@ -418,20 +416,16 @@ app.get("/", async (context) => {
 
 app.get("/definitions", async (context) => {
   try {
-    const definitions = await listTestDefinitions(context.env.HYPERDRIVE.connectionString);
-    try {
-      const outcomes = await listTestResultOutcomes(context.env.HYPERDRIVE.connectionString);
-      return context.render(<Definitions definitions={definitions} outcomes={outcomes} />);
-    } catch (error) {
-      Sentry.captureException(error);
-      console.error("dashboard: listing test result outcomes:", errorMessage(error));
-      return context.render(<Definitions definitions={definitions} outcomes={null} />);
-    }
+    const [definitions, outcomes] = await Promise.all([
+      listTestDefinitions(context.env.HYPERDRIVE.connectionString),
+      listTestResultOutcomes(context.env.HYPERDRIVE.connectionString),
+    ]);
+    return context.render(<Definitions definitions={definitions} outcomes={outcomes} />);
   } catch (error) {
     Sentry.captureException(error);
-    console.error("dashboard: listing test definitions:", errorMessage(error));
+    console.error("dashboard: loading the definitions page:", errorMessage(error));
     context.status(500);
-    return context.render(<Definitions definitions={null} outcomes={null} />);
+    return context.render(<Definitions definitions={null} outcomes={[]} />);
   }
 });
 

--- a/v2/src/dashboard/query.ts
+++ b/v2/src/dashboard/query.ts
@@ -28,6 +28,18 @@ export type DefinitionStat = {
   readonly models: ReadonlyArray<string>;
 };
 
+export type TestResultOutcome = {
+  readonly definitionName: string;
+  readonly model: string | null;
+  readonly status: (typeof testResults.$inferSelect)["status"];
+};
+
+export type ModelStat = {
+  readonly model: string;
+  readonly succeeded: number;
+  readonly failed: number;
+};
+
 // One connection per call, ended whether the query returned, threw, or never connected;
 // a client left open holds a Hyperdrive connection for the rest of the request.
 async function withDatabase<T>(
@@ -78,6 +90,29 @@ export function definitionStats(rows: ReadonlyArray<Session>): DefinitionStat[] 
       failed: current.failed,
       other: current.other,
       models: [...current.models].sort(),
+    }));
+}
+
+export function modelStats(rows: ReadonlyArray<TestResultOutcome>): ModelStat[] {
+  const byModel = new Map<string, { succeeded: number; failed: number }>();
+  for (const row of rows) {
+    if (row.model === null || (row.status !== "passed" && row.status !== "failed")) {
+      continue;
+    }
+    const current = byModel.get(row.model) ?? { succeeded: 0, failed: 0 };
+    if (row.status === "passed") {
+      current.succeeded += 1;
+    } else {
+      current.failed += 1;
+    }
+    byModel.set(row.model, current);
+  }
+  return [...byModel.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([model, current]) => ({
+      model,
+      succeeded: current.succeeded,
+      failed: current.failed,
     }));
 }
 
@@ -143,6 +178,19 @@ export function getImage(connectionString: string, id: string): Promise<Buffer |
 export function listTestDefinitions(connectionString: string): Promise<TestDefinition[]> {
   return withDatabase(connectionString, (db) =>
     db.select().from(testDefinitions).orderBy(testDefinitions.name),
+  );
+}
+
+export function listTestResultOutcomes(connectionString: string): Promise<TestResultOutcome[]> {
+  return withDatabase(connectionString, (db) =>
+    db
+      .select({
+        definitionName: testDefinitions.name,
+        model: testResults.model,
+        status: testResults.status,
+      })
+      .from(testResults)
+      .innerJoin(testDefinitions, eq(testDefinitions.id, testResults.definitionId)),
   );
 }
 

--- a/v2/test/dashboard/query.unit.test.ts
+++ b/v2/test/dashboard/query.unit.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { definitionStats, type Session } from "../../src/dashboard/query.ts";
+import {
+  definitionStats,
+  modelStats,
+  type Session,
+  type TestResultOutcome,
+} from "../../src/dashboard/query.ts";
 
 const session = (
   status: Session["status"],
@@ -63,5 +68,66 @@ describe("definitionStats unhappy path", () => {
         session("succeeded", "lock-screen", "grok-4.6"),
       ]),
     ).toEqual([{ name: "lock-screen", succeeded: 1, failed: 0, other: 0, models: ["grok-4.6"] }]);
+  });
+});
+
+const outcome = (
+  status: TestResultOutcome["status"],
+  definitionName: string,
+  model: string | null,
+): TestResultOutcome => ({ definitionName, model, status });
+
+describe("modelStats happy path", () => {
+  it("groups passed and failed results by model and sorts the models", () => {
+    expect(
+      modelStats([
+        outcome("passed", "lock-screen", "grok-4.6"),
+        outcome("failed", "lock-screen", "grok-4.6"),
+        outcome("failed", "lock-screen", "grok-4.6"),
+        outcome("passed", "install", "composer-2.5"),
+      ]),
+    ).toEqual([
+      { model: "composer-2.5", succeeded: 1, failed: 0 },
+      { model: "grok-4.6", succeeded: 1, failed: 2 },
+    ]);
+  });
+
+  it("counts one model's results across definitions when the rows are not filtered", () => {
+    expect(
+      modelStats([
+        outcome("passed", "lock-screen", "grok-4.6"),
+        outcome("failed", "install", "grok-4.6"),
+      ]),
+    ).toEqual([{ model: "grok-4.6", succeeded: 1, failed: 1 }]);
+  });
+});
+
+describe("modelStats unhappy path", () => {
+  it("returns no rows when there are no results", () => {
+    expect(modelStats([])).toEqual([]);
+  });
+
+  it("omits results with no model, and statuses that are not passed or failed", () => {
+    expect(
+      modelStats([
+        outcome("passed", "lock-screen", null),
+        outcome("failed", "lock-screen", null),
+        outcome("pending", "lock-screen", "grok-4.6"),
+        outcome("running", "lock-screen", "grok-4.6"),
+        outcome("aborted", "lock-screen", "grok-4.6"),
+        outcome("timed_out", "lock-screen", "grok-4.6"),
+        outcome("passed", "lock-screen", "grok-4.6"),
+      ]),
+    ).toEqual([{ model: "grok-4.6", succeeded: 1, failed: 0 }]);
+  });
+
+  it("omits a model that has only pending, running, aborted or timed_out results", () => {
+    expect(
+      modelStats([
+        outcome("pending", "lock-screen", "composer-2.5"),
+        outcome("timed_out", "lock-screen", "composer-2.5"),
+        outcome("passed", "lock-screen", "grok-4.6"),
+      ]),
+    ).toEqual([{ model: "grok-4.6", succeeded: 1, failed: 0 }]);
   });
 });

--- a/v2/test/integration/dashboard.integration.test.ts
+++ b/v2/test/integration/dashboard.integration.test.ts
@@ -124,6 +124,44 @@ console.log(JSON.stringify(query.definitionStats(rows)));
     ]);
   });
 
+  it("lists test result outcomes with definition name and model and ends the connection", async () => {
+    const result = await runQuery(
+      `
+const { eq } = await import("drizzle-orm");
+const { drizzle } = await import("drizzle-orm/node-postgres");
+const { Client } = await import("pg");
+const schema = await import(${JSON.stringify(SCHEMA)});
+const client = new Client({ connectionString: url });
+await client.connect();
+const db = drizzle(client);
+const [lock] = await db.select({ id: schema.testDefinitions.id }).from(schema.testDefinitions).where(eq(schema.testDefinitions.name, "lock-screen"));
+const [install] = await db.insert(schema.testDefinitions).values({ name: "install-outcomes", description: "d", instruction: "i", proof: "p" }).returning({ id: schema.testDefinitions.id });
+const [run] = await db.insert(schema.testRuns).values({ name: "Omarchy experiment", iso: "https://example.com/omarchy.iso", serverUrl: "http://127.0.0.1:42069" }).returning({ id: schema.testRuns.id });
+await db.insert(schema.testResults).values([
+  { runId: run.id, definitionId: lock.id, status: "passed", model: "grok-4.6" },
+  { runId: run.id, definitionId: install.id, status: "failed", model: "composer-2.5" },
+]);
+await client.end();
+const rows = await query.listTestResultOutcomes(url);
+const counted = query.modelStats(rows.filter((row) => row.definitionName === "lock-screen" || row.definitionName === "install-outcomes"));
+console.log(rows.filter((row) => row.definitionName === "lock-screen" || row.definitionName === "install-outcomes").map((row) => [row.definitionName, row.model, row.status].join(" ")).sort().join("\\n"));
+console.log(JSON.stringify(counted));
+`,
+      dbUrl,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    const printed = lines(result.stdout);
+    const stats = printed.at(-1);
+    const listed = printed.slice(0, -1);
+    expect(listed).toEqual(["install-outcomes composer-2.5 failed", "lock-screen grok-4.6 passed"]);
+    expect(JSON.parse(stats ?? "")).toEqual([
+      { model: "composer-2.5", succeeded: 0, failed: 1 },
+      { model: "grok-4.6", succeeded: 1, failed: 0 },
+    ]);
+  });
+
   it("lists base prompts and ends the connection", async () => {
     const result = await runQuery(
       "const rows = await query.listTestBasePrompts(url);\nconsole.log(rows.map((row) => `${row.name} ${typeof row.prompt}`).join('\\n'));",
@@ -171,6 +209,17 @@ describe("dashboard/query unhappy path: unreachable database", () => {
   it("surfaces a refused connection and exits without echoing the password", async () => {
     const result = await runQuery(
       "try {\n  await query.listTestDefinitions(url);\n} catch (err) {\n  console.error(err.message);\n  process.exitCode = 3;\n}",
+      REFUSED_URL,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.code).toBe(3);
+    expect(result.stderr).toMatch(/ECONNREFUSED/);
+    expect(result.stderr).not.toContain(SENTINEL_PASSWORD);
+  });
+
+  it("surfaces a refused connection from listTestResultOutcomes without echoing the password", async () => {
+    const result = await runQuery(
+      "try {\n  await query.listTestResultOutcomes(url);\n} catch (err) {\n  console.error(err.message);\n  process.exitCode = 3;\n}",
       REFUSED_URL,
     );
     expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);

--- a/v2/test/integration/dashboard.integration.test.ts
+++ b/v2/test/integration/dashboard.integration.test.ts
@@ -127,14 +127,13 @@ console.log(JSON.stringify(query.definitionStats(rows)));
   it("lists test result outcomes with definition name and model and ends the connection", async () => {
     const result = await runQuery(
       `
-const { eq } = await import("drizzle-orm");
 const { drizzle } = await import("drizzle-orm/node-postgres");
 const { Client } = await import("pg");
 const schema = await import(${JSON.stringify(SCHEMA)});
 const client = new Client({ connectionString: url });
 await client.connect();
 const db = drizzle(client);
-const [lock] = await db.select({ id: schema.testDefinitions.id }).from(schema.testDefinitions).where(eq(schema.testDefinitions.name, "lock-screen"));
+const [lock] = await db.insert(schema.testDefinitions).values({ name: "lock-outcomes", description: "d", instruction: "i", proof: "p" }).returning({ id: schema.testDefinitions.id });
 const [install] = await db.insert(schema.testDefinitions).values({ name: "install-outcomes", description: "d", instruction: "i", proof: "p" }).returning({ id: schema.testDefinitions.id });
 const [run] = await db.insert(schema.testRuns).values({ name: "Omarchy experiment", iso: "https://example.com/omarchy.iso", serverUrl: "http://127.0.0.1:42069" }).returning({ id: schema.testRuns.id });
 await db.insert(schema.testResults).values([
@@ -143,8 +142,8 @@ await db.insert(schema.testResults).values([
 ]);
 await client.end();
 const rows = await query.listTestResultOutcomes(url);
-const counted = query.modelStats(rows.filter((row) => row.definitionName === "lock-screen" || row.definitionName === "install-outcomes"));
-console.log(rows.filter((row) => row.definitionName === "lock-screen" || row.definitionName === "install-outcomes").map((row) => [row.definitionName, row.model, row.status].join(" ")).sort().join("\\n"));
+const counted = query.modelStats(rows.filter((row) => row.definitionName === "lock-outcomes" || row.definitionName === "install-outcomes"));
+console.log(rows.filter((row) => row.definitionName === "lock-outcomes" || row.definitionName === "install-outcomes").map((row) => [row.definitionName, row.model, row.status].join(" ")).sort().join("\\n"));
 console.log(JSON.stringify(counted));
 `,
       dbUrl,
@@ -155,7 +154,10 @@ console.log(JSON.stringify(counted));
     const printed = lines(result.stdout);
     const stats = printed.at(-1);
     const listed = printed.slice(0, -1);
-    expect(listed).toEqual(["install-outcomes composer-2.5 failed", "lock-screen grok-4.6 passed"]);
+    expect(listed).toEqual([
+      "install-outcomes composer-2.5 failed",
+      "lock-outcomes grok-4.6 passed",
+    ]);
     expect(JSON.parse(stats ?? "")).toEqual([
       { model: "composer-2.5", succeeded: 0, failed: 1 },
       { model: "grok-4.6", succeeded: 1, failed: 0 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The test-results scoreboard still groups the last 50 sessions by definition. This adds a model slice on the Test definitions page, using every stored `test_results` row (not the last-50 session window).

Each definition card that has passed or failed results now shows a stacked bar per model: name on the left, green for `passed`, red for `failed`, with the counts inside the segments. Models are stacked as rows. Pending, running, aborted, timed-out, and null-model rows are omitted.

The definition list and the outcome list load together. A failure of either is the same route error as a failed definition list, so a missing chart is not confused with zero results.

[Test definitions page with model success/failure bars](https://cursor.com/agents/bc-01a07821-096e-76e2-94ce-e691d46c40e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdefinitions-all-cards.webp)
[definitions-model-chart.mp4](https://cursor.com/agents/bc-01a07821-096e-76e2-94ce-e691d46c40e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdefinitions-model-chart.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07821-096e-76e2-94ce-e691d46c40e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07821-096e-76e2-94ce-e691d46c40e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

