### PR TITLE
Dashboard: edit a test definition into its next version; wordings newest first, each with its runs

### DIFF
--- a/public/dashboard.css
+++ b/public/dashboard.css
@@ -529,43 +529,135 @@ main {
   color: var(--terminal-blue);
 }
 
-/* A definition's wordings, oldest first; the one the card shows is marked. */
-.definition__versions {
+/* A definition's wordings, newest first; each folds open on its text, its chart and its runs. */
+.definition__wordings {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.definition__wording {
+  border: 1px solid rgb(122 162 247 / 22%);
+}
+
+.definition__wording > summary {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.definition__version {
-  padding: 0.3em 0.8em;
-  border: 1px solid rgb(122 162 247 / 30%);
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.8em 1em;
   color: var(--terminal-blue);
-  font-weight: 700;
-  text-decoration: none;
-  transition:
-    color var(--transition),
-    background var(--transition),
-    border-color var(--transition);
+  cursor: pointer;
+  list-style: none;
 }
 
-.definition__version:hover {
+.definition__wording > summary::-webkit-details-marker {
+  display: none;
+}
+
+.definition__wording > summary::before {
+  content: "▸";
   color: var(--turquoise);
 }
 
-.definition__version:focus-visible {
+.definition__wording[open] > summary::before {
+  content: "▾";
+}
+
+.definition__wording > summary:focus-visible {
   outline: 2px solid var(--turquoise);
-  outline-offset: 2px;
+  outline-offset: -2px;
 }
 
-.definition__version--current {
-  border-color: var(--turquoise);
-  background: rgb(122 162 247 / 10%);
-  color: var(--turquoise);
+.definition__wording-label {
+  color: var(--terminal-white);
+  font-size: 1.15em;
+  font-weight: 700;
+}
+
+.definition__wording > summary time {
+  font-size: 0.7em;
+  text-transform: uppercase;
+}
+
+.definition__wording-runs {
+  margin-left: auto;
+  font-size: 0.85em;
+}
+
+.definition__wording-body {
+  display: grid;
+  gap: 1.5rem;
+  padding: 0 1em 1.2em;
 }
 
 .definition__chart {
   display: grid;
   gap: 1.5rem;
+}
+
+/* The edit form: the newest wording, ready to be saved as the next. */
+.definition__edit > summary {
+  display: inline-block;
+  line-height: 2.9em;
+  cursor: pointer;
+  list-style: none;
+}
+
+.definition__edit > summary::-webkit-details-marker {
+  display: none;
+}
+
+.definition__form {
+  display: grid;
+  gap: 1.1rem;
+  margin-top: 1.1rem;
+  padding: 1.2em 1em;
+  border: 1px solid var(--turquoise);
+}
+
+.definition__form-note,
+.definition__form-notice {
+  margin: 0;
+  color: var(--terminal-blue);
+}
+
+.definition__form-notice {
+  color: var(--failed);
+  font-weight: 700;
+}
+
+.definition__form-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.definition__form-field > span {
+  color: var(--terminal-blue);
+  font-size: 0.7em;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.definition__form textarea {
+  width: 100%;
+  padding: 0.6em 0.75em;
+  border: 1px solid rgb(122 162 247 / 30%);
+  background: rgb(122 162 247 / 6%);
+  color: var(--terminal-white);
+  font: inherit;
+  resize: vertical;
+}
+
+.definition__form textarea:focus-visible {
+  outline: 2px solid var(--turquoise);
+  outline-offset: 2px;
+}
+
+.definition__form .button {
+  justify-self: start;
 }
 
 /* The runs that used the wording shown, newest first. */
@@ -677,10 +769,8 @@ main {
     grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
     grid-template-areas:
       "title title"
-      "versions versions"
-      "time time"
-      "chart fields"
-      "runs runs";
+      "chart edit"
+      "wordings wordings";
     align-items: start;
     column-gap: 4rem;
   }
@@ -690,23 +780,36 @@ main {
     font-size: 2em;
   }
 
-  .definition__versions {
-    grid-area: versions;
-  }
-
-  .definition > time {
-    grid-area: time;
-  }
-
-  .definition__chart {
+  .definition > .definition__chart {
     grid-area: chart;
   }
 
-  .definition__fields {
+  .definition__edit {
+    grid-area: edit;
+  }
+
+  .definition__wordings {
+    grid-area: wordings;
+  }
+
+  /* Inside a wording: its text beside its chart, the runs beneath both. */
+  .definition__wording-body {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    grid-template-areas:
+      "fields chart"
+      "runs runs";
+    column-gap: 4rem;
+  }
+
+  .definition__wording-body > .definition__fields {
     grid-area: fields;
   }
 
-  .definition__runs {
+  .definition__wording-body > .definition__chart {
+    grid-area: chart;
+  }
+
+  .definition__wording-body > .definition__runs {
     grid-area: runs;
   }
 

--- a/public/dashboard.css
+++ b/public/dashboard.css
@@ -706,8 +706,8 @@ main {
   gap: 1.1rem;
 }
 
-/* Wide screens: the definition names down the left, the current definition's results by model in
-   the centre and its text on the right. */
+/* Wide screens: the definition names down the left; the current definition's results by version
+   beside its edit form, then its wordings newest first, each folding open on text, chart and runs. */
 @media (min-width: 64rem) {
   main[data-page="definitions"] {
     width: min(100% - 4rem, 96rem);

--- a/public/dashboard.css
+++ b/public/dashboard.css
@@ -219,7 +219,7 @@ main {
     transform var(--transition);
 }
 
-.button:hover {
+.button:hover:not(:disabled) {
   background: var(--turquoise);
   transform: translateY(-1px);
 }
@@ -227,6 +227,13 @@ main {
 .button:focus-visible {
   outline: 2px solid var(--turquoise);
   outline-offset: 3px;
+}
+
+.button:disabled {
+  background: rgb(122 162 247 / 25%);
+  box-shadow: none;
+  color: rgb(26 27 38 / 70%);
+  cursor: not-allowed;
 }
 
 .scoreboard {
@@ -597,24 +604,13 @@ main {
   gap: 1.5rem;
 }
 
-/* The edit form: the newest wording, ready to be saved as the next. */
-.definition__edit > summary {
-  display: inline-block;
-  line-height: 2.9em;
-  cursor: pointer;
-  list-style: none;
-}
-
-.definition__edit > summary::-webkit-details-marker {
-  display: none;
-}
-
+/* The newest wording as a form: its update writes the next version, and the button stays gray until
+   a field differs from the text the page came with. */
 .definition__form {
   display: grid;
   gap: 1.1rem;
-  margin-top: 1.1rem;
   padding: 1.2em 1em;
-  border: 1px solid var(--turquoise);
+  border: 1px solid rgb(122 162 247 / 22%);
 }
 
 .definition__form-note,
@@ -707,7 +703,8 @@ main {
 }
 
 /* Wide screens: the definition names down the left; the current definition's results by version
-   beside its edit form, then its wordings newest first, each folding open on text, chart and runs. */
+   beside its newest wording as a form, then its wordings newest first, each folding open on text,
+   chart and runs. */
 @media (min-width: 64rem) {
   main[data-page="definitions"] {
     width: min(100% - 4rem, 96rem);
@@ -769,7 +766,7 @@ main {
     grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
     grid-template-areas:
       "title title"
-      "chart edit"
+      "chart form"
       "wordings wordings";
     align-items: start;
     column-gap: 4rem;
@@ -784,8 +781,8 @@ main {
     grid-area: chart;
   }
 
-  .definition__edit {
-    grid-area: edit;
+  .definition__form {
+    grid-area: form;
   }
 
   .definition__wordings {

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -1,0 +1,13 @@
+// A definition's update button is handed over disabled and enabled here once a field differs from
+// the wording the page was rendered with (a textarea's default value): an unchanged wording is not
+// an update. Delegated from the document so it holds across the page's htmx swaps.
+document.addEventListener("input", (event) => {
+  const form = event.target instanceof Element ? event.target.closest("form.definition__form") : null;
+  if (form === null) {
+    return;
+  }
+  const changed = [...form.querySelectorAll("textarea")].some(
+    (field) => field.value !== field.defaultValue,
+  );
+  form.querySelector("button[type=submit]").disabled = !changed;
+});

--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -669,9 +669,11 @@ app.get("/definitions", async (context) => {
 // fields filled; a request that arrives without one is answered all the same.
 app.post("/definitions", async (context) => {
   const body = await context.req.parseBody();
-  // A field is text with something in it; a file part or a repeated field is not this form's.
+  // A field is text with something in it; a file part is not this form's. A browser submits a
+  // textarea's newlines as CRLF; the wording is kept with LF, as ctrl writes it, so the same text
+  // posted back reads unchanged.
   const text = (value: (typeof body)[string]): string | undefined =>
-    typeof value === "string" && value !== "" ? value : undefined;
+    typeof value === "string" && value !== "" ? value.replaceAll("\r\n", "\n") : undefined;
   const name = text(body.name);
   if (name === undefined) {
     return context.notFound();
@@ -689,7 +691,7 @@ app.post("/definitions", async (context) => {
       instruction,
       proof,
     });
-    switch (revision.outcome) {
+    switch (revision) {
       case "unknown":
         return context.notFound();
       case "unchanged":

--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -11,13 +11,13 @@ import {
   listTestDefinitions,
   listTestResultOutcomes,
   modelStats,
+  reviseTestDefinition,
   selectDefinition,
   versionStats,
   type DefinitionStat,
   type DefinitionVersions,
   type Session,
   type TestBasePrompt,
-  type TestDefinition,
   type TestResultOutcome,
 } from "./query.ts";
 import { clickerPage } from "./clicker.ts";
@@ -291,59 +291,73 @@ const Home: FC<HomeProps> = ({ sessions }) => (
   </Shell>
 );
 
+type EditNotice = "unchanged" | "empty";
+
+const EDIT_NOTICES: Record<EditNotice, string> = {
+  unchanged: "Nothing changed: the newest wording already reads like this.",
+  empty: "Every field needs text.",
+};
+
 type DefinitionsProps = {
   groups: DefinitionVersions[] | null;
   outcomes: TestResultOutcome[];
-  // The ?name and ?id the page was asked for, and the wording they resolved to: nothing when the
-  // name is unknown or the id is not one of its wordings, so the wide layout can say so instead
-  // of opening on another one.
+  // The ?name the page was asked for and the definition it resolved to: nothing when the name is
+  // unknown, so the wide layout can say so instead of opening on another one.
   name: string | undefined;
-  id: string | undefined;
-  selected: TestDefinition | undefined;
+  selected: DefinitionVersions | undefined;
+  // Why the last edit of the selected definition was refused, when it was.
+  notice: EditNotice | undefined;
 };
 
 const definitionHref = (name: string): string => `/definitions?name=${encodeURIComponent(name)}`;
-const versionHref = (name: string, id: number): string =>
-  `${definitionHref(name)}&id=${String(id)}`;
+const editHref = (name: string, notice: EditNotice): string =>
+  `${definitionHref(name)}&edit=${notice}`;
 
-// One name's card: the wording shown (the selected one, or the newest), its version strip, the
-// name's results by version beside the wording's by model, its text, and the runs that used it.
+const RunsTable: FC<{ runs: ReadonlyArray<TestResultOutcome> }> = ({ runs }) =>
+  runs.length === 0 ? (
+    <p class="result-chart__empty">No runs yet.</p>
+  ) : (
+    <table class="runs">
+      <thead>
+        <tr>
+          <th>Run</th>
+          <th>Omarchy version</th>
+          <th>Started</th>
+          <th>Model</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {runs.map((run) => (
+          <tr>
+            <td>
+              <code>{run.runId}</code>
+            </td>
+            <td>{run.iso.split("/").at(-1) ?? run.iso}</td>
+            <td>
+              <time dateTime={run.startedAt.toISOString()}>{dateTime.format(run.startedAt)}</time>
+            </td>
+            <td>{run.model ?? "—"}</td>
+            <td>{run.status === "timed_out" ? "timed out" : run.status}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+// One name's card: its results by version, the edit form that saves the next version, then every
+// wording newest first, the newest open, each with its text, its results by model and the runs
+// that used it. The name is what the wordings collapse under, so it is not a field.
 const DefinitionCard: FC<{
   group: DefinitionVersions;
-  shown: TestDefinition;
   outcomes: ReadonlyArray<TestResultOutcome>;
-}> = ({ group, shown, outcomes }) => {
-  const version = group.versions.indexOf(shown) + 1;
-  const runs = outcomes
-    .filter((row) => row.definitionId === shown.id)
-    .sort((left, right) => right.startedAt.getTime() - left.startedAt.getTime());
+  notice: EditNotice | undefined;
+}> = ({ group, outcomes, notice }) => {
+  const newest = group.versions[group.versions.length - 1];
+  const next = group.versions.length + 1;
   return (
     <article class="record definition">
       <h2>{group.name}</h2>
-      <nav
-        class="definition__versions"
-        aria-label={`Versions of ${group.name}`}
-        hx-target:inherited="#definitions"
-        hx-select:inherited="#definitions"
-        hx-swap:inherited="outerHTML"
-        hx-push-url:inherited="true"
-      >
-        {group.versions.map((wording, index) => (
-          <a
-            href={versionHref(group.name, wording.id)}
-            hx-get={versionHref(group.name, wording.id)}
-            class={
-              wording.id === shown.id
-                ? "definition__version definition__version--current"
-                : "definition__version"
-            }
-            aria-current={wording.id === shown.id ? "true" : undefined}
-          >
-            v{index + 1}
-          </a>
-        ))}
-      </nav>
-      <time dateTime={shown.createdAt.toISOString()}>{dateTime.format(shown.createdAt)}</time>
       <div class="definition__chart">
         <ResultChart
           title="Results by version"
@@ -353,73 +367,104 @@ const DefinitionCard: FC<{
             failed: row.failed,
           }))}
         />
-        <ResultChart
-          title={`Results by model, v${String(version)}`}
-          rows={modelStats(runs).map((row) => ({
-            label: row.model,
-            succeeded: row.succeeded,
-            failed: row.failed,
-          }))}
-        />
       </div>
-      <div class="definition__fields">
-        <div class="record__field">
-          <h3>Description</h3>
-          <p>{shown.description}</p>
-        </div>
-        <div class="record__field">
-          <h3>Instruction</h3>
-          <p>{shown.instruction}</p>
-        </div>
-        <div class="record__field">
-          <h3>Proof</h3>
-          <p>{shown.proof}</p>
-        </div>
-      </div>
-      <div class="record__field definition__runs">
-        <h3>Runs of v{version}</h3>
-        {runs.length === 0 ? (
-          <p class="result-chart__empty">No runs yet.</p>
-        ) : (
-          <table class="runs">
-            <thead>
-              <tr>
-                <th>Run</th>
-                <th>Omarchy version</th>
-                <th>Started</th>
-                <th>Model</th>
-                <th>Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {runs.map((run) => (
-                <tr>
-                  <td>
-                    <code>{run.runId}</code>
-                  </td>
-                  <td>{run.iso.split("/").at(-1) ?? run.iso}</td>
-                  <td>
-                    <time dateTime={run.startedAt.toISOString()}>
-                      {dateTime.format(run.startedAt)}
-                    </time>
-                  </td>
-                  <td>{run.model ?? "—"}</td>
-                  <td>{run.status === "timed_out" ? "timed out" : run.status}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
+      <details class="definition__edit" open={notice !== undefined}>
+        <summary class="button">Edit</summary>
+        <form method="post" action="/definitions" class="definition__form">
+          <input type="hidden" name="name" value={group.name} />
+          <p class="definition__form-note">
+            Saving writes v{next} of {group.name}; the earlier wordings keep their runs.
+          </p>
+          {notice === undefined ? null : (
+            <p class="definition__form-notice" role="alert">
+              {EDIT_NOTICES[notice]}
+            </p>
+          )}
+          <label class="definition__form-field">
+            <span>Description</span>
+            <textarea name="description" rows={3} required>
+              {newest.description}
+            </textarea>
+          </label>
+          <label class="definition__form-field">
+            <span>Instruction</span>
+            <textarea name="instruction" rows={6} required>
+              {newest.instruction}
+            </textarea>
+          </label>
+          <label class="definition__form-field">
+            <span>Proof</span>
+            <textarea name="proof" rows={3} required>
+              {newest.proof}
+            </textarea>
+          </label>
+          <button class="button" type="submit">
+            Save as v{next}
+          </button>
+        </form>
+      </details>
+      <ul class="definition__wordings">
+        {group.versions.toReversed().map((wording, index) => {
+          const version = group.versions.length - index;
+          const runs = outcomes
+            .filter((row) => row.definitionId === wording.id)
+            .sort((left, right) => right.startedAt.getTime() - left.startedAt.getTime());
+          return (
+            <li>
+              <details class="definition__wording" open={version === group.versions.length}>
+                <summary>
+                  <span class="definition__wording-label">v{version}</span>
+                  <time dateTime={wording.createdAt.toISOString()}>
+                    {dateTime.format(wording.createdAt)}
+                  </time>
+                  <span class="definition__wording-runs">
+                    {runs.length} {runs.length === 1 ? "run" : "runs"}
+                  </span>
+                </summary>
+                <div class="definition__wording-body">
+                  <div class="definition__fields">
+                    <div class="record__field">
+                      <h3>Description</h3>
+                      <p>{wording.description}</p>
+                    </div>
+                    <div class="record__field">
+                      <h3>Instruction</h3>
+                      <p>{wording.instruction}</p>
+                    </div>
+                    <div class="record__field">
+                      <h3>Proof</h3>
+                      <p>{wording.proof}</p>
+                    </div>
+                  </div>
+                  <div class="definition__chart">
+                    <ResultChart
+                      title="Results by model"
+                      rows={modelStats(runs).map((row) => ({
+                        label: row.model,
+                        succeeded: row.succeeded,
+                        failed: row.failed,
+                      }))}
+                    />
+                  </div>
+                  <div class="record__field definition__runs">
+                    <h3>Runs</h3>
+                    <RunsTable runs={runs} />
+                  </div>
+                </div>
+              </details>
+            </li>
+          );
+        })}
+      </ul>
     </article>
   );
 };
 
 // Every card is in the page so a narrow screen keeps its scrolling list; the wide layout shows
-// the sidebar and only the current card. A sidebar or version click fetches the page for that
-// wording and swaps this section in place (htmx 4 inherits an attribute only when told to),
-// pushing the URL so a reload or a shared link opens on the same one.
-const Definitions: FC<DefinitionsProps> = ({ groups, outcomes, name, id, selected }) => (
+// the sidebar and only the current card. A sidebar click fetches the page for that name and swaps
+// this section in place (htmx 4 inherits an attribute only when told to), pushing the URL so a
+// reload or a shared link opens on the same definition.
+const Definitions: FC<DefinitionsProps> = ({ groups, outcomes, name, selected, notice }) => (
   <Shell page="definitions">
     <section id="definitions" class="records definitions" aria-labelledby="definitions-heading">
       <div class="sessions__heading">
@@ -448,10 +493,10 @@ const Definitions: FC<DefinitionsProps> = ({ groups, outcomes, name, id, selecte
               const isCurrent = group.name === selected?.name;
               // The swap replaces the focused link; htmx puts focus back only on an element with
               // the same id, so a keyboard user does not fall back to the top of the page. The
-              // newest wording's id stays the same across the name's versions.
+              // first wording's id is the name's for good.
               return (
                 <a
-                  id={`definition-${String(group.versions[group.versions.length - 1].id)}`}
+                  id={`definition-${String(group.versions[0].id)}`}
                   href={definitionHref(group.name)}
                   hx-get={definitionHref(group.name)}
                   class={
@@ -467,38 +512,28 @@ const Definitions: FC<DefinitionsProps> = ({ groups, outcomes, name, id, selecte
           <div class="definitions__detail">
             {selected === undefined ? (
               <div class="empty-state definitions__missing">
-                {groups.some((group) => group.name === name) ? (
-                  <p>
-                    No version <code>{id}</code> of <code>{name}</code>.
-                  </p>
-                ) : (
-                  <p>
-                    No test definition named <code>{name}</code>.
-                  </p>
-                )}
+                <p>
+                  No test definition named <code>{name}</code>.
+                </p>
                 <span>Pick one from the list.</span>
               </div>
             ) : null}
             <ol class="definitions__list">
-              {groups.map((group) => {
-                // Every card shows a name's newest wording but the current one, which shows the
-                // wording selected under it.
-                const shown =
-                  selected !== undefined && selected.name === group.name
-                    ? selected
-                    : group.versions[group.versions.length - 1];
-                return (
-                  <li
-                    class={
-                      group.name === selected?.name
-                        ? "definitions__item definitions__item--current"
-                        : "definitions__item"
-                    }
-                  >
-                    <DefinitionCard group={group} shown={shown} outcomes={outcomes} />
-                  </li>
-                );
-              })}
+              {groups.map((group) => (
+                <li
+                  class={
+                    group.name === selected?.name
+                      ? "definitions__item definitions__item--current"
+                      : "definitions__item"
+                  }
+                >
+                  <DefinitionCard
+                    group={group}
+                    outcomes={outcomes}
+                    notice={group.name === selected?.name ? notice : undefined}
+                  />
+                </li>
+              ))}
             </ol>
           </div>
         </div>
@@ -590,28 +625,91 @@ app.get("/", async (context) => {
 
 app.get("/definitions", async (context) => {
   const name = context.req.query("name");
-  const id = context.req.query("id");
+  const edit = context.req.query("edit");
+  // Only the two refusals the edit route redirects with are a notice; anything else in ?edit is
+  // a stale or hand-made link and shows nothing.
+  const notice = edit === "unchanged" || edit === "empty" ? edit : undefined;
   try {
     const [definitions, outcomes] = await Promise.all([
       listTestDefinitions(context.env.HYPERDRIVE.connectionString),
       listTestResultOutcomes(context.env.HYPERDRIVE.connectionString),
     ]);
     const groups = groupDefinitions(definitions);
-    const selected = selectDefinition(groups, name, id);
-    // A stale link: the page still lists what exists, the status says the name or wording does
-    // not. An empty table selects nothing and is not a stale link.
-    if (groups.length > 0 && selected === undefined) {
+    const selected = selectDefinition(groups, name);
+    // A stale link: the page still lists what exists, the status says the name does not.
+    if (name !== undefined && selected === undefined) {
       context.status(404);
     }
     return context.render(
-      <Definitions groups={groups} outcomes={outcomes} name={name} id={id} selected={selected} />,
+      <Definitions
+        groups={groups}
+        outcomes={outcomes}
+        name={name}
+        selected={selected}
+        notice={notice}
+      />,
     );
   } catch (error) {
     Sentry.captureException(error);
     console.error("dashboard: loading the definitions page:", errorMessage(error));
     context.status(500);
     return context.render(
-      <Definitions groups={null} outcomes={[]} name={name} id={id} selected={undefined} />,
+      <Definitions
+        groups={null}
+        outcomes={[]}
+        name={name}
+        selected={undefined}
+        notice={undefined}
+      />,
+    );
+  }
+});
+
+// The edit form's save: the next wording of a known name. The browser's `required` keeps the
+// fields filled; a request that arrives without one is answered all the same.
+app.post("/definitions", async (context) => {
+  const body = await context.req.parseBody();
+  // A field is text with something in it; a file part or a repeated field is not this form's.
+  const text = (value: (typeof body)[string]): string | undefined =>
+    typeof value === "string" && value !== "" ? value : undefined;
+  const name = text(body.name);
+  if (name === undefined) {
+    return context.notFound();
+  }
+  const description = text(body.description);
+  const instruction = text(body.instruction);
+  const proof = text(body.proof);
+  if (description === undefined || instruction === undefined || proof === undefined) {
+    return context.redirect(editHref(name, "empty"), 303);
+  }
+  try {
+    const revision = await reviseTestDefinition(context.env.HYPERDRIVE.connectionString, {
+      name,
+      description,
+      instruction,
+      proof,
+    });
+    switch (revision.outcome) {
+      case "unknown":
+        return context.notFound();
+      case "unchanged":
+        return context.redirect(editHref(name, "unchanged"), 303);
+      case "revised":
+        return context.redirect(definitionHref(name), 303);
+    }
+    return revision satisfies never;
+  } catch (error) {
+    Sentry.captureException(error);
+    console.error("dashboard: saving a definition:", errorMessage(error));
+    context.status(500);
+    return context.render(
+      <Definitions
+        groups={null}
+        outcomes={[]}
+        name={name}
+        selected={undefined}
+        notice={undefined}
+      />,
     );
   }
 });

--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -345,9 +345,10 @@ const RunsTable: FC<{ runs: ReadonlyArray<TestResultOutcome> }> = ({ runs }) =>
     </table>
   );
 
-// One name's card: its results by version, the edit form that saves the next version, then every
-// wording newest first, the newest open, each with its text, its results by model and the runs
-// that used it. The name is what the wordings collapse under, so it is not a field.
+// One name's card: its results by version beside the newest wording as a form whose update writes
+// the next version, then every wording newest first, the newest open, each with its text, its
+// results by model and the runs that used it. The name is what the wordings collapse under, so it
+// is not a field.
 const DefinitionCard: FC<{
   group: DefinitionVersions;
   outcomes: ReadonlyArray<TestResultOutcome>;
@@ -368,41 +369,40 @@ const DefinitionCard: FC<{
           }))}
         />
       </div>
-      <details class="definition__edit" open={notice !== undefined}>
-        <summary class="button">Edit</summary>
-        <form method="post" action="/definitions" class="definition__form">
-          <input type="hidden" name="name" value={group.name} />
-          <p class="definition__form-note">
-            Saving writes v{next} of {group.name}; the earlier wordings keep their runs.
+      {/* The update button is handed over disabled; public/dashboard.js enables it once a field
+          differs from the wording it was rendered with, so an unchanged wording is not offered. */}
+      <form method="post" action="/definitions" class="definition__form">
+        <input type="hidden" name="name" value={group.name} />
+        <p class="definition__form-note">
+          Updating writes v{next} of {group.name}; the earlier wordings keep their runs.
+        </p>
+        {notice === undefined ? null : (
+          <p class="definition__form-notice" role="alert">
+            {EDIT_NOTICES[notice]}
           </p>
-          {notice === undefined ? null : (
-            <p class="definition__form-notice" role="alert">
-              {EDIT_NOTICES[notice]}
-            </p>
-          )}
-          <label class="definition__form-field">
-            <span>Description</span>
-            <textarea name="description" rows={3} required>
-              {newest.description}
-            </textarea>
-          </label>
-          <label class="definition__form-field">
-            <span>Instruction</span>
-            <textarea name="instruction" rows={6} required>
-              {newest.instruction}
-            </textarea>
-          </label>
-          <label class="definition__form-field">
-            <span>Proof</span>
-            <textarea name="proof" rows={3} required>
-              {newest.proof}
-            </textarea>
-          </label>
-          <button class="button" type="submit">
-            Save as v{next}
-          </button>
-        </form>
-      </details>
+        )}
+        <label class="definition__form-field">
+          <span>Description</span>
+          <textarea name="description" rows={3} required>
+            {newest.description}
+          </textarea>
+        </label>
+        <label class="definition__form-field">
+          <span>Instruction</span>
+          <textarea name="instruction" rows={6} required>
+            {newest.instruction}
+          </textarea>
+        </label>
+        <label class="definition__form-field">
+          <span>Proof</span>
+          <textarea name="proof" rows={3} required>
+            {newest.proof}
+          </textarea>
+        </label>
+        <button class="button" type="submit" disabled>
+          Update
+        </button>
+      </form>
       <ul class="definition__wordings">
         {group.versions.toReversed().map((wording, index) => {
           const version = group.versions.length - index;
@@ -605,6 +605,7 @@ app.use(
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="stylesheet" href="/dashboard.css" />
         <script src={HTMX_URL} integrity={HTMX_INTEGRITY} crossorigin="anonymous"></script>
+        <script src="/dashboard.js" defer></script>
       </head>
       <body>{children}</body>
     </html>

--- a/src/dashboard/query.ts
+++ b/src/dashboard/query.ts
@@ -1,4 +1,4 @@
-import { desc, eq, sql } from "drizzle-orm";
+import { desc, eq, getTableColumns, sql } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import {
@@ -255,10 +255,14 @@ export function getImage(connectionString: string, id: string): Promise<Buffer |
   });
 }
 
-// Every wording of every definition, by name then oldest first.
+// Every wording of every definition, by name then oldest first. The clock in the select keeps the
+// list out of Hyperdrive's query cache: the page after a save must show the wording just written.
 export function listTestDefinitions(connectionString: string): Promise<TestDefinition[]> {
   return withDatabase(connectionString, (db) =>
-    db.select().from(testDefinitions).orderBy(testDefinitions.name, testDefinitions.id),
+    db
+      .select({ ...getTableColumns(testDefinitions), queriedAt: sql`CURRENT_TIMESTAMP` })
+      .from(testDefinitions)
+      .orderBy(testDefinitions.name, testDefinitions.id),
   );
 }
 
@@ -269,39 +273,32 @@ export type Wording = {
   readonly proof: string;
 };
 
-export type Revision =
-  | { readonly outcome: "unknown" }
-  | { readonly outcome: "unchanged" }
-  | { readonly outcome: "revised"; readonly id: number };
-
 // A new wording of a known name: a row is never updated, so the edit is an insert, and the newest
-// wording read again is not a new one. A name nobody carries is a new test, which is ctrl's.
+// wording read again is not a new one. A name nobody carries is a new test, which is ctrl's. The
+// newest wording is read past Hyperdrive's cache, the same way, so a save compares with what is.
 export function reviseTestDefinition(
   connectionString: string,
   wording: Wording,
-): Promise<Revision> {
+): Promise<"unknown" | "unchanged" | "revised"> {
   return withDatabase(connectionString, async (db) => {
     const [newest] = await db
-      .select()
+      .select({ ...getTableColumns(testDefinitions), queriedAt: sql`CURRENT_TIMESTAMP` })
       .from(testDefinitions)
       .where(eq(testDefinitions.name, wording.name))
       .orderBy(desc(testDefinitions.id))
       .limit(1);
     if (newest === undefined) {
-      return { outcome: "unknown" };
+      return "unknown";
     }
     if (
       newest.description === wording.description &&
       newest.instruction === wording.instruction &&
       newest.proof === wording.proof
     ) {
-      return { outcome: "unchanged" };
+      return "unchanged";
     }
-    const [row] = await db
-      .insert(testDefinitions)
-      .values(wording)
-      .returning({ id: testDefinitions.id });
-    return { outcome: "revised", id: row.id };
+    await db.insert(testDefinitions).values(wording);
+    return "revised";
   });
 }
 

--- a/src/dashboard/query.ts
+++ b/src/dashboard/query.ts
@@ -127,22 +127,14 @@ export function groupDefinitions(rows: ReadonlyArray<TestDefinition>): Definitio
     }));
 }
 
-// The wording the wide layout opens on: the newest of the name ?name asks for (the first listed
-// when the page is opened bare), or the one ?id names under it. A name nobody carries, or an id
-// that is not one of that name's wordings, selects nothing, so the route can answer 404 rather
-// than quietly show another wording under a URL that names this one.
+// The definition the wide layout opens on, every wording of it: the name ?name asks for, or the
+// first listed when the page is opened bare. A name nobody carries selects nothing, so the route
+// can answer 404 rather than quietly show another definition under a URL that names this one.
 export function selectDefinition(
   groups: ReadonlyArray<DefinitionVersions>,
   name: string | undefined,
-  id: string | undefined,
-): TestDefinition | undefined {
-  const group = name === undefined ? groups[0] : groups.find((entry) => entry.name === name);
-  if (group === undefined) {
-    return undefined;
-  }
-  return id === undefined
-    ? group.versions.at(-1)
-    : group.versions.find((version) => String(version.id) === id);
+): DefinitionVersions | undefined {
+  return name === undefined ? groups[0] : groups.find((group) => group.name === name);
 }
 
 // Passed and failed per wording of one name, oldest first; a wording with neither is left out.
@@ -268,6 +260,49 @@ export function listTestDefinitions(connectionString: string): Promise<TestDefin
   return withDatabase(connectionString, (db) =>
     db.select().from(testDefinitions).orderBy(testDefinitions.name, testDefinitions.id),
   );
+}
+
+export type Wording = {
+  readonly name: string;
+  readonly description: string;
+  readonly instruction: string;
+  readonly proof: string;
+};
+
+export type Revision =
+  | { readonly outcome: "unknown" }
+  | { readonly outcome: "unchanged" }
+  | { readonly outcome: "revised"; readonly id: number };
+
+// A new wording of a known name: a row is never updated, so the edit is an insert, and the newest
+// wording read again is not a new one. A name nobody carries is a new test, which is ctrl's.
+export function reviseTestDefinition(
+  connectionString: string,
+  wording: Wording,
+): Promise<Revision> {
+  return withDatabase(connectionString, async (db) => {
+    const [newest] = await db
+      .select()
+      .from(testDefinitions)
+      .where(eq(testDefinitions.name, wording.name))
+      .orderBy(desc(testDefinitions.id))
+      .limit(1);
+    if (newest === undefined) {
+      return { outcome: "unknown" };
+    }
+    if (
+      newest.description === wording.description &&
+      newest.instruction === wording.instruction &&
+      newest.proof === wording.proof
+    ) {
+      return { outcome: "unchanged" };
+    }
+    const [row] = await db
+      .insert(testDefinitions)
+      .values(wording)
+      .returning({ id: testDefinitions.id });
+    return { outcome: "revised", id: row.id };
+  });
 }
 
 export function listTestResultOutcomes(connectionString: string): Promise<TestResultOutcome[]> {

--- a/test/dashboard/query.unit.test.ts
+++ b/test/dashboard/query.unit.test.ts
@@ -179,42 +179,38 @@ describe("groupDefinitions unhappy path", () => {
 });
 
 describe("selectDefinition happy path", () => {
-  it("selects the newest version of the first name when nothing is asked for", () => {
-    expect(selectDefinition(groupDefinitions(ROWS), undefined, undefined)).toBe(install);
-    expect(selectDefinition(groupDefinitions([lockV1, lockV2]), undefined, undefined)).toBe(lockV2);
+  it("selects the first name, with every one of its versions, when nothing is asked for", () => {
+    const [first] = groupDefinitions(ROWS);
+    expect(selectDefinition(groupDefinitions(ROWS), undefined)).toEqual(first);
+    expect(selectDefinition(groupDefinitions([lockV2, lockV1]), undefined)).toEqual({
+      name: "lock-screen",
+      versions: [lockV1, lockV2],
+    });
   });
 
-  it("selects the newest version of the name asked for, wherever it sits", () => {
-    expect(selectDefinition(groupDefinitions(ROWS), "lock-screen", undefined)).toBe(lockV3);
-    expect(selectDefinition(groupDefinitions(ROWS), "install", undefined)).toBe(install);
-  });
-
-  it("selects the version whose id is asked for under its name", () => {
-    expect(selectDefinition(groupDefinitions(ROWS), "lock-screen", "5")).toBe(lockV2);
-    expect(selectDefinition(groupDefinitions(ROWS), "lock-screen", "2")).toBe(lockV1);
+  it("selects the name asked for, wherever it sits, with every one of its versions", () => {
+    expect(selectDefinition(groupDefinitions(ROWS), "lock-screen")).toEqual({
+      name: "lock-screen",
+      versions: [lockV1, lockV2, lockV3],
+    });
+    expect(selectDefinition(groupDefinitions(ROWS), "install")).toEqual({
+      name: "install",
+      versions: [install],
+    });
   });
 });
 
 describe("selectDefinition unhappy path", () => {
   it("selects nothing when no definition carries exactly that name", () => {
     const groups = groupDefinitions(ROWS);
-    expect(selectDefinition(groups, "wifi", undefined)).toBeUndefined();
-    expect(selectDefinition(groups, "Install", undefined)).toBeUndefined();
-    expect(selectDefinition(groups, "", undefined)).toBeUndefined();
+    expect(selectDefinition(groups, "wifi")).toBeUndefined();
+    expect(selectDefinition(groups, "Install")).toBeUndefined();
+    expect(selectDefinition(groups, "")).toBeUndefined();
   });
 
-  it("selects nothing for an id that is not a version of that name", () => {
-    const groups = groupDefinitions(ROWS);
-    expect(selectDefinition(groups, "lock-screen", "3")).toBeUndefined();
-    expect(selectDefinition(groups, "lock-screen", "7")).toBeUndefined();
-    expect(selectDefinition(groups, "lock-screen", "abc")).toBeUndefined();
-    expect(selectDefinition(groups, "lock-screen", "")).toBeUndefined();
-  });
-
-  it("selects nothing from no groups, whatever is asked for", () => {
-    expect(selectDefinition([], undefined, undefined)).toBeUndefined();
-    expect(selectDefinition([], "install", undefined)).toBeUndefined();
-    expect(selectDefinition([], "install", "3")).toBeUndefined();
+  it("selects nothing from no groups, with or without a name", () => {
+    expect(selectDefinition([], undefined)).toBeUndefined();
+    expect(selectDefinition([], "install")).toBeUndefined();
   });
 });
 

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -263,10 +263,16 @@ const wordings = (card: string): ReadonlyArray<Wording> =>
     body: body ?? "",
   }));
 
-// The edit form of the current card: the hidden name and each field's prefilled text.
+// The edit form of the current card: the hidden name, each field's prefilled text, and the update
+// button's label and whether the page hands it over disabled.
 const editForm = (
   card: string,
-): { readonly name: string; readonly fields: Record<string, string>; readonly button: string } => {
+): {
+  readonly name: string;
+  readonly fields: Record<string, string>;
+  readonly button: string;
+  readonly disabled: boolean;
+} => {
   const form =
     /<form method="post" action="\/definitions"[^>]*>([\s\S]*?)<\/form>/.exec(card)?.[1] ?? "";
   const fields: Record<string, string> = {};
@@ -275,10 +281,12 @@ const editForm = (
   )) {
     fields[field ?? ""] = text ?? "";
   }
+  const button = /<button([^>]*type="submit"[^>]*)>([\s\S]*?)<\/button>/.exec(form);
   return {
     name: /<input type="hidden" name="name" value="([^"]*)"/.exec(form)?.[1] ?? "",
     fields,
-    button: /<button[^>]*type="submit"[^>]*>([\s\S]*?)<\/button>/.exec(form)?.[1] ?? "",
+    button: button?.[2] ?? "",
+    disabled: (button?.[1] ?? "").includes("disabled"),
   };
 };
 
@@ -455,7 +463,7 @@ describe.skipIf(dbUrl === "")("dashboard/definitions page happy path", () => {
     }
   });
 
-  it("offers an edit form prefilled with the newest wording, the name fixed, saving as the next version", async () => {
+  it("shows the newest wording in a form, the name fixed, its update button handed over disabled", async () => {
     await seed(dbUrl, async (db) => {
       await db.insert(testDefinitions).values([
         { name: "wide-edit", description: "old d", instruction: "old i", proof: "old p" },
@@ -465,14 +473,22 @@ describe.skipIf(dbUrl === "")("dashboard/definitions page happy path", () => {
     const { status, html } = await getPage("/definitions?name=wide-edit", dbUrl);
     expect(status).toBe(200);
     const card = currentCard(html);
+    // The form is in the card as it is, not behind a fold; the page's script enables the button
+    // once a field differs from the text it was rendered with.
+    expect(card).not.toContain('<details class="definition__edit"');
     expect(editForm(card)).toEqual({
       name: "wide-edit",
       fields: { description: "new d", instruction: "new i", proof: "new p" },
-      button: "Save as v3",
+      button: "Update",
+      disabled: true,
     });
+    expect(card).toContain(
+      "Updating writes v3 of wide-edit; the earlier wordings keep their runs.",
+    );
+    expect(html).toContain('<script src="/dashboard.js" defer=""></script>');
     // The name is not a field: it is what the wordings collapse under.
     expect(card).not.toMatch(/<(input|textarea)[^>]*name="name"[^>]*type="text"/);
-    expect(card).not.toContain('<details class="definition__edit" open');
+    expect(card).not.toContain('class="definition__form-notice"');
   });
 
   it("says so in the charts and the run list when the selected definition has not run yet", async () => {
@@ -528,8 +544,12 @@ describe.skipIf(dbUrl === "")("dashboard/definitions edit happy path", () => {
     expect(wordings(card).map((wording) => wording.label)).toEqual(["v3", "v2", "v1"]);
     expect(editForm(card)).toMatchObject({
       fields: { instruction: "third\nand more" },
-      button: "Save as v4",
+      button: "Update",
+      disabled: true,
     });
+    expect(card).toContain(
+      "Updating writes v4 of wide-save; the earlier wordings keep their runs.",
+    );
   });
 
   it("saves a wording that changes one field only, the other two as they were (happy)", async () => {
@@ -572,7 +592,7 @@ describe.skipIf(dbUrl === "")("dashboard/definitions edit unhappy path", () => {
     const { status, html } = await getPage("/definitions?name=wide-same&edit=unchanged", dbUrl);
     expect(status).toBe(200);
     const card = currentCard(html);
-    expect(card).toContain('<details class="definition__edit" open');
+    expect(card).toContain('<p class="definition__form-notice" role="alert">');
     expect(card).toContain("Nothing changed: the newest wording already reads like this.");
   });
 
@@ -595,7 +615,7 @@ describe.skipIf(dbUrl === "")("dashboard/definitions edit unhappy path", () => {
 
     const { html } = await getPage("/definitions?name=wide-empty&edit=empty", dbUrl);
     const card = currentCard(html);
-    expect(card).toContain('<details class="definition__edit" open');
+    expect(card).toContain('<p class="definition__form-notice" role="alert">');
     expect(card).toContain("Every field needs text.");
   });
 
@@ -613,7 +633,7 @@ describe.skipIf(dbUrl === "")("dashboard/definitions edit unhappy path", () => {
   it("shows a stale ?edit value as no notice at all", async () => {
     const { status, html } = await getPage("/definitions?name=lock-screen&edit=whatever", dbUrl);
     expect(status).toBe(200);
-    expect(currentCard(html)).not.toContain('<details class="definition__edit" open');
+    expect(currentCard(html)).not.toContain('class="definition__form-notice"');
   });
 });
 

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -510,23 +510,24 @@ describe.skipIf(dbUrl === "")("dashboard/definitions edit happy path", () => {
         { name: "wide-save", description: "d", instruction: "second", proof: "p" },
       ]);
     });
+    // Typed over two lines: the browser sends CRLF, the wording is stored with LF as ctrl writes it.
     const saved = await postForm(
-      { name: "wide-save", description: "d", instruction: "third", proof: "p" },
+      { name: "wide-save", description: "d", instruction: "third\r\nand more", proof: "p" },
       dbUrl,
     );
     expect(saved.status).toBe(303);
     expect(saved.location).toBe("/definitions?name=wide-save");
-    expect(await wordingsOf(dbUrl, "wide-save")).toEqual(["first", "second", "third"]);
+    expect(await wordingsOf(dbUrl, "wide-save")).toEqual(["first", "second", "third\nand more"]);
 
     const { status, html } = await getPage("/definitions?name=wide-save", dbUrl);
     expect(status).toBe(200);
     const card = currentCard(html);
     const [newest] = wordings(card);
     expect(newest).toMatchObject({ label: "v3", open: true });
-    expect(newest?.body).toContain("<p>third</p>");
+    expect(newest?.body).toContain("<p>third\nand more</p>");
     expect(wordings(card).map((wording) => wording.label)).toEqual(["v3", "v2", "v1"]);
     expect(editForm(card)).toMatchObject({
-      fields: { instruction: "third" },
+      fields: { instruction: "third\nand more" },
       button: "Save as v4",
     });
   });
@@ -552,17 +553,21 @@ describe.skipIf(dbUrl === "")("dashboard/definitions edit happy path", () => {
 describe.skipIf(dbUrl === "")("dashboard/definitions edit unhappy path", () => {
   it("refuses a wording identical to the newest: nothing is written and the form says so", async () => {
     await seed(dbUrl, async (db) => {
-      await db
-        .insert(testDefinitions)
-        .values({ name: "wide-same", description: "d", instruction: "i", proof: "p" });
+      await db.insert(testDefinitions).values({
+        name: "wide-same",
+        description: "d",
+        instruction: "i\nover two lines",
+        proof: "p",
+      });
     });
+    // A browser submits a textarea's newlines as CRLF; the wording ctrl wrote has LF.
     const same = await postForm(
-      { name: "wide-same", description: "d", instruction: "i", proof: "p" },
+      { name: "wide-same", description: "d", instruction: "i\r\nover two lines", proof: "p" },
       dbUrl,
     );
     expect(same.status).toBe(303);
     expect(same.location).toBe("/definitions?name=wide-same&edit=unchanged");
-    expect(await wordingsOf(dbUrl, "wide-same")).toEqual(["i"]);
+    expect(await wordingsOf(dbUrl, "wide-same")).toEqual(["i\nover two lines"]);
 
     const { status, html } = await getPage("/definitions?name=wide-same&edit=unchanged", dbUrl);
     expect(status).toBe(200);

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { eq } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import { describe, expect, inject, it } from "vitest";
@@ -248,17 +249,78 @@ const currentCard = (html: string): string =>
 const currentLinks = (html: string): number =>
   (html.match(/class="definitions__link definitions__link--current"/g) ?? []).length;
 
-// The version strip of the current card: the links, in order, with the one marked current.
-const versionStrip = (
+// The wordings of the current card, in page order: each a <details> whose summary names the
+// version, the newest open, with the body that follows it up to the next wording or the list's end.
+type Wording = { readonly label: string; readonly open: boolean; readonly body: string };
+const wordings = (card: string): ReadonlyArray<Wording> =>
+  [
+    ...card.matchAll(
+      /<details class="definition__wording"([^>]*)>\s*<summary[^>]*>[\s\S]*?<span class="definition__wording-label">([^<]+)<\/span>[\s\S]*?<\/summary>([\s\S]*?)<\/details>/g,
+    ),
+  ].map(([, attributes, label, body]) => ({
+    label: label ?? "",
+    open: (attributes ?? "").includes("open"),
+    body: body ?? "",
+  }));
+
+// The edit form of the current card: the hidden name and each field's prefilled text.
+const editForm = (
   card: string,
-): ReadonlyArray<{ readonly href: string; readonly label: string; readonly current: boolean }> =>
-  [...card.matchAll(/<a ([^>]*class="definition__version[^"]*"[^>]*)>([^<]+)<\/a>/g)].map(
-    ([, attributes, label]) => ({
-      href: /href="([^"]+)"/.exec(attributes ?? "")?.[1] ?? "",
-      label: label ?? "",
-      current: (attributes ?? "").includes('aria-current="true"'),
-    }),
+): { readonly name: string; readonly fields: Record<string, string>; readonly button: string } => {
+  const form =
+    /<form method="post" action="\/definitions"[^>]*>([\s\S]*?)<\/form>/.exec(card)?.[1] ?? "";
+  const fields: Record<string, string> = {};
+  for (const [, field, text] of form.matchAll(
+    /<textarea name="([a-z]+)"[^>]*>([\s\S]*?)<\/textarea>/g,
+  )) {
+    fields[field ?? ""] = text ?? "";
+  }
+  return {
+    name: /<input type="hidden" name="name" value="([^"]*)"/.exec(form)?.[1] ?? "",
+    fields,
+    button: /<button[^>]*type="submit"[^>]*>([\s\S]*?)<\/button>/.exec(form)?.[1] ?? "",
+  };
+};
+
+// A form submission as the browser sends it, answered without following the redirect.
+const postForm = async (
+  fields: Record<string, string>,
+  databaseUrl: string,
+): Promise<{
+  readonly status: number;
+  readonly location: string | null;
+  readonly text: string;
+}> => {
+  const response = await app.request(
+    "/definitions",
+    {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(fields).toString(),
+    },
+    { HYPERDRIVE: { connectionString: databaseUrl } },
   );
+  return {
+    status: response.status,
+    location: response.headers.get("location"),
+    text: await response.text(),
+  };
+};
+
+const wordingsOf = async (databaseUrl: string, name: string): Promise<ReadonlyArray<string>> => {
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    const rows = await drizzle(client)
+      .select({ instruction: testDefinitions.instruction })
+      .from(testDefinitions)
+      .where(eq(testDefinitions.name, name))
+      .orderBy(testDefinitions.id);
+    return rows.map((row) => row.instruction);
+  } finally {
+    await client.end();
+  }
+};
 
 // Every result here is its own run: a run holds one result per definition.
 const seedResults = async (
@@ -326,19 +388,19 @@ describe.skipIf(dbUrl === "")("dashboard/definitions page happy path", () => {
     expect(card).toContain('aria-label="v1: 2 succeeded, 1 failed"');
     expect(card).not.toContain("gemini-3.8:");
     expect(card).not.toContain("lock-screen");
-    // One wording so far: a strip of one, current. Every run that used it is listed, the pending
-    // one included, with its model and status.
-    expect(versionStrip(card).map((link) => [link.label, link.current])).toEqual([["v1", true]]);
+    // One wording so far, open. Every run that used it is listed under it, the pending one
+    // included, with its model and status.
+    const [only, ...rest] = wordings(card);
+    expect(rest).toEqual([]);
+    expect(only).toMatchObject({ label: "v1", open: true });
     for (const runId of runIds) {
-      expect(card).toContain(`<code>${runId}</code>`);
+      expect(only?.body).toContain(`<code>${runId}</code>`);
     }
-    expect(card).toContain("<td>gemini-3.8</td>");
-    expect(card).toContain("<td>pending</td>");
+    expect(only?.body).toContain("<td>gemini-3.8</td>");
+    expect(only?.body).toContain("<td>pending</td>");
   });
 
-  it("shows one name for two wordings, the newest selected, each charted by version", async () => {
-    let olderId = 0;
-    let newerId = 0;
+  it("lines a name's wordings up newest first, the newest open, each with its own runs", async () => {
     let olderRuns: ReadonlyArray<string> = [];
     let newerRuns: ReadonlyArray<string> = [];
     await seed(dbUrl, async (db) => {
@@ -350,8 +412,6 @@ describe.skipIf(dbUrl === "")("dashboard/definitions page happy path", () => {
         .insert(testDefinitions)
         .values({ name: "wide-versions", description: "d", instruction: "second", proof: "p" })
         .returning({ id: testDefinitions.id });
-      olderId = older.id;
-      newerId = newer.id;
       olderRuns = await seedResults(db, older.id, [
         { status: "passed", model: "grok-4.6" },
         { status: "failed", model: "grok-4.6" },
@@ -359,57 +419,60 @@ describe.skipIf(dbUrl === "")("dashboard/definitions page happy path", () => {
       newerRuns = await seedResults(db, newer.id, [{ status: "passed", model: "composer-2.5" }]);
     });
 
-    const newest = await getPage("/definitions?name=wide-versions", dbUrl);
-    expect(newest.status).toBe(200);
-    expect(newest.html.match(/href="\/definitions\?name=wide-versions"/g)).toHaveLength(1);
-    expect(currentLinks(newest.html)).toBe(1);
-    const newestCard = currentCard(newest.html);
-    expect(newestCard).toContain("<h2>wide-versions</h2>");
-    expect(versionStrip(newestCard)).toEqual([
-      {
-        href: `/definitions?name=wide-versions&amp;id=${String(olderId)}`,
-        label: "v1",
-        current: false,
-      },
-      {
-        href: `/definitions?name=wide-versions&amp;id=${String(newerId)}`,
-        label: "v2",
-        current: true,
-      },
-    ]);
-    expect(newestCard).toContain("<p>second</p>");
-    expect(newestCard).not.toContain("<p>first</p>");
-    // The model chart is the selected wording's; the version chart is the whole name's.
-    expect(newestCard).toContain('aria-label="composer-2.5: 1 succeeded, 0 failed"');
-    expect(newestCard).not.toContain('aria-label="grok-4.6:');
-    expect(newestCard).toContain('aria-label="v1: 1 succeeded, 1 failed"');
-    expect(newestCard).toContain('aria-label="v2: 1 succeeded, 0 failed"');
+    const { status, html } = await getPage("/definitions?name=wide-versions", dbUrl);
+    expect(status).toBe(200);
+    // One sidebar entry for the name, however many wordings it has.
+    expect(html.match(/href="\/definitions\?name=wide-versions"/g)).toHaveLength(1);
+    expect(currentLinks(html)).toBe(1);
+    const card = currentCard(html);
+    expect(card).toContain("<h2>wide-versions</h2>");
+    // The version chart spans the name; each wording carries its own text, model chart and runs.
+    expect(card).toContain('aria-label="v1: 1 succeeded, 1 failed"');
+    expect(card).toContain('aria-label="v2: 1 succeeded, 0 failed"');
+    const [v2, v1, ...rest] = wordings(card);
+    expect(rest).toEqual([]);
+    expect(v2).toMatchObject({ label: "v2", open: true });
+    expect(v1).toMatchObject({ label: "v1", open: false });
+    expect(v2?.body).toContain("<p>second</p>");
+    expect(v2?.body).not.toContain("<p>first</p>");
+    expect(v2?.body).toContain('aria-label="composer-2.5: 1 succeeded, 0 failed"');
+    expect(v2?.body).not.toContain("grok-4.6:");
     for (const runId of newerRuns) {
-      expect(newestCard).toContain(`<code>${runId}</code>`);
+      expect(v2?.body).toContain(`<code>${runId}</code>`);
     }
     for (const runId of olderRuns) {
-      expect(newestCard).not.toContain(runId);
+      expect(v2?.body).not.toContain(runId);
     }
+    expect(v1?.body).toContain("<p>first</p>");
+    expect(v1?.body).not.toContain("<p>second</p>");
+    expect(v1?.body).toContain('aria-label="grok-4.6: 1 succeeded, 1 failed"');
+    expect(v1?.body).not.toContain("composer-2.5:");
+    for (const runId of olderRuns) {
+      expect(v1?.body).toContain(`<code>${runId}</code>`);
+    }
+    for (const runId of newerRuns) {
+      expect(v1?.body).not.toContain(runId);
+    }
+  });
 
-    const older = await getPage(`/definitions?name=wide-versions&id=${String(olderId)}`, dbUrl);
-    expect(older.status).toBe(200);
-    expect(currentLinks(older.html)).toBe(1);
-    const olderCard = currentCard(older.html);
-    expect(versionStrip(olderCard).map((link) => [link.label, link.current])).toEqual([
-      ["v1", true],
-      ["v2", false],
-    ]);
-    expect(olderCard).toContain("<p>first</p>");
-    expect(olderCard).not.toContain("<p>second</p>");
-    expect(olderCard).toContain('aria-label="grok-4.6: 1 succeeded, 1 failed"');
-    expect(olderCard).not.toContain("composer-2.5:");
-    expect(olderCard).toContain('aria-label="v2: 1 succeeded, 0 failed"');
-    for (const runId of olderRuns) {
-      expect(olderCard).toContain(`<code>${runId}</code>`);
-    }
-    for (const runId of newerRuns) {
-      expect(olderCard).not.toContain(runId);
-    }
+  it("offers an edit form prefilled with the newest wording, the name fixed, saving as the next version", async () => {
+    await seed(dbUrl, async (db) => {
+      await db.insert(testDefinitions).values([
+        { name: "wide-edit", description: "old d", instruction: "old i", proof: "old p" },
+        { name: "wide-edit", description: "new d", instruction: "new i", proof: "new p" },
+      ]);
+    });
+    const { status, html } = await getPage("/definitions?name=wide-edit", dbUrl);
+    expect(status).toBe(200);
+    const card = currentCard(html);
+    expect(editForm(card)).toEqual({
+      name: "wide-edit",
+      fields: { description: "new d", instruction: "new i", proof: "new p" },
+      button: "Save as v3",
+    });
+    // The name is not a field: it is what the wordings collapse under.
+    expect(card).not.toMatch(/<(input|textarea)[^>]*name="name"[^>]*type="text"/);
+    expect(card).not.toContain('<details class="definition__edit" open');
   });
 
   it("says so in the charts and the run list when the selected definition has not run yet", async () => {
@@ -437,31 +500,127 @@ describe.skipIf(dbUrl === "")("dashboard/definitions page unhappy path", () => {
     expect(currentLinks(html)).toBe(0);
     expect(currentCard(html)).toBe("");
   });
+});
 
-  it("answers 404 for an id that is not a version of that name, keeping the sidebar", async () => {
-    let otherId = 0;
+describe.skipIf(dbUrl === "")("dashboard/definitions edit happy path", () => {
+  it("saves a changed wording as the next version and returns to the name, which now opens on it", async () => {
     await seed(dbUrl, async (db) => {
-      const [other] = await db
-        .insert(testDefinitions)
-        .values({ name: "wide-other", description: "d", instruction: "i", proof: "p" })
-        .returning({ id: testDefinitions.id });
-      otherId = other.id;
+      await db.insert(testDefinitions).values([
+        { name: "wide-save", description: "d", instruction: "first", proof: "p" },
+        { name: "wide-save", description: "d", instruction: "second", proof: "p" },
+      ]);
     });
-    const { status, html } = await getPage(
-      `/definitions?name=lock-screen&id=${String(otherId)}`,
+    const saved = await postForm(
+      { name: "wide-save", description: "d", instruction: "third", proof: "p" },
       dbUrl,
     );
-    expect(status).toBe(404);
-    expect(html).toContain(
-      `No version <code>${String(otherId)}</code> of <code>lock-screen</code>.`,
-    );
-    expect(html).toContain('href="/definitions?name=lock-screen"');
-    expect(currentLinks(html)).toBe(0);
-    expect(currentCard(html)).toBe("");
+    expect(saved.status).toBe(303);
+    expect(saved.location).toBe("/definitions?name=wide-save");
+    expect(await wordingsOf(dbUrl, "wide-save")).toEqual(["first", "second", "third"]);
 
-    const garbage = await getPage("/definitions?name=lock-screen&id=abc", dbUrl);
-    expect(garbage.status).toBe(404);
-    expect(garbage.html).toContain("No version <code>abc</code> of <code>lock-screen</code>.");
+    const { status, html } = await getPage("/definitions?name=wide-save", dbUrl);
+    expect(status).toBe(200);
+    const card = currentCard(html);
+    const [newest] = wordings(card);
+    expect(newest).toMatchObject({ label: "v3", open: true });
+    expect(newest?.body).toContain("<p>third</p>");
+    expect(wordings(card).map((wording) => wording.label)).toEqual(["v3", "v2", "v1"]);
+    expect(editForm(card)).toMatchObject({
+      fields: { instruction: "third" },
+      button: "Save as v4",
+    });
+  });
+
+  it("saves a wording that changes one field only, the other two as they were (happy)", async () => {
+    await seed(dbUrl, async (db) => {
+      await db
+        .insert(testDefinitions)
+        .values({ name: "wide-one-field", description: "d", instruction: "i", proof: "p" });
+    });
+    const saved = await postForm(
+      { name: "wide-one-field", description: "d", instruction: "i", proof: "p2" },
+      dbUrl,
+    );
+    expect(saved.status).toBe(303);
+    const { html } = await getPage("/definitions?name=wide-one-field", dbUrl);
+    const [newest] = wordings(currentCard(html));
+    expect(newest?.body).toContain("<p>p2</p>");
+    expect(newest?.body).toContain("<p>i</p>");
+  });
+});
+
+describe.skipIf(dbUrl === "")("dashboard/definitions edit unhappy path", () => {
+  it("refuses a wording identical to the newest: nothing is written and the form says so", async () => {
+    await seed(dbUrl, async (db) => {
+      await db
+        .insert(testDefinitions)
+        .values({ name: "wide-same", description: "d", instruction: "i", proof: "p" });
+    });
+    const same = await postForm(
+      { name: "wide-same", description: "d", instruction: "i", proof: "p" },
+      dbUrl,
+    );
+    expect(same.status).toBe(303);
+    expect(same.location).toBe("/definitions?name=wide-same&edit=unchanged");
+    expect(await wordingsOf(dbUrl, "wide-same")).toEqual(["i"]);
+
+    const { status, html } = await getPage("/definitions?name=wide-same&edit=unchanged", dbUrl);
+    expect(status).toBe(200);
+    const card = currentCard(html);
+    expect(card).toContain('<details class="definition__edit" open');
+    expect(card).toContain("Nothing changed: the newest wording already reads like this.");
+  });
+
+  it("refuses an empty field: nothing is written and the form says so", async () => {
+    await seed(dbUrl, async (db) => {
+      await db
+        .insert(testDefinitions)
+        .values({ name: "wide-empty", description: "d", instruction: "i", proof: "p" });
+    });
+    const empty = await postForm(
+      { name: "wide-empty", description: "d", instruction: "", proof: "p" },
+      dbUrl,
+    );
+    expect(empty.status).toBe(303);
+    expect(empty.location).toBe("/definitions?name=wide-empty&edit=empty");
+    const missing = await postForm({ name: "wide-empty", description: "d", proof: "p" }, dbUrl);
+    expect(missing.status).toBe(303);
+    expect(missing.location).toBe("/definitions?name=wide-empty&edit=empty");
+    expect(await wordingsOf(dbUrl, "wide-empty")).toEqual(["i"]);
+
+    const { html } = await getPage("/definitions?name=wide-empty&edit=empty", dbUrl);
+    const card = currentCard(html);
+    expect(card).toContain('<details class="definition__edit" open');
+    expect(card).toContain("Every field needs text.");
+  });
+
+  it("answers 404 for a name nobody carries, or none at all: a new test is ctrl test define's", async () => {
+    const unknown = await postForm(
+      { name: "wide-nobody", description: "d", instruction: "i", proof: "p" },
+      dbUrl,
+    );
+    expect(unknown.status).toBe(404);
+    const nameless = await postForm({ description: "d", instruction: "i", proof: "p" }, dbUrl);
+    expect(nameless.status).toBe(404);
+    expect(await wordingsOf(dbUrl, "wide-nobody")).toEqual([]);
+  });
+
+  it("shows a stale ?edit value as no notice at all", async () => {
+    const { status, html } = await getPage("/definitions?name=lock-screen&edit=whatever", dbUrl);
+    expect(status).toBe(200);
+    expect(currentCard(html)).not.toContain('<details class="definition__edit" open');
+  });
+});
+
+describe("dashboard/definitions edit unhappy path: unreachable database", () => {
+  it("answers 500 without echoing the password", async () => {
+    const result = await postForm(
+      { name: "lock-screen", description: "d", instruction: "i", proof: "p" },
+      REFUSED_URL,
+    );
+    expect(result.status).toBe(500);
+    expect(result.text).toContain("Test definitions are unavailable.");
+    expect(result.text).not.toContain(SENTINEL_PASSWORD);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

After #89 a definition's wordings are immutable rows and the dashboard showed one wording at a time behind a version strip. The request: make definitions editable from the dashboard, everything but the name (the name is what the wordings collapse under), line the versions up newest first, keep every earlier version's runs in view, and have the definition's form to the right with an Update button that stays gray until a field differs from the stored wording.

## What

- **Definitions card**: on the left the "Results by version" chart across the name's wordings; on the right the newest wording as a form (three textareas; the name is a hidden field, not an input) whose **Update** writes `v<n+1>`; below, **every wording newest first** as a fold, the newest open, each with its text, its "Results by model" chart and the runs that used it. Earlier wordings keep their runs. The `?id=` strip is gone; `?name=` stays.
- **Update button**: handed over `disabled` and gray; `public/dashboard.js` (one delegated `input` listener, so it holds across htmx swaps) enables it the moment a textarea's value differs from the text the page came with, and disables it again when the text is put back. An unchanged wording is never offered.
- **`POST /definitions`**: inserts the next wording of a known name; never updates. An unchanged wording or an empty field redirects back to the name with `?edit=unchanged|empty` and a notice in the form (the server keeps refusing even though the button no longer offers it); a name nobody carries, or none, is a 404 (a new test is `ctrl test define`'s). Redirects are 303.
- **Read after write**: the definition list and the newest-wording read select `CURRENT_TIMESTAMP`, the file's existing pattern for keeping a query out of Hyperdrive's cache, so the page after a save shows the wording just written and a save compares with what is.
- **CRLF**: a browser submits textarea newlines as CRLF; the route decodes them to LF, as `ctrl` writes wordings, so a multi-line wording saved untouched reads unchanged.

## Open question

`POST /definitions` is as public as the rest of the dashboard: no auth, insert only. Anyone who can reach the page can append a wording to a known name, and the newest wording is what `test new` runs next. If that is not acceptable, the options are a Cloudflare Access policy in front of the Worker or a `wrangler secret` the form must carry; neither is in this PR.

## Tests

Written first, happy and unhappy paths: `dashboard/query.unit` (`selectDefinition`), `dashboard.integration` (wordings newest first with the newest open and each one's own runs and chart; the form's hidden name, prefilled fields, "Update" handed over disabled and the script tag; saves incl. CRLF and a one-field change; unchanged, empty, unknown and nameless refusals; a stale `?edit`; unreachable database 500 without the password). The enabling itself is browser behaviour, verified over CDP (`disabled` flips on append, back on exact restore, on again for another field) and in the recording below.

`npm run check:fast`: 767 unit tests green. The `dashboard` integration lane (24 tests) is green against a local Postgres 16 (Docker is absent on the agent VM).

Sol review (per `development.md`): the Hyperdrive read-after-write and CRLF findings are applied; the public-POST finding is the open question above; serialising concurrent saves on one name is declined, since one operator saves by hand.

## Evidence

[Definitions page: results by version on the left, the newest wording as a form on the right with a gray Update button, then the wordings newest first](https://cursor.com/agents/bc-f601b495-f3a1-4b9d-99b5-1b74b51dafe0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_definitions_form_right_update_gray.png)
[dashboard_update_button_gray_until_changed_then_saves_v5.mp4](https://cursor.com/agents/bc-f601b495-f3a1-4b9d-99b5-1b74b51dafe0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_update_button_gray_until_changed_then_saves_v5.mp4)
[dashboard_edit_definition_saves_next_version_keeping_earlier_runs.mp4](https://cursor.com/agents/bc-f601b495-f3a1-4b9d-99b5-1b74b51dafe0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_edit_definition_saves_next_version_keeping_earlier_runs.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f601b495-f3a1-4b9d-99b5-1b74b51dafe0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f601b495-f3a1-4b9d-99b5-1b74b51dafe0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

