### PR TITLE
Reverse proxy spawns agents: POST /agent with a vendor-neutral model choice

### DIFF
--- a/SERVER_VS_REVERSE_PROXY.md
+++ b/SERVER_VS_REVERSE_PROXY.md
@@ -524,6 +524,13 @@ used":
 - `--reasoning` and `--fast` on `ctrl test run` and `ctrl diagnose run`. `--model` takes the id
   alone there, as before; the full choice is the route's.
 - A second spawning strategy. The `CursorAgents` layer is the seam; nothing else was asked for.
+- A `key` field in the `/agent` body. The key the caller must provide is the bearer every route
+  of this process already requires; a second way to present it would be a second thing to check.
+- A shape for a driving task. A Linear identifier's form is Linear's (`OLI-42` today, another
+  team's key tomorrow), and `ctrl test run --ticket` accepts any non-empty string; the session id
+  of a reviewer is ours (a uuid column) and is checked.
+- An idempotency key on the Cursor create. Nothing retries; a caller that repeats a `/agent` POST
+  gets a second agent, and the only key that could dedupe it would be the caller's.
 
 - A health loop. A dead server costs one 10 s probe per start and per `GET /servers` until
   `DELETE /servers` forgets it; a loop that dropped servers on its own would turn a flapping host

--- a/SERVER_VS_REVERSE_PROXY.md
+++ b/SERVER_VS_REVERSE_PROXY.md
@@ -10,14 +10,14 @@ written out for operators here. A third party is named where it matters: the das
 
 | | The server (`./server`, `src/proxy/`) | The reverse proxy (`./reverse-proxy`, `src/reverse-proxy/`) |
 | --- | --- | --- |
-| One sentence | Boots and drives QEMU machines on one host | Sends each session's requests to the host that booted it |
+| One sentence | Boots and drives QEMU machines on one host | Sends each session's requests to the host that booted it, and spawns the agents that drive and review them |
 | Owns | The machines, the sessions map, the QMP sockets, the session directories | The fleet (`servers`) and the routing table (`session_servers`) |
-| Needs on its host | `qemu-system-x86_64`, `qemu-img`, OVMF, `/dev/kvm`, a display backend | Nothing but Node and a route to the database and the servers |
-| Reads | `OLIGARCHY_TOKEN`, `DATABASE_URL` | The same two, through the same `ProxyConfig` |
+| Needs on its host | `qemu-system-x86_64`, `qemu-img`, OVMF, `/dev/kvm`, a display backend | Nothing but Node and a route to the database, the servers and Cursor's API |
+| Reads | `OLIGARCHY_TOKEN`, `DATABASE_URL` | The same two, through the same `ProxyConfig`, then `CURSOR_API_TOKEN` |
 | Default ports | `42069` | `42070` for the API, `55445` for the diagnostics page |
-| Speaks to clients | `ProxyApi`: the 11 `Sessions` routes, `/stats` among them | The same `Sessions` routes minus `/stats`, plus `POST/DELETE/GET /servers` |
+| Speaks to clients | `ProxyApi`: the 11 `Sessions` routes, `/stats` among them | The same `Sessions` routes minus `/stats`, plus `POST/DELETE/GET /servers` and `POST /agent` |
 | Speaks to operators | Nothing beyond the API | The diagnostics page: the fleet, an add box, a delete button each |
-| Speaks to | QEMU over QMP, the database | The servers over HTTP (their own `ProxyApi`), the database |
+| Speaks to | QEMU over QMP, the database | The servers over HTTP (their own `ProxyApi`), the database, Cursor's API through `@cursor/sdk` |
 | Writes | `sessions`, `agent_runs`, `actions`, `images`, `debug_logs`, `logs` | `servers`, `session_servers`, `logs` |
 | Serves images | No: `GET /images/:id` is the catch-all's 404 | No: the same 404 |
 | Background work | The 10 s timeout sweep, the cpu sampler, the log drain | The log drain only |
@@ -48,9 +48,10 @@ neither the server nor the reverse proxy has an image route, and the path is the
 on both. One HTTP address; the only other reader of the bytes is `./session image`, straight
 from the database.
 
-### The reverse proxy knows where sessions live and nothing else
+### The reverse proxy knows where sessions live, and who to start on them
 
-The reverse proxy holds no session state. It knows three things, all of them rows:
+The reverse proxy holds no session state. It knows three things, all of them rows (a fourth, how
+to start an agent, is the section after this one):
 
 - Which servers exist, because an operator registered them (`POST /servers { url }`), and the
   reverse proxy checked each one answered `GET /stats` before remembering it. Registering the same
@@ -74,11 +75,55 @@ Its routes, all behind `Authorization: Bearer <OLIGARCHY_TOKEN>` on `127.0.0.1:4
 | `GET /servers` | none | `{"servers":[{"url","stats"}]}` | none |
 | `POST /start` | as the proxy | the server's answer | 503, else the server's |
 | `GET /image`, `GET /serial`, `GET /follow`, `POST /stop`, `POST /send-keys`, `POST /send-mouse`, `POST /intent/start`, `POST /intent/end` | as the proxy | the server's answer | 404, else the server's |
+| `POST /agent` | `{ "task", "type", "model"?, "reasoning"?, "fast"? }` | `{"id","url","model"}` | 400 502 |
 
 Every route may also answer 400 (a body or query the contract refuses), 401, 500 and 502 through
-the `RouteBoundary` middleware; `GET /stats`, `GET /images/:id` and anything else unrouted is the
-catch-all's 404 `{"error":"not found"}`, unlogged. The proxy's `/dump` was retired on master and
-is not routed here either: an ended session's console is read from the database by `ctrl`.
+the `RouteBoundary` middleware (`/agent` sits behind the proxy's `ApiBoundary`, which declares 400
+and 500; its 400 and 502 are its own); `GET /stats`, `GET /images/:id` and anything else unrouted
+is the catch-all's 404 `{"error":"not found"}`, unlogged. The proxy's `/dump` was retired on
+master and is not routed here either: an ended session's console is read from the database by
+`ctrl`.
+
+### The reverse proxy spawns the agents
+
+`POST /agent` is the one route where the reverse proxy does more than route: it starts the cloud
+agent that will drive or review a session. The body names the work and the worker:
+
+- `task` — what the agent works on: the Linear ticket identifier for a `driving-agent`
+  (`OLI-42`, which is also the agent id its session will carry), the session id for a
+  `diagnosing-agent`. A diagnosing task that is not a uuid is 400
+  `task must be a session id for a diagnosing-agent` before any template is read: a ticket there
+  would cost an agent run to find out.
+- `type` — `driving-agent` or `diagnosing-agent`: which prompt the agent is handed
+  (`prompts/driving-agent.html` with the ticket, `prompts/diagnosing-agent.html` with the session
+  and the reviewer's guide), the same texts `ctrl test run` and `ctrl diagnose run` send.
+- `model`, `reasoning`, `fast` — the model choice, in one vocabulary for every vendor: the model
+  as Cursor's catalog lists it, `reasoning` one of `none`, `low`, `medium`, `high`, `xhigh`,
+  `max`, and `fast` a boolean. No `model` means the default, `grok-4.6` at `high` running `fast`,
+  with `reasoning` and `fast` in the body still honoured (`{ "fast": false }` is `grok-4.6-high`).
+  A `model` given alone is asked for alone: Cursor's own defaults decide how hard it thinks and
+  whether it runs fast.
+
+The choice is mapped onto Cursor's catalog (`Cursor.models.list()`) at spawn time, so what the
+vendor cannot do is refused here, with what the model does take, instead of by Cursor once the
+agent exists: 400 `unknown model "<id>"`, `model "<id>" has no reasoning level` (a model without
+the knob), `model "<id>" has no reasoning level "<level>"; it has low, medium, high, xhigh`, or
+`model "<id>" has no fast mode`. Each vendor spells the knob its own way — `effort`, `reasoning`,
+`reasoning_effort`, and `extra-high` where we say `xhigh` — and the mapping speaks the vendor's
+spelling. A Cursor failure (a bad key, a rate limit) is 502 with Cursor's message.
+
+The agent is told its model as one label, `<model>-<reasoning>-fast` with each part present only
+when asked for (`grok-4.6-high-fast`, `composer-2.5`, `claude-opus-5-max`), because that label is
+what a driver records with `ctrl test start --model` and a reviewer with `ctrl diagnose --model`;
+the answer carries the same label so the caller knows what was written. The reverse proxy logs
+`agent spawned; <type>; <task>; <model>; <url>`, attributed to the ticket as agent id for a
+driver and to the session for a reviewer, and answers `{ "id": "bc-…", "url":
+"https://cursor.com/agents/bc-…", "model": "grok-4.6-high-fast" }` as soon as the agent exists; it
+never waits for it.
+
+Cursor cloud agents are the one way of spawning today. The seam for another is the `CursorAgents`
+layer (`src/ctrl/cursor.ts`): `prompt(text, choice?)` is the whole interface, and `/agent` knows
+nothing of the SDK behind it.
 
 The same fleet is on the diagnostics page, `http://127.0.0.1:55445/` by default: an unstyled text
 page listing every registered server with its `qemus`, memory and cpu, or `did not answer`, a
@@ -109,6 +154,9 @@ The reverse proxy answers a request itself only when it cannot or should not for
 | 401 `unauthorized` | Bearer missing or wrong | `<METHOD> <url> failed: unauthorized`, no Sentry |
 | 400 `<schema message>` | Body or query fails the contract (same schemas as the server) | same shape, no Sentry |
 | 400 `url must be an http or https url` | `POST/DELETE /servers` with a url that is not http(s) with a host | same shape, no Sentry |
+| 400 `task must be a session id for a diagnosing-agent` | `POST /agent` for a reviewer of something that is not a session | same shape, no Sentry |
+| 400 `unknown model "<id>"` / `model "<id>" has no reasoning level[ "<level>"; it has …]` / `model "<id>" has no fast mode` | `POST /agent` with a choice Cursor's catalog cannot honour | same shape, no Sentry, no agent started |
+| 502 `<Cursor's message>` | `POST /agent` when the Cursor SDK refuses or fails to start the agent | the SDK's error as the cause, reported |
 | 404 `unknown session "<id>"` | The id is not a uuid or has no `session_servers` row | attributed to the id (when a uuid) and the agent |
 | 404 `not found` | `DELETE /servers` for a url never registered; any unrouted path (`/stats`, `/images/:id`, `/nope`) | the DELETE is logged; the catch-all is not |
 | 502 `server <url> unreachable: <cause>` | The server refused the connection, reset it, or did not answer a probe within 10 s | attributed, cause to Sentry |
@@ -390,10 +438,92 @@ watchdog that could never fire. Declined with the reviewer's agreement: dropping
 `RouterService` type (the `SessionsService` and `LogService` convention) and sharing the ten
 duplicated startup lines.
 
+## The agent route, and why it is here
+
+The request was a way to spawn the agents that work the tickets without a keyboard at `ctrl`:
+"spawn off agent to do work" as one message to the reverse proxy, with room for other ways of
+spawning later, Cursor cloud agents first. The reverse proxy is the process every client already
+reaches with the shared bearer, and the only one that is always up, so it is where the message
+goes. It stays a relay for everything else.
+
+### `src/shared/domain.ts`, `contract.ts`, `errors.ts`, `api.ts`
+
+- `Domain.Reasoning` (`none`, `low`, `medium`, `high`, `xhigh`, `max`) and `Domain.AgentType`
+  (`driving-agent`, `diagnosing-agent`) are the two closed vocabularies; `Domain.ModelChoice`
+  `{ model, reasoning?, fast? }` is how a model is asked for everywhere, `Domain.DEFAULT_MODEL`
+  is `grok-4.6` high fast, and `Domain.modelLabel` builds the one string an agent records. They
+  live in `domain.ts` because `ctrl` and the reverse proxy both spawn.
+- `Contract.AgentBody` and `Contract.AgentStarted` are the request and the answer;
+  `Api.Agents` is a third group with the one endpoint, behind `BearerAuth` and the proxy's
+  `ApiBoundary`. Why not `RouteBoundary`: it declares 502 `ServerFailed` and 503 `NoServer`,
+  answers this route never gives, and the doc's rule is that an api must not advertise a status
+  it never answers. The route's own refusals are declared on the endpoint, which a new endpoint
+  can do.
+- `ModelUnavailable { message, model }`, status 400, is the catalog's refusal;
+  `CursorAgentFailed` gained a status, 502, and the `[ErrorReporter.ignore]` every API error
+  carries, so the boundary's line is the one report. Both have `{ "error" }` codecs and arms in
+  `apiErrorClasses` and the middleware's `attribution` (unattributed: the task is in the line).
+
+### `src/ctrl/cursor.ts`: one interface, the catalog as the judge
+
+`CursorAgents.prompt(text, choice = DEFAULT_MODEL)` replaced `prompt(text, ModelSelection?)`:
+the second argument is ours, not the SDK's. `select(choice, catalog)` is the pure mapping, a
+`Result`: find the model by id or alias, put the reasoning level on whichever of `effort`,
+`reasoning`, `reasoning_effort` the model has (taking `extra-high` for `xhigh` where that is the
+spelling), put `fast` on the `fast` switch, and refuse anything the model does not list. The
+catalog is asked on every prompt (`Cursor.models.list()`, one GET the SDK also makes for its own
+pre-flight) rather than hard-coded: the vendor's list is the truth and changes without us. What
+is not asked for is not sent, so the vendor's default variant stands for it.
+
+### `src/reverse-proxy/agents.ts`, `handlers.ts`, `main.ts`
+
+- `Agents.spawn(body)` is a plain `Effect.fn`, not a service: it reaches `CursorAgents`, `Log`
+  and the `FileSystem` (the templates) with `yield*`, and the handler calls it. It refuses a
+  diagnosing task that is not a uuid, builds the choice, renders the type's template with the
+  label, prompts, logs and answers. A template that cannot be read is an `Internal` (500), as a
+  database failure is on the routing side.
+- The handler is uninterruptible, as the driving routes are: a client gone mid-create must not
+  leave an agent created and never prompted, or prompted and answered to nobody.
+- `main.ts` builds `CursorLive` from `Config.cursorApiToken` above `ProxyConfig`, so a missing
+  `CURSOR_API_TOKEN` is reported after `OLIGARCHY_TOKEN` and `DATABASE_URL`, never before, and
+  the process refuses to start without it: the route would only fail later otherwise.
+
+### `ctrl`, the prompts, the default
+
+- `prompts/diagnosing-agent.html` gained `{{MODEL}}` and tells the reviewer to pass it to
+  `ctrl diagnose --model`, as the driving prompt already did for `test start`; who diagnosed is
+  recorded on the diagnosis row today, and now as the label rather than whatever the agent
+  believed it was. `ctrl diagnose run` takes `--model` like `test run`; both send `{ model }`
+  alone for a given id, and the default otherwise.
+- The default moved from `grok-4.6` xhigh fast to `grok-4.6` high fast, as asked.
+
+### Tests
+
+- `test/reverse-proxy/http.unit.test.ts` gained nine `/agent` cases over the real handler and
+  templates with a fake `CursorAgents`: the default and its label, a named model, `fast: false`
+  and `reasoning` on the default, a reviewer attributed to its session, a non-uuid reviewer task,
+  bodies the contract refuses, the catalog's 400, Cursor's 502, and an unreadable template's 500.
+  `/agent` joined the 401 sweep.
+- `test/ctrl/cursor.unit.test.ts` tests `select` against `test/support/cursor-catalog.ts`, six
+  entries captured from `Cursor.models.list()` on 2026-09-09; `test/support/stub-cursor.ts` lists
+  the same `grok-4.6` so the integration lanes see a catalog with knobs.
+- `test/integration/reverse-proxy.integration.test.ts` requires `CURSOR_API_TOKEN` at startup
+  and, when the database is there, POSTs `/agent` against the stub Cursor API through the real
+  SDK: the default model's params, the prompt, the label, the log line, and a level the stub's
+  `grok-4.6` refuses.
+
 ## Deliberately not done
 
 Each of these was considered and left for a need to show itself, per "support only what is
 used":
+
+- Checking a diagnosing task's session before spawning (ended, not yet diagnosed), as
+  `ctrl diagnose run` does. It would bring `SessionStore` and `DiagnosisStore` into the reverse
+  proxy for one route; the reviewer's `ctrl diagnose` refuses the same things, at the cost of the
+  run. `ctrl diagnose run` keeps its checks.
+- `--reasoning` and `--fast` on `ctrl test run` and `ctrl diagnose run`. `--model` takes the id
+  alone there, as before; the full choice is the route's.
+- A second spawning strategy. The `CursorAgents` layer is the seam; nothing else was asked for.
 
 - A health loop. A dead server costs one 10 s probe per start and per `GET /servers` until
   `DELETE /servers` forgets it; a loop that dropped servers on its own would turn a flapping host
@@ -422,8 +552,8 @@ used":
 # on each host that boots machines
 OLIGARCHY_TOKEN=… DATABASE_URL=… ./server --port 42069 --automation
 
-# in front of them, on any host that reaches them and the database
-OLIGARCHY_TOKEN=… DATABASE_URL=… ./reverse-proxy --port 42070 --diagnostics-port 55445
+# in front of them, on any host that reaches them, the database and Cursor
+OLIGARCHY_TOKEN=… DATABASE_URL=… CURSOR_API_TOKEN=… ./reverse-proxy --port 42070 --diagnostics-port 55445
 
 # register the hosts: on the page at http://127.0.0.1:55445/ (add box, delete buttons), or over
 # the API; either way the reverse proxy probes each one's /stats first
@@ -433,10 +563,18 @@ curl -H "authorization: Bearer $OLIGARCHY_TOKEN" http://127.0.0.1:42070/servers
 
 # clients point at the reverse proxy and change nothing else
 ./client start --server-url http://127.0.0.1:42070 --agent-id OLI-42 --iso https://…/omarchy.iso
+
+# spawn the agent that drives a ticket, on the default model or one named; the answer is its link
+curl -H "authorization: Bearer $OLIGARCHY_TOKEN" -H 'content-type: application/json' \
+  -d '{"task":"OLI-42","type":"driving-agent"}' http://127.0.0.1:42070/agent
+curl -H "authorization: Bearer $OLIGARCHY_TOKEN" -H 'content-type: application/json' \
+  -d '{"task":"<session uuid>","type":"diagnosing-agent","model":"claude-opus-5","reasoning":"max"}' \
+  http://127.0.0.1:42070/agent
 ```
 
 The reverse proxy's stdout, like the server's, is the convenience copy; its rows in `logs` and its
 Sentry reports are the record. The lines to know: `server registered; <url>`,
 `server removed; <url>`, `server skipped; <reason>` (a warning during placement),
-`routed; <url>` (attributed to the new session and its agent), `forward cut short; <reason>`, and
-`<METHOD> <url> failed: <reason>` for every request it refused itself.
+`routed; <url>` (attributed to the new session and its agent), `forward cut short; <reason>`,
+`agent spawned; <type>; <task>; <model>; <url>` (attributed to the ticket as agent, or to the
+session), and `<METHOD> <url> failed: <reason>` for every request it refused itself.

--- a/ctrl.md
+++ b/ctrl.md
@@ -43,7 +43,7 @@ If you are an agent driving a guest, you need two of these: [test start](#test-s
 ./ctrl error-type new  --key <key> --description <text>
 ./ctrl error-type list [--json]
 ./ctrl diagnose       --session-id <id> --verdict passed|failed [--type <key>] --summary <text> --model <id>
-./ctrl diagnose run   --session-id <id>
+./ctrl diagnose run   --session-id <id> [--model <id>]
 ```
 
 The action comes first. Every value is a flag; there are no positional arguments. Flags may sit in any order after the action.
@@ -124,7 +124,7 @@ Prints every Linear issue on the Oligarchy team whose status type is backlog, as
 Spawns a Cursor cloud agent that drives one Linear ticket. The ticket carries the proxy URL for the driver's `./client`. The kickoff prompt names the model the agent runs as, which the driver records with `test start --model`. Prints a link to the agent as soon as it starts; does not wait for it. Not used while driving a guest. Reads `CURSOR_API_TOKEN`.
 
 - `--ticket <linear-ticket>` — the issue identifier created by `test new`.
-- `--model <id>` — the Cursor model id to run the agent on. Omitted, the agent runs on the default (`grok-4.6`, effort xhigh, fast), named in the prompt as `grok-4.6-xhigh-fast`.
+- `--model <id>` — the Cursor model id to run the agent on, as Cursor's catalog lists it (`composer-2.5`, `claude-opus-5`); the id alone, so Cursor's own defaults decide how hard it thinks and whether it runs fast, and the prompt names it as given. Omitted, the agent runs on the default (`grok-4.6`, effort high, fast), named in the prompt as `grok-4.6-high-fast`. An id the catalog does not list is a failure (`unknown model "<id>"`), before any agent starts.
 
 ```bash
 ./ctrl test run --ticket OLI-42
@@ -258,13 +258,15 @@ Records the post-run diagnosis: a reviewer's verdict on one session that has end
 ## diagnose run
 
 ```
-./ctrl diagnose run --session-id <id>
+./ctrl diagnose run --session-id <id> [--model <id>]
 ```
 
-Spawns a Cursor cloud agent that reviews one ended session and records its verdict with [diagnose](#diagnose). The agent is handed the session id and the reviewer's guide (`ctrl-diagnose.md`), nothing else: it reads the rest back from the database with [session](#session). Prints a link to the agent as soon as it starts; does not wait for it. Not used while driving a guest. Reads `CURSOR_API_TOKEN`.
+Spawns a Cursor cloud agent that reviews one ended session and records its verdict with [diagnose](#diagnose). The agent is handed the session id, the model it runs as (which it records with `diagnose --model`) and the reviewer's guide (`ctrl-diagnose.md`), nothing else: it reads the rest back from the database with [session](#session). Prints a link to the agent as soon as it starts; does not wait for it. Not used while driving a guest. Reads `CURSOR_API_TOKEN`.
 
 - `--session-id <id>` — the session. Unknown, still running or downloading, or already diagnosed is a failure (`diagnose run: session <id> already has a diagnosis`), before any agent is spawned.
+- `--model <id>` — the Cursor model id to run the reviewer on, as [test run](#test-run) takes it. Omitted, the default (`grok-4.6`, effort high, fast), named in the prompt as `grok-4.6-high-fast`.
 
 ```bash
 ./ctrl diagnose run --session-id 6f1c...e2a9
+./ctrl diagnose run --session-id 6f1c...e2a9 --model claude-opus-5
 ```

--- a/prompts/diagnosing-agent.html
+++ b/prompts/diagnosing-agent.html
@@ -9,11 +9,13 @@ Post-run reviewer. Your goal is the post-run diagnosis of one finished Omarchy s
   <rule>Judge from the evidence: the images, the actions, the logs, the serial console. The driver's own verdict is a claim to check, not a fact.</rule>
   <rule>Always look at the final image before any verdict; it is what the driver saw when it decided. When a log line, an action, or the serial console makes you suspect a step, fetch the images around that step and look at them too.</rule>
   <rule>For a failed verdict, read the whole of ./ctrl error-type list and pick the type whose description matches the cause in your evidence. Mint a new type with ./ctrl error-type new only when none matches. This should be rare; be very careful. A different wording or a different symptom of the same cause is not a new type.</rule>
+  <rule>When you record the diagnosis with ./ctrl diagnose, pass `--model {{MODEL}}`: the model below is the one you are running as.</rule>
   <rule>Record exactly one diagnosis, then stop.</rule>
 </rules>
 
 <run>
   <session_id>{{SESSION_ID}}</session_id>
+  <model>{{MODEL}}</model>
 </run>
 
 <ctrl>
@@ -34,6 +36,6 @@ $ ./session image --image-id <the id of the image after the step you suspect> -o
 # look at it: what did the driver actually see there?
 $ ./ctrl error-type list
 # a type whose description matches the cause? use it. none at all? only then ./ctrl error-type new
-$ ./ctrl diagnose --session-id {{SESSION_ID}} --verdict failed --type guest_boot_hang --summary "Serial stops after 'Waiting for root device'; the last image is still the boot menu" --model <the Cursor model id you are running as>
+$ ./ctrl diagnose --session-id {{SESSION_ID}} --verdict failed --type guest_boot_hang --summary "Serial stops after 'Waiting for root device'; the last image is still the boot menu" --model {{MODEL}}
 ```
 </example-session>

--- a/src/ctrl/command.ts
+++ b/src/ctrl/command.ts
@@ -411,24 +411,26 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     yield* printJson(yield* linear.listBacklog);
   });
 
-  // test run --ticket <linear-ticket>
+  // The model an agent is started on: the id given, alone, so the vendor's defaults decide the
+  // rest; or the default. The prompt names it as the label the agent must record.
+  const modelChoice = (model: Option.Option<string>): Domain.ModelChoice =>
+    Option.match(model, {
+      onNone: () => Domain.DEFAULT_MODEL,
+      onSome: (id) => ({ model: id }),
+    });
+
   // test run --ticket <linear-ticket> [--model <id>]
   const testRun = Effect.fn("ctrl.test.run")(function* (input: {
     readonly ticket: string;
     readonly model: Option.Option<string>;
   }) {
     const agents = yield* Cursor.CursorAgents;
-    // The prompt names the model the agent runs as, so the driver can record it at test start:
-    // the id given, or the label of the default the agent is started on.
-    const selection = Option.map(input.model, (id): Cursor.Model => ({ id }));
+    const choice = modelChoice(input.model);
     const text = yield* Prompts.render("driving-agent.html", {
       LINEAR_TICKET: input.ticket,
-      MODEL: Option.getOrElse(input.model, () => Cursor.modelLabel(Cursor.GROK_4_6_FAST_XHIGH)),
+      MODEL: Domain.modelLabel(choice),
     });
-    const { agentId } = yield* Option.match(selection, {
-      onNone: () => agents.prompt(text),
-      onSome: (model) => agents.prompt(text, model),
-    });
+    const { agentId } = yield* agents.prompt(text, choice);
     yield* Console.log(Render.agentLink(Cursor.agentUrl(agentId)));
   });
 
@@ -580,9 +582,10 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     });
   });
 
-  // diagnose run --session-id <id>
+  // diagnose run --session-id <id> [--model <id>]
   const diagnoseRun = Effect.fn("ctrl.diagnose.run")(function* (input: {
     readonly sessionId: string;
+    readonly model: Option.Option<string>;
   }) {
     const diagnosis = yield* Diagnosis.DiagnosisStore;
     const agents = yield* Cursor.CursorAgents;
@@ -595,9 +598,14 @@ export const makeCtrlCommand = (deps: Deps = live) => {
           refuse(`diagnose run: session ${input.sessionId} already has a diagnosis`),
         ),
       );
-    // The reviewer reads everything back from the database: the session id is all it needs.
-    const text = yield* Prompts.render("diagnosing-agent.html", { SESSION_ID: input.sessionId });
-    const { agentId } = yield* agents.prompt(text);
+    const choice = modelChoice(input.model);
+    // The reviewer reads everything back from the database: the session id and the model it
+    // records with diagnose are all it needs.
+    const text = yield* Prompts.render("diagnosing-agent.html", {
+      SESSION_ID: input.sessionId,
+      MODEL: Domain.modelLabel(choice),
+    });
+    const { agentId } = yield* agents.prompt(text, choice);
     yield* Console.log(Render.agentLink(Cursor.agentUrl(agentId)));
   });
 
@@ -919,7 +927,16 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     Command.withSubcommands([errorTypeNewCommand, errorTypeListCommand]),
   );
 
-  const diagnoseRunCommand = Command.make("run", { sessionId: sessionIdFlag }, diagnoseRun).pipe(
+  const diagnoseRunCommand = Command.make(
+    "run",
+    {
+      sessionId: sessionIdFlag,
+      model: modelFlag(
+        "Cursor model id to run the reviewing agent on; the default when omitted",
+      ).pipe(Flag.optional),
+    },
+    diagnoseRun,
+  ).pipe(
     Command.withDescription("Kick off a Cursor cloud agent that reviews one ended session"),
     Command.provide(withDbAndCursor),
   );

--- a/src/ctrl/cursor.ts
+++ b/src/ctrl/cursor.ts
@@ -40,15 +40,17 @@ export const select = (
       );
     }
     const offered = reasoning.values.map((entry) => entry.value);
-    // Older GPT models spell our xhigh as extra-high.
+    // Older GPT models spell our xhigh as extra-high; the refusal lists what can be asked for,
+    // so it says xhigh there.
     const level =
       offered.find((value) => value === choice.reasoning) ??
       (choice.reasoning === "xhigh" ? offered.find((value) => value === "extra-high") : undefined);
     if (level === undefined) {
+      const levels = offered.map((value) => (value === "extra-high" ? "xhigh" : value));
       return Result.fail(
         unavailable(
           choice.model,
-          `model "${choice.model}" has no reasoning level "${choice.reasoning}"; it has ${offered.join(", ")}`,
+          `model "${choice.model}" has no reasoning level "${choice.reasoning}"; it has ${levels.join(", ")}`,
         ),
       );
     }

--- a/src/ctrl/cursor.ts
+++ b/src/ctrl/cursor.ts
@@ -1,40 +1,76 @@
-import { Agent, type ModelSelection } from "@cursor/sdk";
-import { Context, Effect, Layer, Option, Redacted, Schema } from "effect";
+import { Agent, Cursor, type ModelListItem, type ModelSelection } from "@cursor/sdk";
+import { Context, Effect, Layer, Option, Redacted, Result, Schema } from "effect";
 import * as ExternalFailure from "../external-failure.ts";
+import * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
-
-export type Model = ModelSelection;
 
 export const REPOSITORY = "https://github.com/ThePrimeagen/Oligarchy";
 
-export const GROK_4_6_FAST_XHIGH: Model = {
-  id: "grok-4.6",
-  params: [
-    { id: "effort", value: "xhigh" },
-    { id: "fast", value: "true" },
-  ],
-};
-
 export const agentUrl = (agentId: string): string => `https://cursor.com/agents/${agentId}`;
 
-// The one string a driver is told to record with `ctrl test start --model`: the id, then the
-// effort value, then `fast` when set, then any other param as `id-value` — the shape cursor-agent
-// spells its own slugs (`gpt-5.6-luna-none-fast`), so local and cloud drivers record alike.
-export const modelLabel = (model: Model): string =>
-  [
-    model.id,
-    ...(model.params ?? []).flatMap((param) => {
-      if (param.id === "effort") return [param.value];
-      if (param.id === "fast") return param.value === "true" ? ["fast"] : [];
-      return [`${param.id}-${param.value}`];
-    }),
-  ].join("-");
+// The catalog as `Cursor.models.list()` answers it: each model with the parameters it takes.
+export type Catalog = ReadonlyArray<ModelListItem>;
+
+// Every vendor has a knob for how hard the model thinks; these are the names the catalog uses.
+const REASONING_PARAMS = ["effort", "reasoning", "reasoning_effort"];
+
+const unavailable = (model: string, message: string): Errors.ModelUnavailable =>
+  Errors.ModelUnavailable.make({ model, message });
+
+// Says a choice in the vendor's own params, against what the catalog says the model takes: the
+// model must be listed (by id or alias), a reasoning level must be one it offers, and fast needs
+// the switch. What is not asked for is not sent, so the vendor's default stands for it.
+export const select = (
+  choice: Domain.ModelChoice,
+  catalog: Catalog,
+): Result.Result<ModelSelection, Errors.ModelUnavailable> => {
+  const listed = catalog.find(
+    (entry) => entry.id === choice.model || entry.aliases?.includes(choice.model) === true,
+  );
+  if (listed === undefined) {
+    return Result.fail(unavailable(choice.model, `unknown model "${choice.model}"`));
+  }
+  const parameters = listed.parameters ?? [];
+  const params: Array<{ readonly id: string; readonly value: string }> = [];
+  if (choice.reasoning !== undefined) {
+    const reasoning = parameters.find((parameter) => REASONING_PARAMS.includes(parameter.id));
+    if (reasoning === undefined) {
+      return Result.fail(
+        unavailable(choice.model, `model "${choice.model}" has no reasoning level`),
+      );
+    }
+    const offered = reasoning.values.map((entry) => entry.value);
+    // Older GPT models spell our xhigh as extra-high.
+    const level =
+      offered.find((value) => value === choice.reasoning) ??
+      (choice.reasoning === "xhigh" ? offered.find((value) => value === "extra-high") : undefined);
+    if (level === undefined) {
+      return Result.fail(
+        unavailable(
+          choice.model,
+          `model "${choice.model}" has no reasoning level "${choice.reasoning}"; it has ${offered.join(", ")}`,
+        ),
+      );
+    }
+    params.push({ id: reasoning.id, value: level });
+  }
+  if (choice.fast !== undefined) {
+    if (!parameters.some((parameter) => parameter.id === "fast")) {
+      return Result.fail(unavailable(choice.model, `model "${choice.model}" has no fast mode`));
+    }
+    params.push({ id: "fast", value: String(choice.fast) });
+  }
+  return Result.succeed({ id: choice.model, params });
+};
 
 export type CursorAgentsService = {
   readonly prompt: (
     text: string,
-    model?: Model,
-  ) => Effect.Effect<{ readonly agentId: string }, Errors.CursorAgentFailed>;
+    choice?: Domain.ModelChoice,
+  ) => Effect.Effect<
+    { readonly agentId: string },
+    Errors.ModelUnavailable | Errors.CursorAgentFailed
+  >;
 };
 
 // The SDK's errors carry `isRetryable` as an own field; anything else thrown is terminal.
@@ -52,14 +88,24 @@ export const cursorAgentFailed = (thrown: unknown): Errors.CursorAgentFailed =>
 
 const makeCursorAgents = (apiKey: Redacted.Redacted): Effect.Effect<CursorAgentsService> =>
   Effect.succeed({
-    // send resolves once the cloud run exists; the agent keeps working after close().
-    prompt: Effect.fn("CursorAgents.prompt")(function* (text: string, model?: Model) {
+    // The catalog is asked each time: a choice is refused here, with what the model does take,
+    // rather than by the backend once the agent exists. send resolves once the cloud run exists;
+    // the agent keeps working after close().
+    prompt: Effect.fn("CursorAgents.prompt")(function* (
+      text: string,
+      choice: Domain.ModelChoice = Domain.DEFAULT_MODEL,
+    ) {
+      const catalog = yield* Effect.tryPromise({
+        try: () => Cursor.models.list({ apiKey: Redacted.value(apiKey) }),
+        catch: cursorAgentFailed,
+      });
+      const model = yield* Effect.fromResult(select(choice, catalog));
       return yield* Effect.acquireUseRelease(
         Effect.tryPromise({
           try: () =>
             Agent.create({
               apiKey: Redacted.value(apiKey),
-              model: model ?? GROK_4_6_FAST_XHIGH,
+              model,
               cloud: { repos: [{ url: REPOSITORY }] },
             }),
           catch: cursorAgentFailed,

--- a/src/proxy/middleware.ts
+++ b/src/proxy/middleware.ts
@@ -38,6 +38,8 @@ const isApiError: (value: unknown) => value is Errors.ApiError = Schema.is(
     Errors.Internal,
     Errors.ServerFailed,
     Errors.NoServer,
+    Errors.ModelUnavailable,
+    Errors.CursorAgentFailed,
   ]),
 );
 
@@ -58,6 +60,8 @@ const attribution = (error: Errors.ApiError): Log.Attribution => {
   switch (error._tag) {
     case "Unauthorized":
     case "NotFound":
+    case "ModelUnavailable":
+    case "CursorAgentFailed":
       return {};
     case "Forbidden":
       return { sessionId: error.sessionId, agentId: error.agentId };

--- a/src/reverse-proxy/agents.ts
+++ b/src/reverse-proxy/agents.ts
@@ -1,0 +1,42 @@
+import { Effect } from "effect";
+import * as Cursor from "../ctrl/cursor.ts";
+import * as Prompts from "../ctrl/prompts.ts";
+import * as Log from "../observability/log.ts";
+import * as Contract from "../shared/contract.ts";
+import * as Domain from "../shared/domain.ts";
+import * as Errors from "../shared/errors.ts";
+
+// POST /agent: one cloud agent, handed the prompt its type names, on the model asked for. The
+// agent is told its model as the label it must record, so the label is built here from the same
+// choice the agent is started on. Another way of spawning is another CursorAgents layer.
+export const spawn = Effect.fn("Agents.spawn")(function* (body: Contract.AgentBody) {
+  const agents = yield* Cursor.CursorAgents;
+  const log = yield* Log.Log;
+  // A reviewer's task is the session it reads back; a ticket there would cost an agent run to
+  // find out, and the line below is attributed to a uuid column.
+  if (body.type === "diagnosing-agent" && !Domain.isSessionId(body.task)) {
+    return yield* Errors.BadRequest.make({
+      message: "task must be a session id for a diagnosing-agent",
+    });
+  }
+  // No model means the default; reasoning and fast in the body still say their piece.
+  const choice: Domain.ModelChoice = Object.assign(
+    body.model === undefined ? { ...Domain.DEFAULT_MODEL } : { model: body.model },
+    body.reasoning === undefined ? undefined : { reasoning: body.reasoning },
+    body.fast === undefined ? undefined : { fast: body.fast },
+  );
+  const model = Domain.modelLabel(choice);
+  const text = yield* (
+    body.type === "driving-agent"
+      ? Prompts.render("driving-agent.html", { LINEAR_TICKET: body.task, MODEL: model })
+      : Prompts.render("diagnosing-agent.html", { SESSION_ID: body.task, MODEL: model })
+  ).pipe(Effect.mapError((cause) => Errors.Internal.make({ cause })));
+  const { agentId } = yield* agents.prompt(text, choice);
+  const url = Cursor.agentUrl(agentId);
+  // A driving agent's ticket is the agent id its session will carry; a reviewer's is its session.
+  yield* log.info(
+    `agent spawned; ${body.type}; ${body.task}; ${model}; ${url}`,
+    body.type === "driving-agent" ? { agentId: body.task } : { sessionId: body.task },
+  );
+  return Contract.AgentStarted.make({ id: agentId, url, model });
+});

--- a/src/reverse-proxy/handlers.ts
+++ b/src/reverse-proxy/handlers.ts
@@ -4,6 +4,7 @@ import * as ProxyHandlers from "../proxy/handlers.ts";
 import * as Middleware from "../proxy/middleware.ts";
 import * as Api from "../shared/api.ts";
 import * as Contract from "../shared/contract.ts";
+import * as Agents from "./agents.ts";
 import * as Router from "./router.ts";
 
 const ok = Contract.Ok.make({});
@@ -118,10 +119,22 @@ export const ServersLive = HttpApiBuilder.group(Api.ReverseProxyApi, "Servers", 
     ),
 );
 
+// Uninterruptible for the agent's sake: a client gone mid-create must not leave an agent created
+// and never prompted, or prompted and never answered to anyone.
+export const AgentsLive = HttpApiBuilder.group(Api.ReverseProxyApi, "Agents", (handlers) =>
+  handlers.handle("spawn", ({ payload }) => Agents.spawn(payload), uninterruptible),
+);
+
 export const routes = Layer.mergeAll(
   HttpApiBuilder.layer(Api.ReverseProxyApi).pipe(
-    Layer.provide(Layer.mergeAll(SessionsLive, ServersLive)),
-    Layer.provide(Layer.mergeAll(Middleware.BearerAuthLive, Middleware.RouteBoundaryLive)),
+    Layer.provide(Layer.mergeAll(SessionsLive, ServersLive, AgentsLive)),
+    Layer.provide(
+      Layer.mergeAll(
+        Middleware.BearerAuthLive,
+        Middleware.RouteBoundaryLive,
+        Middleware.ApiBoundaryLive,
+      ),
+    ),
   ),
   ProxyHandlers.NotFoundRoute,
 );

--- a/src/reverse-proxy/main.ts
+++ b/src/reverse-proxy/main.ts
@@ -4,6 +4,7 @@ import { Cause, Deferred, Effect, Exit, Layer, type Runtime } from "effect";
 import { Command } from "effect/unstable/cli";
 import { HttpMiddleware, HttpRouter, HttpServer, HttpServerError } from "effect/unstable/http";
 import * as Config from "../config.ts";
+import * as Cursor from "../ctrl/cursor.ts";
 import * as Client from "../db/client.ts";
 import * as Logs from "../db/logs.ts";
 import * as Servers from "../db/servers.ts";
@@ -67,8 +68,14 @@ const DatabaseLive = Layer.unwrap(
   Effect.map(Config.ProxyConfig, (config) => Client.Database.layer(config.databaseUrl)),
 );
 
+// The reverse proxy spawns agents, so it needs the key at startup. Built above ProxyConfig, so a
+// missing CURSOR_API_TOKEN is reported after the proxy's two, never before.
+const CursorLive = Layer.unwrap(
+  Effect.map(Config.cursorApiToken, (apiKey) => Cursor.CursorAgents.layer(apiKey)),
+);
+
 // Sentry sits beneath Log so the log rows flush before Sentry does, and Log captures the reporter.
-const MainLive = Layer.mergeAll(Servers.ServerStore.layer, Log.Log.layer).pipe(
+const MainLive = Layer.mergeAll(Servers.ServerStore.layer, Log.Log.layer, CursorLive).pipe(
   Layer.provideMerge(Logs.LogStore.layer),
   Layer.provideMerge(DatabaseLive),
   Layer.provideMerge(Config.ProxyConfig.layer),

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -159,8 +159,23 @@ export class Servers extends HttpApiGroup.make("Servers")
   .middleware(BearerAuth)
   .middleware(RouteBoundary) {}
 
+// Agents group: one cloud agent per request, driving a ticket or diagnosing a session; bearer
+// required. It neither forwards nor places, so it sits behind the proxy's own boundary and
+// declares the two refusals of its own: a model the catalog cannot honour, and Cursor failing.
+export const spawn = HttpApiEndpoint.post("spawn", "/agent", {
+  payload: Contract.AgentBody,
+  success: Contract.AgentStarted,
+  error: [Errors.ModelUnavailableWire, Errors.CursorAgentFailedWire],
+});
+
+export class Agents extends HttpApiGroup.make("Agents")
+  .add(spawn)
+  .middleware(BearerAuth)
+  .middleware(ApiBoundary) {}
+
 export class ReverseProxyApi extends HttpApi.make("OligarchyReverseProxy")
   .add(RoutedSessions)
-  .add(Servers) {}
+  .add(Servers)
+  .add(Agents) {}
 
 export const VERSION = "0.0.0";

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -101,6 +101,26 @@ export class Servers extends Schema.Class<Servers>("@oligarchy/shared/contract/S
   servers: Schema.Array(Server),
 }) {}
 
+// POST /agent on the reverse proxy: what the agent works on (the Linear ticket a driving agent
+// completes, the session a diagnosing agent reviews), which kind it is, and the model. No model
+// means the default; reasoning and fast are kept as given.
+export class AgentBody extends Schema.Class<AgentBody>("@oligarchy/shared/contract/AgentBody")({
+  task: Schema.NonEmptyString,
+  type: Domain.AgentType,
+  model: Schema.optionalKey(Schema.NonEmptyString),
+  reasoning: Schema.optionalKey(Domain.Reasoning),
+  fast: Schema.optionalKey(Schema.Boolean),
+}) {}
+
+// The agent that started: its id, where to watch it, and the model label it was told it runs as.
+export class AgentStarted extends Schema.Class<AgentStarted>(
+  "@oligarchy/shared/contract/AgentStarted",
+)({
+  id: Schema.String,
+  url: Schema.String,
+  model: Schema.String,
+}) {}
+
 const STORED_IMAGE_ORIGIN = "https://oligarchy.trm.sh";
 
 export const StoredImageUrl = (id: string): string => `${STORED_IMAGE_ORIGIN}/images/${id}`;

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -129,6 +129,43 @@ export const DiagnosisVerdict = Schema.Literals(["passed", "failed"]).annotate({
 });
 export type DiagnosisVerdict = typeof DiagnosisVerdict.Type;
 
+// How hard a model is asked to think, in one vocabulary; each vendor spells it as a parameter of
+// its own, and a model offers a subset.
+export const Reasoning = Schema.Literals([
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]).annotate({ identifier: "@oligarchy/shared/domain/Reasoning" });
+export type Reasoning = typeof Reasoning.Type;
+
+// How an agent's model is asked for, wherever one is spawned from: the model as the vendor lists
+// it, and how hard and how fast it runs; a knob left out leaves the vendor's default.
+export type ModelChoice = {
+  readonly model: string;
+  readonly reasoning?: Reasoning;
+  readonly fast?: boolean;
+};
+
+export const DEFAULT_MODEL: ModelChoice = { model: "grok-4.6", reasoning: "high", fast: true };
+
+// The one string an agent is told it runs as and records (`ctrl test start --model`,
+// `ctrl diagnose --model`): the model, the reasoning, then `fast` when it runs fast.
+export const modelLabel = (choice: ModelChoice): string =>
+  [
+    choice.model,
+    ...(choice.reasoning === undefined ? [] : [choice.reasoning]),
+    ...(choice.fast === true ? ["fast"] : []),
+  ].join("-");
+
+// What a spawned agent does: drives one Linear ticket, or diagnoses one ended session.
+export const AgentType = Schema.Literals(["driving-agent", "diagnosing-agent"]).annotate({
+  identifier: "@oligarchy/shared/domain/AgentType",
+});
+export type AgentType = typeof AgentType.Type;
+
 // An ISO named by url is downloaded and cached by the proxy; anything else is a path.
 export const isIsoUrl = (iso: string): boolean =>
   iso.startsWith("http://") || iso.startsWith("https://");

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -148,6 +148,31 @@ export class NoServer extends Schema.TaggedError<NoServer>("@oligarchy/shared/er
   override readonly [ErrorReporter.ignore] = true;
 }
 
+// A model choice the vendor's catalog cannot honour: a model it does not list, or a reasoning
+// level or fast mode that model does not take. The caller's mistake, so 400; the message names
+// what the model does take.
+export class ModelUnavailable extends Schema.TaggedError<ModelUnavailable>(
+  "@oligarchy/shared/errors/ModelUnavailable",
+)("ModelUnavailable", { message: Schema.String, model: Schema.String }, { httpApiStatus: 400 }) {
+  override readonly [ErrorReporter.ignore] = true;
+}
+
+// The Cursor SDK refused or failed to start an agent; 502 because Cursor is the upstream that
+// failed the request.
+export class CursorAgentFailed extends Schema.TaggedError<CursorAgentFailed>(
+  "@oligarchy/shared/errors/CursorAgentFailed",
+)(
+  "CursorAgentFailed",
+  {
+    message: Schema.String,
+    retryable: Schema.Boolean,
+    cause: Schema.Defect(),
+  },
+  { httpApiStatus: 502 },
+) {
+  override readonly [ErrorReporter.ignore] = true;
+}
+
 export type ApiError =
   | BadRequest
   | Unauthorized
@@ -159,7 +184,9 @@ export type ApiError =
   | ExchangeFailed
   | Internal
   | ServerFailed
-  | NoServer;
+  | NoServer
+  | ModelUnavailable
+  | CursorAgentFailed;
 
 const resolveHttpApiStatus = SchemaAST.resolveAt("httpApiStatus");
 
@@ -182,6 +209,8 @@ const apiErrorClasses = {
   Internal,
   ServerFailed,
   NoServer,
+  ModelUnavailable,
+  CursorAgentFailed,
 } satisfies Record<ApiError["_tag"], Schema.Top>;
 
 export const apiStatus = (error: ApiError): number => httpStatus(apiErrorClasses[error._tag]);
@@ -248,6 +277,15 @@ export const ServerFailedWire = wireError(
 export const NoServerWire = wireError(
   NoServer,
   (message) => ({ _tag: "NoServer", message }) as const,
+);
+export const ModelUnavailableWire = wireError(
+  ModelUnavailable,
+  (message) => ({ _tag: "ModelUnavailable", message, model: "" }) as const,
+);
+// A decoded refusal has no SDK error to carry and nothing says it can be retried.
+export const CursorAgentFailedWire = wireError(
+  CursorAgentFailed,
+  (message) => ({ _tag: "CursorAgentFailed", message, retryable: false, cause: null }) as const,
 );
 
 // ---------------------------------------------------------------------------
@@ -351,14 +389,6 @@ export class LinearError extends Schema.TaggedError<LinearError>(
 export class PromptError extends Schema.TaggedError<PromptError>(
   "@oligarchy/shared/errors/PromptError",
 )("PromptError", { message: Schema.String, cause: Schema.optionalKey(Schema.Defect()) }) {}
-
-export class CursorAgentFailed extends Schema.TaggedError<CursorAgentFailed>(
-  "@oligarchy/shared/errors/CursorAgentFailed",
-)("CursorAgentFailed", {
-  message: Schema.String,
-  retryable: Schema.Boolean,
-  cause: Schema.Defect(),
-}) {}
 
 export class ChildExit extends Schema.TaggedError<ChildExit>("@oligarchy/shared/errors/ChildExit")(
   "ChildExit",

--- a/test/ctrl/command.unit.test.ts
+++ b/test/ctrl/command.unit.test.ts
@@ -856,19 +856,19 @@ describe("test run", () => {
       const h = harness({ cursor: FakeCursor.fakeCursor({ agentId: "bc-42" }) });
       const exit = yield* h.run(["test", "run", "--ticket", "OLI-42"], WITH_CURSOR);
       expect(Exit.isSuccess(exit)).toBe(true);
-      // Without --model the agent runs on the default, and the prompt names that default so the
-      // driver records it at test start.
+      // Without --model the agent runs on the default, grok-4.6 at effort high running fast, and
+      // the prompt names that default so the driver records it at test start.
       expect(h.cursor.calls).toEqual([
         {
           text: yield* rendered("driving-agent.html", {
             LINEAR_TICKET: "OLI-42",
-            MODEL: "grok-4.6-xhigh-fast",
+            MODEL: "grok-4.6-high-fast",
           }),
-          model: undefined,
+          choice: { model: "grok-4.6", reasoning: "high", fast: true },
         },
       ]);
       expect(h.cursor.calls[0]?.text).toMatch(/Review Linear ticket\s+OLI-42/);
-      expect(h.cursor.calls[0]?.text).toContain("<model> grok-4.6-xhigh-fast </model>");
+      expect(h.cursor.calls[0]?.text).toContain("<model> grok-4.6-high-fast </model>");
       expect(h.cursor.calls[0]?.text.includes(SERVER)).toBe(false);
       expect(yield* stdout).toEqual([
         "Agent here, go check it out for more information: https://cursor.com/agents/bc-42",
@@ -877,7 +877,7 @@ describe("test run", () => {
     }),
   );
 
-  it.effect("--model runs the agent on that model and names it in the prompt (happy)", () =>
+  it.effect("--model runs the agent on that model alone and names it in the prompt (happy)", () =>
     Effect.gen(function* () {
       const h = harness({ cursor: FakeCursor.fakeCursor({ agentId: "bc-43" }) });
       const exit = yield* h.run(
@@ -885,16 +885,31 @@ describe("test run", () => {
         WITH_CURSOR,
       );
       expect(Exit.isSuccess(exit)).toBe(true);
+      // The id alone: the vendor's own defaults decide how hard it thinks and how fast it runs.
       expect(h.cursor.calls).toEqual([
         {
           text: yield* rendered("driving-agent.html", {
             LINEAR_TICKET: "OLI-42",
             MODEL: "composer-2.5",
           }),
-          model: { id: "composer-2.5" },
+          choice: { model: "composer-2.5" },
         },
       ]);
       expect(h.cursor.calls[0]?.text).toContain("--model composer-2.5");
+    }),
+  );
+
+  it.effect("a model the catalog refuses fails with the refusal and prints no link (unhappy)", () =>
+    Effect.gen(function* () {
+      const refusal = Errors.ModelUnavailable.make({
+        message: 'unknown model "grok-9"',
+        model: "grok-9",
+      });
+      const h = harness({ cursor: FakeCursor.fakeCursor({ failure: refusal }) });
+      expect(
+        yield* h.fail(["test", "run", "--ticket", "OLI-42", "--model", "grok-9"], WITH_CURSOR),
+      ).toBe(refusal);
+      expect(yield* stdout).toEqual([]);
     }),
   );
 
@@ -920,7 +935,10 @@ describe("test run", () => {
         expect(fs.reads).toHaveLength(1);
         expect(fs.reads[0]).toMatch(DRIVING_AGENT_PATH);
         expect(h.cursor.calls).toEqual([
-          { text: "Review Linear ticket OLI-42\n", model: undefined },
+          {
+            text: "Review Linear ticket OLI-42\n",
+            choice: { model: "grok-4.6", reasoning: "high", fast: true },
+          },
         ]);
       }),
   );
@@ -1899,18 +1917,27 @@ const DIAGNOSING_AGENT_PATH = /\/prompts\/diagnosing-agent\.html$/;
 
 describe("diagnose run", () => {
   it.effect(
-    "kicks off the reviewer with the session and the diagnosis guide, and prints its link (happy)",
+    "kicks off the reviewer with the session, the default model and the diagnosis guide, and prints its link (happy)",
     () =>
       Effect.gen(function* () {
         const h = harness({ cursor: FakeCursor.fakeCursor({ agentId: "bc-42" }) });
         h.stores.sessions.sessions.push(session(SESSION_ID, "failed", ago(500)));
         const exit = yield* h.run(DIAGNOSE_RUN, WITH_CURSOR);
         expect(Exit.isSuccess(exit)).toBe(true);
+        // The prompt names the model the reviewer runs as, so it records it with diagnose.
         expect(h.cursor.calls).toEqual([
-          { text: yield* rendered("diagnosing-agent.html", { SESSION_ID }), model: undefined },
+          {
+            text: yield* rendered("diagnosing-agent.html", {
+              SESSION_ID,
+              MODEL: "grok-4.6-high-fast",
+            }),
+            choice: { model: "grok-4.6", reasoning: "high", fast: true },
+          },
         ]);
         const text = h.cursor.calls[0]?.text ?? "";
         expect(text).toContain(`<session_id>${SESSION_ID}</session_id>`);
+        expect(text).toContain("<model>grok-4.6-high-fast</model>");
+        expect(text).toContain("--model grok-4.6-high-fast");
         expect(text).toContain("## diagnose");
         expect(text.includes("{{")).toBe(false);
         // The reviewer reads the database alone: no proxy is named anywhere in its prompt.
@@ -1932,6 +1959,37 @@ describe("diagnose run", () => {
       expect(h.cursor.calls).toHaveLength(1);
       expect(h.cursor.calls[0]?.text).toContain(`--session-id ${SESSION_ID} --all`);
       expect(h.cursor.calls[0]?.text.includes(SERVER)).toBe(false);
+    }),
+  );
+
+  it.effect(
+    "--model runs the reviewer on that model alone and names it in the prompt (happy)",
+    () =>
+      Effect.gen(function* () {
+        const h = harness({ cursor: FakeCursor.fakeCursor({ agentId: "bc-43" }) });
+        h.stores.sessions.sessions.push(session(SESSION_ID, "failed", ago(500)));
+        const exit = yield* h.run([...DIAGNOSE_RUN, "--model", "claude-opus-5"], WITH_CURSOR);
+        expect(Exit.isSuccess(exit)).toBe(true);
+        expect(h.cursor.calls).toEqual([
+          {
+            text: yield* rendered("diagnosing-agent.html", { SESSION_ID, MODEL: "claude-opus-5" }),
+            choice: { model: "claude-opus-5" },
+          },
+        ]);
+        expect(h.cursor.calls[0]?.text).toContain("--model claude-opus-5");
+        expect(yield* stdout).toEqual([
+          "Agent here, go check it out for more information: https://cursor.com/agents/bc-43",
+        ]);
+      }),
+  );
+
+  it.effect("an empty --model is refused before any agent starts (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.sessions.sessions.push(session(SESSION_ID, "failed", ago(500)));
+      const exit = yield* h.run([...DIAGNOSE_RUN, "--model", ""], WITH_CURSOR);
+      expect(helpErrors(exit).join("\n")).toMatch(/--model.*length of at least 1/s);
+      expect(h.cursor.calls).toEqual([]);
     }),
   );
 

--- a/test/ctrl/cursor.unit.test.ts
+++ b/test/ctrl/cursor.unit.test.ts
@@ -1,45 +1,161 @@
 import { describe, expect, it as plain } from "vitest";
 import { it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Result } from "effect";
 import * as Cursor from "../../src/ctrl/cursor.ts";
+import * as Domain from "../../src/shared/domain.ts";
 import * as Errors from "../../src/shared/errors.ts";
+import * as Catalog from "../support/cursor-catalog.ts";
 import * as FakeCursor from "../support/fake-cursor.ts";
 
-const prompt = (text: string, model?: Cursor.Model) =>
+const prompt = (text: string, choice?: Domain.ModelChoice) =>
   Effect.flatMap(Cursor.CursorAgents, (agents) =>
-    model === undefined ? agents.prompt(text) : agents.prompt(text, model),
+    choice === undefined ? agents.prompt(text) : agents.prompt(text, choice),
   );
 
+const selected = (choice: Domain.ModelChoice) =>
+  Result.getOrThrow(Cursor.select(choice, Catalog.CATALOG));
+
+const refused = (choice: Domain.ModelChoice): Errors.ModelUnavailable => {
+  const result = Cursor.select(choice, Catalog.CATALOG);
+  if (Result.isSuccess(result)) {
+    throw new Error(`expected ${JSON.stringify(choice)} to be refused`);
+  }
+  return result.failure;
+};
+
+// The catalog is the vendor's word on what a model takes; the choice is ours. `select` says the
+// choice in the vendor's params, or refuses it naming what the model does take.
+describe("select happy path", () => {
+  plain("the default is grok-4.6 at effort high, running fast", () => {
+    expect(selected(Domain.DEFAULT_MODEL)).toEqual({
+      id: "grok-4.6",
+      params: [
+        { id: "effort", value: "high" },
+        { id: "fast", value: "true" },
+      ],
+    });
+  });
+
+  plain("a model asked for by id alone carries no params: the vendor's defaults apply", () => {
+    expect(selected({ model: "composer-2.5" })).toEqual({ id: "composer-2.5", params: [] });
+    expect(selected({ model: "gemini-3.1-pro" })).toEqual({ id: "gemini-3.1-pro", params: [] });
+  });
+
+  plain("an alias names the model and the selection carries the alias as given", () => {
+    expect(selected({ model: "opus", reasoning: "max" })).toEqual({
+      id: "opus",
+      params: [{ id: "effort", value: "max" }],
+    });
+  });
+
+  plain("reasoning lands on the parameter the vendor spells it as", () => {
+    expect(selected({ model: "claude-opus-5", reasoning: "low" }).params).toEqual([
+      { id: "effort", value: "low" },
+    ]);
+    expect(selected({ model: "gpt-5.5", reasoning: "none" }).params).toEqual([
+      { id: "reasoning", value: "none" },
+    ]);
+    expect(selected({ model: "gemini-3.8-flash", reasoning: "medium" }).params).toEqual([
+      { id: "reasoning_effort", value: "medium" },
+    ]);
+  });
+
+  plain("xhigh is extra-high on a model that spells it so", () => {
+    expect(selected({ model: "gpt-5.5", reasoning: "xhigh", fast: true }).params).toEqual([
+      { id: "reasoning", value: "extra-high" },
+      { id: "fast", value: "true" },
+    ]);
+  });
+
+  plain("fast false is sent as the vendor's false, not left out", () => {
+    expect(selected({ model: "grok-4.6", reasoning: "medium", fast: false }).params).toEqual([
+      { id: "effort", value: "medium" },
+      { id: "fast", value: "false" },
+    ]);
+  });
+});
+
+describe("select unhappy path", () => {
+  plain("a model the catalog does not list is refused by name", () => {
+    expect(refused({ model: "grok-9", reasoning: "high" })).toMatchObject({
+      _tag: "ModelUnavailable",
+      model: "grok-9",
+      message: 'unknown model "grok-9"',
+    });
+    expect(refused({ model: "" }).message).toBe('unknown model ""');
+  });
+
+  plain("a model without a fast switch refuses fast, true or false", () => {
+    expect(refused({ model: "gemini-3.8-flash", fast: true })).toMatchObject({
+      model: "gemini-3.8-flash",
+      message: 'model "gemini-3.8-flash" has no fast mode',
+    });
+    expect(refused({ model: "gemini-3.1-pro", fast: false }).message).toBe(
+      'model "gemini-3.1-pro" has no fast mode',
+    );
+  });
+
+  plain("a model without a reasoning parameter refuses every level", () => {
+    expect(refused({ model: "composer-2.5", reasoning: "high" })).toMatchObject({
+      model: "composer-2.5",
+      message: 'model "composer-2.5" has no reasoning level',
+    });
+    expect(refused({ model: "gemini-3.1-pro", reasoning: "none" }).message).toBe(
+      'model "gemini-3.1-pro" has no reasoning level',
+    );
+  });
+
+  plain("a level the model does not offer is refused naming the ones it does", () => {
+    expect(refused({ model: "grok-4.6", reasoning: "max" })).toMatchObject({
+      model: "grok-4.6",
+      message: 'model "grok-4.6" has no reasoning level "max"; it has low, medium, high, xhigh',
+    });
+    expect(refused({ model: "gemini-3.8-flash", reasoning: "xhigh" }).message).toBe(
+      'model "gemini-3.8-flash" has no reasoning level "xhigh"; it has low, medium, high',
+    );
+    expect(refused({ model: "grok-4.6", reasoning: "none", fast: true }).message).toBe(
+      'model "grok-4.6" has no reasoning level "none"; it has low, medium, high, xhigh',
+    );
+  });
+
+  plain("the model is checked first, then reasoning, then fast", () => {
+    expect(refused({ model: "nope", reasoning: "max", fast: true }).message).toBe(
+      'unknown model "nope"',
+    );
+    expect(refused({ model: "composer-2.5", reasoning: "max", fast: true }).message).toBe(
+      'model "composer-2.5" has no reasoning level',
+    );
+  });
+});
+
 describe("CursorAgents.prompt happy path", () => {
-  it.effect("returns the agent id and records the prompt text", () =>
+  it.effect("returns the agent id and records the prompt text and the choice", () =>
     Effect.gen(function* () {
       const cursor = FakeCursor.fakeCursor({ agentId: "bc-42" });
-      const created = yield* prompt("Review Linear ticket OLI-42 and complete your task.").pipe(
-        Effect.provide(cursor.layer),
-      );
+      const created = yield* prompt("Review Linear ticket OLI-42 and complete your task.", {
+        model: "grok-4.6",
+        reasoning: "xhigh",
+        fast: true,
+      }).pipe(Effect.provide(cursor.layer));
       expect(created).toEqual({ agentId: "bc-42" });
       expect(cursor.calls).toEqual([
-        { text: "Review Linear ticket OLI-42 and complete your task.", model: undefined },
+        {
+          text: "Review Linear ticket OLI-42 and complete your task.",
+          choice: { model: "grok-4.6", reasoning: "xhigh", fast: true },
+        },
       ]);
     }),
   );
 
-  it.effect("passes the model given instead of the default", () =>
+  it.effect("without a choice the agent starts on the default", () =>
     Effect.gen(function* () {
       const cursor = FakeCursor.fakeCursor();
-      yield* prompt("hello", { id: "composer-2.5" }).pipe(Effect.provide(cursor.layer));
-      expect(cursor.calls).toEqual([{ text: "hello", model: { id: "composer-2.5" } }]);
+      yield* prompt("hello").pipe(Effect.provide(cursor.layer));
+      expect(cursor.calls).toEqual([{ text: "hello", choice: undefined }]);
     }),
   );
 
-  it("kicks off on the repository with Grok 4.6 fast, extra high, by default", () => {
-    expect(Cursor.GROK_4_6_FAST_XHIGH).toEqual({
-      id: "grok-4.6",
-      params: [
-        { id: "effort", value: "xhigh" },
-        { id: "fast", value: "true" },
-      ],
-    });
+  plain("kicks off on the repository and links the agent by id", () => {
     expect(Cursor.REPOSITORY).toBe("https://github.com/ThePrimeagen/Oligarchy");
     expect(Cursor.agentUrl("bc-42")).toBe("https://cursor.com/agents/bc-42");
   });
@@ -56,12 +172,25 @@ describe("CursorAgents.prompt unhappy path", () => {
       const cursor = FakeCursor.fakeCursor({ failure });
       const error = yield* Effect.flip(prompt("hello")).pipe(Effect.provide(cursor.layer));
       expect(error).toBe(failure);
-      expect(error.message).toBe("Invalid API key");
-      expect(error.retryable).toBe(false);
+      expect(error).toMatchObject({ message: "Invalid API key", retryable: false });
     }),
   );
 
-  it("classifies a thrown SDK error by its message and retry flag", () => {
+  it.effect("surfaces a model the catalog refuses as ModelUnavailable, before any agent", () =>
+    Effect.gen(function* () {
+      const failure = Errors.ModelUnavailable.make({
+        model: "grok-9",
+        message: 'unknown model "grok-9"',
+      });
+      const cursor = FakeCursor.fakeCursor({ failure });
+      const error = yield* Effect.flip(prompt("hello", { model: "grok-9" })).pipe(
+        Effect.provide(cursor.layer),
+      );
+      expect(error).toBe(failure);
+    }),
+  );
+
+  plain("classifies a thrown SDK error by its message and retry flag", () => {
     const retryable = Cursor.cursorAgentFailed(
       Object.assign(new Error("rate limited"), { isRetryable: true }),
     );
@@ -83,34 +212,12 @@ describe("CursorAgents.prompt unhappy path", () => {
     });
   });
 
-  it("falls back to a fixed message for a thrown value without one", () => {
+  plain("falls back to a fixed message for a thrown value without one", () => {
     const failure = Cursor.cursorAgentFailed("boom");
     expect(failure).toMatchObject({
       message: "cursor: agent request failed",
       retryable: false,
       cause: "boom",
     });
-  });
-});
-
-// The label is what a driver is told to record with `ctrl test start --model`: the id, then the
-// effort and a `fast` marker, in the shape cursor-agent spells its own model slugs.
-describe("modelLabel", () => {
-  plain("names the default with its effort and speed", () => {
-    expect(Cursor.modelLabel(Cursor.GROK_4_6_FAST_XHIGH)).toBe("grok-4.6-xhigh-fast");
-  });
-
-  plain("a bare id is its own label; other params are appended as id-value", () => {
-    expect(Cursor.modelLabel({ id: "composer-2.5" })).toBe("composer-2.5");
-    expect(
-      Cursor.modelLabel({
-        id: "gpt-5.6",
-        params: [
-          { id: "effort", value: "low" },
-          { id: "fast", value: "false" },
-          { id: "context", value: "1m" },
-        ],
-      }),
-    ).toBe("gpt-5.6-low-context-1m");
   });
 });

--- a/test/ctrl/cursor.unit.test.ts
+++ b/test/ctrl/cursor.unit.test.ts
@@ -118,6 +118,12 @@ describe("select unhappy path", () => {
     );
   });
 
+  plain("the levels a refusal lists are ours, xhigh where the vendor says extra-high", () => {
+    expect(refused({ model: "gpt-5.5", reasoning: "max" }).message).toBe(
+      'model "gpt-5.5" has no reasoning level "max"; it has none, low, medium, high, xhigh',
+    );
+  });
+
   plain("the model is checked first, then reasoning, then fast", () => {
     expect(refused({ model: "nope", reasoning: "max", fast: true }).message).toBe(
       'unknown model "nope"',

--- a/test/ctrl/prompts.unit.test.ts
+++ b/test/ctrl/prompts.unit.test.ts
@@ -162,15 +162,21 @@ describe("render happy path", () => {
   );
 
   it.effect(
-    "diagnosing-agent.html: the session and the diagnosis guide; no proxy, nothing of the drive",
+    "diagnosing-agent.html: the session, the model and the diagnosis guide; no proxy, nothing of the drive",
     () =>
       Effect.gen(function* () {
-        const text = yield* real(Prompts.render("diagnosing-agent.html", { SESSION_ID }));
+        const text = yield* real(
+          Prompts.render("diagnosing-agent.html", { SESSION_ID, MODEL: "claude-opus-5-max" }),
+        );
 
         expect(text.includes("{{")).toBe(false);
         expect(text).toContain(`<session_id>${SESSION_ID}</session_id>`);
         expect(text).toContain(`./ctrl session --session-id ${SESSION_ID} --all`);
         expect(text).toContain(`./ctrl diagnose --session-id ${SESSION_ID}`);
+        // The reviewer is told its model once and what to do with it: diagnose records it. The
+        // guide it embeds keeps its own generic wording for the flag.
+        expect(text).toContain("<model>claude-opus-5-max</model>");
+        expect(text).toContain(`--model claude-opus-5-max`);
         expect(text).toContain("--model <the Cursor model id you are running as>");
         // The reviewer reads the database alone: no server url, no token, reaches it.
         expect(text.includes("server_url")).toBe(false);
@@ -211,6 +217,13 @@ describe("render unhappy path", () => {
         );
         expect(withoutModel.message).toBe(
           "prompt: prompts/driving-agent.html uses {{MODEL}}, which has no value",
+        );
+        // A reviewer kicked off without a model would have nothing to record with diagnose.
+        const reviewerWithoutModel = yield* Effect.flip(
+          real(Prompts.render("diagnosing-agent.html", { SESSION_ID })),
+        );
+        expect(reviewerWithoutModel.message).toBe(
+          "prompt: prompts/diagnosing-agent.html uses {{MODEL}}, which has no value",
         );
         const withoutTicket = yield* Effect.flip(
           real(Prompts.render("linear-issue.html", { SESSION_ID, SERVER_URL: SERVER })),

--- a/test/integration/ctrl.integration.test.ts
+++ b/test/integration/ctrl.integration.test.ts
@@ -193,7 +193,7 @@ describe("./ctrl without a database", () => {
     expect(body.model).toEqual({
       id: "grok-4.6",
       params: [
-        { id: "effort", value: "xhigh" },
+        { id: "effort", value: "high" },
         { id: "fast", value: "true" },
       ],
     });
@@ -202,6 +202,22 @@ describe("./ctrl without a database", () => {
       stub.requests.some((request) => request.method === "GET" && request.url === "/v1/models"),
     ).toBe(true);
     expect(created[0]?.authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("test run --model asks the catalog and refuses a model it does not list, before any agent", async () => {
+    const stub = await cursor();
+    const result = await runCtrl(["test", "run", "--ticket", "OLI-42", "--model", "grok-9"], {
+      DATABASE_URL: UNUSED_DB,
+      CURSOR_API_TOKEN: TOKEN,
+      CURSOR_BACKEND_URL: stub.url,
+    });
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(firstLine(result.stderr)).toBe('unknown model "grok-9"');
+    expect(
+      stub.requests.some((request) => request.method === "GET" && request.url === "/v1/models"),
+    ).toBe(true);
+    expect(StubCursor.createdAgents(stub)).toEqual([]);
   });
 
   it("test run takes no server URL and wants CURSOR_API_TOKEN after parsing", async () => {
@@ -918,7 +934,7 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
     expect(body.model).toEqual({
       id: "grok-4.6",
       params: [
-        { id: "effort", value: "xhigh" },
+        { id: "effort", value: "high" },
         { id: "fast", value: "true" },
       ],
     });

--- a/test/integration/reverse-proxy.integration.test.ts
+++ b/test/integration/reverse-proxy.integration.test.ts
@@ -10,9 +10,11 @@ import { Effect } from "effect";
 import * as Client from "../../src/db/client.ts";
 import * as DbSchema from "../../src/db/schema.ts";
 import * as Postgres from "../support/postgres.ts";
+import * as StubCursor from "../support/stub-cursor.ts";
 
 const REVERSE_PROXY = fileURLToPath(new URL("../../reverse-proxy", import.meta.url));
 const TOKEN = "t";
+const CURSOR_TOKEN = "cursor-t";
 const UNREACHABLE = "postgres://user:sentinel-pw@127.0.0.1:1/oligarchy";
 const EXIT_WITHIN_MS = 60_000;
 
@@ -27,12 +29,15 @@ type Process = {
 };
 
 // Sentry is initialised by the wrapper's --import; a proxy nobody listens on keeps the test
-// run's fatal lines out of the real project without touching the code under test.
+// run's fatal lines out of the real project without touching the code under test. The Cursor
+// SDK is pointed at a stub the same way (CURSOR_BACKEND_URL), or at nothing.
 const environment = (overrides: Record<string, string>): NodeJS.ProcessEnv => {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     OLIGARCHY_TOKEN: TOKEN,
     DATABASE_URL: dbUrl === "" ? UNREACHABLE : dbUrl,
+    CURSOR_API_TOKEN: CURSOR_TOKEN,
+    CURSOR_BACKEND_URL: "http://127.0.0.1:1",
     https_proxy: "http://127.0.0.1:1",
     http_proxy: "http://127.0.0.1:1",
     no_proxy: "",
@@ -168,11 +173,24 @@ describe("reverse proxy startup refusals", () => {
 
   it.live("a missing OLIGARCHY_TOKEN exits 1 with OLIGARCHY_TOKEN is not set", () =>
     Effect.promise(async () => {
-      const process = spawnReverseProxy([], { OLIGARCHY_TOKEN: "" });
+      const process = spawnReverseProxy([], { OLIGARCHY_TOKEN: "", CURSOR_API_TOKEN: "" });
       const { code } = await process.exited;
       expect(code).toBe(1);
       expect(process.stderr()).toContain("OLIGARCHY_TOKEN is not set");
+      expect(process.stderr()).not.toContain("CURSOR_API_TOKEN");
       expect(process.stderr()).not.toContain("sentinel-pw");
+    }),
+  );
+
+  // The reverse proxy spawns agents, so it needs the key at startup, after the proxy's two.
+  it.live("a missing CURSOR_API_TOKEN exits 1 with CURSOR_API_TOKEN is not set", () =>
+    Effect.promise(async () => {
+      const process = spawnReverseProxy([], { CURSOR_API_TOKEN: "" });
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("CURSOR_API_TOKEN is not set");
+      expect(process.stderr()).not.toContain("sentinel-pw");
+      expect(process.stdout()).not.toContain("listening");
     }),
   );
 
@@ -236,12 +254,12 @@ describe("reverse proxy serving", () => {
   const served = async (signal: "SIGINT" | "SIGTERM") => {
     const port = await freePort();
     const diagnosticsPort = await freePort();
-    const process = spawnReverseProxy([
-      "--port",
-      String(port),
-      "--diagnostics-port",
-      String(diagnosticsPort),
-    ]);
+    const stub = await StubCursor.startStubCursor();
+    const process = spawnReverseProxy(
+      ["--port", String(port), "--diagnostics-port", String(diagnosticsPort)],
+      { CURSOR_BACKEND_URL: stub.url },
+    );
+    let spawnedUrl = "";
     try {
       await process.waitFor(/oligarchy reverse proxy listening/);
       expect(lines(process.stdout())).toContain(
@@ -297,15 +315,67 @@ describe("reverse proxy serving", () => {
       );
       expect(noServer.status).toBe(503);
       expect(await noServer.json()).toEqual({ error: "no server registered" });
+
+      // An agent for a ticket, through the Cursor SDK to the stub: the default model, the
+      // driving prompt, and the link back.
+      const spawned = await request(
+        port,
+        "POST",
+        "/agent",
+        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        '{"task":"OLI-2","type":"driving-agent"}',
+      );
+      expect(spawned.status).toBe(200);
+      const started: { id: string; url: string; model: string } = JSON.parse(await spawned.text());
+      expect(started.model).toBe("grok-4.6-high-fast");
+      expect(started.url).toBe(`https://cursor.com/agents/${started.id}`);
+      spawnedUrl = started.url;
+      const created = StubCursor.createdAgents(stub);
+      expect(created).toHaveLength(1);
+      expect(created[0]?.authorization).toBe(`Bearer ${CURSOR_TOKEN}`);
+      const body: { agentId: string; prompt: { text: string }; model: unknown } = JSON.parse(
+        created[0]?.body ?? "{}",
+      );
+      expect(body.agentId).toBe(started.id);
+      expect(body.prompt.text).toMatch(/Review Linear ticket\s+OLI-2/);
+      expect(body.prompt.text).toContain("<model> grok-4.6-high-fast </model>");
+      expect(body.model).toEqual({
+        id: "grok-4.6",
+        params: [
+          { id: "effort", value: "high" },
+          { id: "fast", value: "true" },
+        ],
+      });
+
+      // A level the stub's grok-4.6 does not offer: the catalog refuses it, no agent is created.
+      const refused = await request(
+        port,
+        "POST",
+        "/agent",
+        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        '{"task":"OLI-3","type":"driving-agent","reasoning":"max"}',
+      );
+      expect(refused.status).toBe(400);
+      expect(await refused.json()).toEqual({
+        error: 'model "grok-4.6" has no reasoning level "max"; it has low, medium, high, xhigh',
+      });
+      expect(StubCursor.createdAgents(stub)).toHaveLength(1);
     } finally {
       // A failed expectation must not leave the process listening past the test.
       process.child.kill(signal);
+      await stub.close();
     }
     const { code } = await process.exited;
     expect(code, process.stdout()).toBe(0);
     const output = lines(process.stdout());
     expect(output).toContain("[global] error: POST /send-keys failed: unauthorized");
     expect(output).toContain("[OLI-1] error: POST /start failed: no server registered");
+    expect(output).toContain(
+      `[OLI-2] agent spawned; driving-agent; OLI-2; grok-4.6-high-fast; ${spawnedUrl}`,
+    );
+    expect(output).toContain(
+      '[global] error: POST /agent failed: model "grok-4.6" has no reasoning level "max"; it has low, medium, high, xhigh',
+    );
     expect(
       output.some((line) =>
         line.startsWith(
@@ -322,7 +392,7 @@ describe("reverse proxy serving", () => {
   };
 
   it.live.skipIf(dbUrl === "")(
-    "listens, answers /servers, 401 and 404, and exits 0 on SIGINT",
+    "listens, answers /servers, /agent, 401 and 404, and exits 0 on SIGINT",
     () => serving("SIGINT"),
     120_000,
   );

--- a/test/reverse-proxy/http.unit.test.ts
+++ b/test/reverse-proxy/http.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
-import { Cause, Deferred, Effect, Exit, Fiber, Layer, Redacted, Stream } from "effect";
+import { Cause, Deferred, Effect, Exit, Fiber, FileSystem, Layer, Redacted, Stream } from "effect";
 import { TestClock } from "effect/testing";
 import {
   HttpBody,
@@ -10,13 +10,16 @@ import {
   HttpRouter,
 } from "effect/unstable/http";
 import { HttpApiClient, HttpApiMiddleware } from "effect/unstable/httpapi";
-import { NodeHttpServer } from "@effect/platform-node";
+import { NodeFileSystem, NodeHttpServer } from "@effect/platform-node";
 import * as Config from "../../src/config.ts";
+import * as Prompts from "../../src/ctrl/prompts.ts";
 import * as Handlers from "../../src/reverse-proxy/handlers.ts";
 import * as Router from "../../src/reverse-proxy/router.ts";
 import * as Api from "../../src/shared/api.ts";
 import * as Contract from "../../src/shared/contract.ts";
 import * as Errors from "../../src/shared/errors.ts";
+import * as FakeCursor from "../support/fake-cursor.ts";
+import * as FakeFs from "../support/fake-fs.ts";
 import * as FakeHttp from "../support/fake-http.ts";
 import * as FakeLog from "../support/log.ts";
 import * as Reporter from "../support/reporter.ts";
@@ -71,6 +74,9 @@ type Fixture = {
   readonly upstream: FakeHttp.Recorder;
   readonly log: FakeLog.FakeLog;
   readonly reporter: Reporter.Collector;
+  readonly cursor: FakeCursor.FakeCursor;
+  // The prompt templates are read from beside the package: the real files unless a test says.
+  readonly fs: Layer.Layer<FileSystem.FileSystem>;
 };
 
 const fixture = (respond: FakeHttp.Respond = fleet, overrides: Partial<Fixture> = {}): Fixture => ({
@@ -78,6 +84,8 @@ const fixture = (respond: FakeHttp.Respond = fleet, overrides: Partial<Fixture> 
   upstream: FakeHttp.recordRequests(respond),
   log: FakeLog.fakeLog(),
   reporter: Reporter.collect(),
+  cursor: FakeCursor.fakeCursor({ agentId: "bc-42" }),
+  fs: NodeFileSystem.layer,
   ...overrides,
 });
 
@@ -92,7 +100,7 @@ const serve = (fixed: Fixture) =>
         ),
       ),
     ),
-    Layer.provide(Layer.mergeAll(fixed.log.layer, ProxyConfigLive)),
+    Layer.provide(Layer.mergeAll(fixed.log.layer, ProxyConfigLive, fixed.cursor.layer, fixed.fs)),
     Layer.provideMerge(NodeHttpServer.layerTest),
     Layer.provideMerge(fixed.reporter.layer),
     Layer.provideMerge(bearer(TOKEN)),
@@ -1088,6 +1096,360 @@ describe("forwarding", () => {
   );
 });
 
+describe("agent spawning", () => {
+  const AGENT_URL = "https://cursor.com/agents/bc-42";
+  const TICKET = "OLI-42";
+
+  const spawnBody = (body: {
+    readonly task: string;
+    readonly type: "driving-agent" | "diagnosing-agent";
+    readonly model?: string;
+    readonly reasoning?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
+    readonly fast?: boolean;
+  }) => Contract.AgentBody.make(body);
+
+  // The very text the agent is handed, rendered from the real template as the handler does.
+  const rendered = (template: Prompts.Template, values: Prompts.Values) =>
+    Prompts.render(template, values).pipe(Effect.provide(NodeFileSystem.layer));
+
+  it.effect(
+    "POST /agent spawns a driving agent on grok-4.6 high fast with the ticket prompt, answers its link and logs it",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture();
+        yield* Effect.gen(function* () {
+          const api = yield* reverseClient;
+          const [started, response] = yield* api.Agents.spawn({
+            payload: spawnBody({ task: TICKET, type: "driving-agent" }),
+            responseMode: "decoded-and-response",
+          });
+          expect(started).toEqual(
+            Contract.AgentStarted.make({
+              id: "bc-42",
+              url: AGENT_URL,
+              model: "grok-4.6-high-fast",
+            }),
+          );
+          expect(yield* response.json).toEqual({
+            id: "bc-42",
+            url: AGENT_URL,
+            model: "grok-4.6-high-fast",
+          });
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.cursor.calls).toEqual([
+          {
+            text: yield* rendered("driving-agent.html", {
+              LINEAR_TICKET: TICKET,
+              MODEL: "grok-4.6-high-fast",
+            }),
+            choice: { model: "grok-4.6", reasoning: "high", fast: true },
+          },
+        ]);
+        const text = fixed.cursor.calls[0]?.text ?? "";
+        expect(text).toMatch(/Review Linear ticket\s+OLI-42/);
+        expect(text).toContain("<model> grok-4.6-high-fast </model>");
+        expect(text).toContain("--model grok-4.6-high-fast");
+        expect(text.includes("{{")).toBe(false);
+        // The ticket is the driver's agent id: the line is attributed to it, as its session's will be.
+        expect(fixed.log.lines).toEqual([
+          {
+            level: "info",
+            text: `agent spawned; driving-agent; ${TICKET}; grok-4.6-high-fast; ${AGENT_URL}`,
+            sessionId: undefined,
+            agentId: TICKET,
+            skipSentry: false,
+            cause: undefined,
+          },
+        ]);
+        expect(fixed.upstream.requests).toEqual([]);
+      }),
+  );
+
+  it.effect("a model named in the body is asked for as given, the vendor deciding the rest", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const api = yield* reverseClient;
+        const started = yield* api.Agents.spawn({
+          payload: spawnBody({ task: TICKET, type: "driving-agent", model: "composer-2.5" }),
+        });
+        expect(started.model).toBe("composer-2.5");
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.cursor.calls).toHaveLength(1);
+      expect(fixed.cursor.calls[0]?.choice).toEqual({ model: "composer-2.5" });
+      expect(fixed.cursor.calls[0]?.text).toContain("<model> composer-2.5 </model>");
+      expect(fixed.log.lines.map((line) => line.text)).toEqual([
+        `agent spawned; driving-agent; ${TICKET}; composer-2.5; ${AGENT_URL}`,
+      ]);
+    }),
+  );
+
+  it.effect("reasoning and fast in the body are kept, on a named model and on the default", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const api = yield* reverseClient;
+        const slow = yield* api.Agents.spawn({
+          payload: spawnBody({ task: TICKET, type: "driving-agent", fast: false }),
+        });
+        expect(slow.model).toBe("grok-4.6-high");
+        const harder = yield* api.Agents.spawn({
+          payload: spawnBody({ task: TICKET, type: "driving-agent", reasoning: "xhigh" }),
+        });
+        expect(harder.model).toBe("grok-4.6-xhigh-fast");
+        const named = yield* api.Agents.spawn({
+          payload: spawnBody({
+            task: TICKET,
+            type: "driving-agent",
+            model: "gpt-5.6-sol",
+            reasoning: "max",
+            fast: true,
+          }),
+        });
+        expect(named.model).toBe("gpt-5.6-sol-max-fast");
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.cursor.calls.map((call) => call.choice)).toEqual([
+        { model: "grok-4.6", reasoning: "high", fast: false },
+        { model: "grok-4.6", reasoning: "xhigh", fast: true },
+        { model: "gpt-5.6-sol", reasoning: "max", fast: true },
+      ]);
+    }),
+  );
+
+  it.effect(
+    "a diagnosing agent is handed the session and the diagnosis guide, attributed to the session",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture();
+        yield* Effect.gen(function* () {
+          const api = yield* reverseClient;
+          const started = yield* api.Agents.spawn({
+            payload: spawnBody({
+              task: SESSION_ID,
+              type: "diagnosing-agent",
+              model: "claude-opus-5",
+              reasoning: "max",
+            }),
+          });
+          expect(started).toEqual(
+            Contract.AgentStarted.make({ id: "bc-42", url: AGENT_URL, model: "claude-opus-5-max" }),
+          );
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.cursor.calls).toEqual([
+          {
+            text: yield* rendered("diagnosing-agent.html", {
+              SESSION_ID,
+              MODEL: "claude-opus-5-max",
+            }),
+            choice: { model: "claude-opus-5", reasoning: "max" },
+          },
+        ]);
+        const text = fixed.cursor.calls[0]?.text ?? "";
+        expect(text).toContain(`<session_id>${SESSION_ID}</session_id>`);
+        expect(text).toContain("--model claude-opus-5-max");
+        expect(text).toContain("## diagnose");
+        expect(text.includes("{{")).toBe(false);
+        expect(fixed.log.lines).toEqual([
+          {
+            level: "info",
+            text: `agent spawned; diagnosing-agent; ${SESSION_ID}; claude-opus-5-max; ${AGENT_URL}`,
+            sessionId: SESSION_ID,
+            agentId: undefined,
+            skipSentry: false,
+            cause: undefined,
+          },
+        ]);
+      }),
+  );
+
+  it.effect(
+    "a diagnosing agent whose task is not a session id is 400 before any template or agent",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture(fleet, { fs: FileSystem.layerNoop({}) });
+        yield* Effect.gen(function* () {
+          const api = yield* reverseClient;
+          const error = yield* Effect.flip(
+            api.Agents.spawn({ payload: spawnBody({ task: TICKET, type: "diagnosing-agent" }) }),
+          );
+          expect(error.message).toBe("task must be a session id for a diagnosing-agent");
+          const http = yield* HttpClient.HttpClient;
+          const raw = yield* http.post("/agent", {
+            headers: { authorization: AUTHORIZATION },
+            body: HttpBody.jsonUnsafe({ task: "garbage", type: "diagnosing-agent" }),
+          });
+          expect(raw.status).toBe(400);
+          expect(yield* raw.json).toEqual({
+            error: "task must be a session id for a diagnosing-agent",
+          });
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.cursor.calls).toEqual([]);
+        expect(fixed.log.lines).toEqual([
+          {
+            level: "error",
+            text: "POST /agent failed: task must be a session id for a diagnosing-agent",
+            sessionId: undefined,
+            agentId: undefined,
+            skipSentry: true,
+            cause: undefined,
+          },
+          {
+            level: "error",
+            text: "POST /agent failed: task must be a session id for a diagnosing-agent",
+            sessionId: undefined,
+            agentId: undefined,
+            skipSentry: true,
+            cause: undefined,
+          },
+        ]);
+        expect(fixed.reporter.reported).toEqual([]);
+      }),
+  );
+
+  it.effect("a type, task or reasoning outside the contract is 400 before anything runs", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(fleet, { fs: FileSystem.layerNoop({}) });
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const headers = { authorization: AUTHORIZATION };
+        const cases: ReadonlyArray<readonly [unknown, string]> = [
+          [{ task: TICKET, type: "developing-agent" }, '["type"]'],
+          [{ task: "", type: "driving-agent" }, '["task"]'],
+          [{ type: "driving-agent" }, '["task"]'],
+          [{ task: TICKET, type: "driving-agent", reasoning: "extra-high" }, '["reasoning"]'],
+          [{ task: TICKET, type: "driving-agent", fast: "yes" }, '["fast"]'],
+          [{ task: TICKET, type: "driving-agent", model: "" }, '["model"]'],
+        ];
+        for (const [body, path] of cases) {
+          const raw = yield* http.post("/agent", { headers, body: HttpBody.jsonUnsafe(body) });
+          expect(raw.status, JSON.stringify(body)).toBe(400);
+          expect(yield* raw.json).toMatchObject({ error: expect.stringContaining(path) });
+        }
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.cursor.calls).toEqual([]);
+      expect(fixed.log.lines).toHaveLength(6);
+      expect(fixed.log.lines.every((line) => line.skipSentry)).toBe(true);
+    }),
+  );
+
+  it.effect("a model the catalog refuses is 400 with the refusal, and no agent starts", () =>
+    Effect.gen(function* () {
+      const refusal = Errors.ModelUnavailable.make({
+        message: 'model "composer-2.5" has no reasoning level',
+        model: "composer-2.5",
+      });
+      const fixed = fixture(fleet, { cursor: FakeCursor.fakeCursor({ failure: refusal }) });
+      yield* Effect.gen(function* () {
+        const api = yield* reverseClient;
+        const error = yield* Effect.flip(
+          api.Agents.spawn({
+            payload: spawnBody({
+              task: TICKET,
+              type: "driving-agent",
+              model: "composer-2.5",
+              reasoning: "high",
+            }),
+          }),
+        );
+        expect(error.message).toBe('model "composer-2.5" has no reasoning level');
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/agent", {
+          headers: { authorization: AUTHORIZATION },
+          body: HttpBody.jsonUnsafe({
+            task: TICKET,
+            type: "driving-agent",
+            model: "composer-2.5",
+            reasoning: "high",
+          }),
+        });
+        expect(raw.status).toBe(400);
+        expect(yield* raw.json).toEqual({ error: 'model "composer-2.5" has no reasoning level' });
+      }).pipe(Effect.provide(serve(fixed)));
+      // The prompt was rendered and the choice made; the catalog said no.
+      expect(fixed.cursor.calls.map((call) => call.choice)).toEqual([
+        { model: "composer-2.5", reasoning: "high" },
+        { model: "composer-2.5", reasoning: "high" },
+      ]);
+      expect(fixed.log.lines).toHaveLength(2);
+      expect(fixed.log.lines[0]).toEqual({
+        level: "error",
+        text: 'POST /agent failed: model "composer-2.5" has no reasoning level',
+        sessionId: undefined,
+        agentId: undefined,
+        skipSentry: true,
+        cause: undefined,
+      });
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
+  it.effect("a Cursor refusal is 502 with its message, logged with the cause", () =>
+    Effect.gen(function* () {
+      const cause = new Error("Invalid API key");
+      const failure = Errors.CursorAgentFailed.make({
+        message: "Invalid API key",
+        retryable: false,
+        cause,
+      });
+      const fixed = fixture(fleet, { cursor: FakeCursor.fakeCursor({ failure }) });
+      yield* Effect.gen(function* () {
+        const api = yield* reverseClient;
+        const error = yield* Effect.flip(
+          api.Agents.spawn({ payload: spawnBody({ task: TICKET, type: "driving-agent" }) }),
+        );
+        expect(error).toMatchObject({ _tag: "CursorAgentFailed", message: "Invalid API key" });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/agent", {
+          headers: { authorization: AUTHORIZATION },
+          body: HttpBody.jsonUnsafe({ task: TICKET, type: "driving-agent" }),
+        });
+        expect(raw.status).toBe(502);
+        expect(yield* raw.json).toEqual({ error: "Invalid API key" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.log.lines).toHaveLength(2);
+      expect(fixed.log.lines[0]).toEqual({
+        level: "error",
+        text: "POST /agent failed: Invalid API key",
+        sessionId: undefined,
+        agentId: undefined,
+        skipSentry: false,
+        cause,
+      });
+    }),
+  );
+
+  it.effect(
+    "an unreadable template is 500 internal error naming the file, and no agent starts",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture(fleet, {
+          fs: FileSystem.layerNoop({
+            readFileString: (path) => Effect.fail(FakeFs.permissionDenied("open", path)),
+          }),
+        });
+        yield* Effect.gen(function* () {
+          const http = yield* HttpClient.HttpClient;
+          const raw = yield* http.post("/agent", {
+            headers: { authorization: AUTHORIZATION },
+            body: HttpBody.jsonUnsafe({ task: TICKET, type: "driving-agent" }),
+          });
+          expect(raw.status).toBe(500);
+          expect(yield* raw.json).toEqual({ error: "internal error" });
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.cursor.calls).toEqual([]);
+        expect(fixed.log.lines).toHaveLength(1);
+        expect(fixed.log.lines[0]).toMatchObject({
+          level: "error",
+          text: expect.stringMatching(
+            /^POST \/agent failed: PermissionDenied: FileSystem\.open \(.*\/prompts\/driving-agent\.html\)$/,
+          ),
+          skipSentry: false,
+        });
+        expect(fixed.log.lines[0]?.cause).toMatchObject({ _tag: "PromptError" });
+      }),
+  );
+});
+
 describe("forwarding refusals", () => {
   it.effect("a uuid nobody routed is 404 unknown session attributed to it and the agent", () =>
     Effect.gen(function* () {
@@ -1287,6 +1649,7 @@ describe("forwarding refusals", () => {
     ["POST", "/servers", true],
     ["DELETE", "/servers", true],
     ["GET", "/servers", false],
+    ["POST", "/agent", true],
   ];
 
   const request = (
@@ -1325,6 +1688,7 @@ describe("forwarding refusals", () => {
         }
       }).pipe(Effect.provide(serve(fixed)));
       expect(fixed.upstream.requests).toEqual([]);
+      expect(fixed.cursor.calls).toEqual([]);
       expect(fixed.log.lines).toHaveLength(everyRoute.length * 2);
       expect(
         fixed.log.lines.every(

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -152,7 +152,7 @@ describe("ProxyApi", () => {
 describe("ReverseProxyApi", () => {
   const reverse = Api.ReverseProxyApi;
 
-  it("declares every routed path of ProxyApi but /stats, plus the three server routes", () => {
+  it("declares every routed path of ProxyApi but /stats, the three server routes and /agent", () => {
     const table = routes(reverse).map(({ method, path }) => `${method} ${path}`);
     expect(table.sort()).toEqual(
       [
@@ -168,6 +168,7 @@ describe("ReverseProxyApi", () => {
         "POST /servers",
         "DELETE /servers",
         "GET /servers",
+        "POST /agent",
       ].sort(),
     );
     expect(table).not.toContain("GET /stats");
@@ -186,12 +187,18 @@ describe("ReverseProxyApi", () => {
     expect(urls.Servers.register()).toBe("/servers");
     expect(urls.Servers.unregister()).toBe("/servers");
     expect(urls.Servers.servers()).toBe("/servers");
+    expect(urls.Agents.spawn()).toBe("/agent");
   });
 
-  it("requires the bearer and applies BearerAuth then RouteBoundary on every endpoint", () => {
+  // The routing groups answer with a server's failure or none to place on; the agent group
+  // answers neither, so it sits behind the proxy's own boundary and declares its two refusals.
+  it("requires the bearer and applies BearerAuth then a boundary on every endpoint", () => {
     const spec = OpenApi.fromApi(reverse);
     for (const route of routes(reverse)) {
-      expect(route.middleware).toEqual([Api.BearerAuth.key, Api.RouteBoundary.key]);
+      expect(route.middleware, route.identifier).toEqual([
+        Api.BearerAuth.key,
+        route.group === "Agents" ? Api.ApiBoundary.key : Api.RouteBoundary.key,
+      ]);
       const item = spec.paths[route.path];
       const operation =
         route.method === "GET"
@@ -222,10 +229,20 @@ describe("ReverseProxyApi", () => {
     expect(byIdentifier(reverse, "servers").errors).toEqual(boundary);
   });
 
-  it("leaves ProxyApi untouched: no server routes and no RouteBoundary", () => {
+  it("declares 400, 401 and 500 on /agent plus its own 400 model refusal and 502 Cursor failure", () => {
+    expect(byIdentifier(reverse, "spawn")).toMatchObject({
+      group: "Agents",
+      method: "POST",
+      path: "/agent",
+      errors: [400, 401, 500, 502],
+    });
+  });
+
+  it("leaves ProxyApi untouched: no server or agent routes and no RouteBoundary", () => {
     const table = routes(Api.ProxyApi).map(({ method, path }) => `${method} ${path}`);
     expect(table).not.toContain("POST /servers");
     expect(table).not.toContain("GET /servers");
+    expect(table).not.toContain("POST /agent");
     for (const route of routes(Api.ProxyApi)) {
       expect(route.middleware).not.toContain(Api.RouteBoundary.key);
     }

--- a/test/shared/domain.unit.test.ts
+++ b/test/shared/domain.unit.test.ts
@@ -101,6 +101,48 @@ describe("brands", () => {
   });
 });
 
+describe("model choice", () => {
+  it("accepts the six reasoning levels and refuses any other spelling", () => {
+    const is = Schema.is(Domain.Reasoning);
+    for (const level of ["none", "low", "medium", "high", "xhigh", "max"]) {
+      expect(is(level), level).toBe(true);
+    }
+    expect(is("extra-high")).toBe(false);
+    expect(is("mid")).toBe(false);
+    expect(is("")).toBe(false);
+  });
+
+  it("accepts the two agent types and refuses anything else", () => {
+    const is = Schema.is(Domain.AgentType);
+    expect(is("driving-agent")).toBe(true);
+    expect(is("diagnosing-agent")).toBe(true);
+    expect(is("developing-agent")).toBe(false);
+    expect(is("")).toBe(false);
+  });
+
+  // The label is what a driver records with `ctrl test start --model` and a reviewer with
+  // `ctrl diagnose --model`: the model, then the reasoning, then `fast` when it runs fast.
+  it("labels the default grok-4.6-high-fast", () => {
+    expect(Domain.modelLabel(Domain.DEFAULT_MODEL)).toBe("grok-4.6-high-fast");
+  });
+
+  it("labels a model by what was asked of it: id alone, with reasoning, with fast", () => {
+    expect(Domain.modelLabel({ model: "composer-2.5" })).toBe("composer-2.5");
+    expect(Domain.modelLabel({ model: "gpt-5.6-sol", reasoning: "max" })).toBe("gpt-5.6-sol-max");
+    expect(Domain.modelLabel({ model: "composer-2.5", fast: true })).toBe("composer-2.5-fast");
+    expect(Domain.modelLabel({ model: "grok-4.6", reasoning: "xhigh", fast: true })).toBe(
+      "grok-4.6-xhigh-fast",
+    );
+  });
+
+  it("leaves fast out of the label when the model is asked not to run fast", () => {
+    expect(Domain.modelLabel({ model: "grok-4.6", reasoning: "high", fast: false })).toBe(
+      "grok-4.6-high",
+    );
+    expect(Domain.modelLabel({ model: "composer-2.5", fast: false })).toBe("composer-2.5");
+  });
+});
+
 describe("QmpInbound", () => {
   const greeting = `{"QMP": {"version": {"qemu": {"micro": 0, "minor": 2, "major": 9}, "package": ""}, "capabilities": ["oob"]}}`;
   const success = `{"return": {}, "id": 1}`;

--- a/test/shared/errors.unit.test.ts
+++ b/test/shared/errors.unit.test.ts
@@ -106,6 +106,25 @@ const cases: ReadonlyArray<WireCase> = [
     error: Errors.NoServer.make({ message: "no server registered", agentId: AGENT_ID }),
     status: 503,
   },
+  {
+    name: "ModelUnavailable",
+    wire: Errors.ModelUnavailableWire,
+    error: Errors.ModelUnavailable.make({
+      message: 'model "composer-2.5" has no reasoning level',
+      model: "composer-2.5",
+    }),
+    status: 400,
+  },
+  {
+    name: "CursorAgentFailed",
+    wire: Errors.CursorAgentFailedWire,
+    error: Errors.CursorAgentFailed.make({
+      message: "Invalid API key",
+      retryable: false,
+      cause: new Error("Invalid API key"),
+    }),
+    status: 502,
+  },
 ];
 
 describe("API error wire codecs", () => {

--- a/test/support/cursor-catalog.ts
+++ b/test/support/cursor-catalog.ts
@@ -1,0 +1,136 @@
+import type { ModelListItem } from "@cursor/sdk";
+
+// Six entries of the catalog `Cursor.models.list()` answered on 2026-09-09, each cut to the
+// fields the mapping reads (id, aliases, parameters); the variants are dropped. Between them they
+// cover every way a vendor spells its knobs: `effort`, `reasoning` (with `extra-high` for the
+// level we call `xhigh`), `reasoning_effort`, a `fast` switch, and a model with no knobs at all.
+export const GROK_4_6: ModelListItem = {
+  id: "grok-4.6",
+  displayName: "Cursor Grok 4.6",
+  parameters: [
+    {
+      id: "effort",
+      displayName: "Effort",
+      values: [
+        { value: "low", displayName: "Low" },
+        { value: "medium", displayName: "Medium" },
+        { value: "high", displayName: "High" },
+        { value: "xhigh", displayName: "Extra High" },
+      ],
+    },
+    {
+      id: "fast",
+      displayName: "Fast",
+      values: [{ value: "false" }, { value: "true", displayName: "Fast\u200b\u200b" }],
+    },
+  ],
+};
+
+export const COMPOSER_2_5: ModelListItem = {
+  id: "composer-2.5",
+  displayName: "Composer 2.5",
+  aliases: ["composer-latest", "composer", "composer-2-5"],
+  parameters: [
+    {
+      id: "fast",
+      displayName: "Fast",
+      values: [{ value: "false" }, { value: "true", displayName: "Fast" }],
+    },
+  ],
+};
+
+export const GPT_5_5: ModelListItem = {
+  id: "gpt-5.5",
+  displayName: "GPT-5.5",
+  aliases: ["gpt-5-5"],
+  parameters: [
+    {
+      id: "context",
+      displayName: "Context",
+      values: [
+        { value: "272k", displayName: "272K" },
+        { value: "1m", displayName: "1M" },
+      ],
+    },
+    {
+      id: "reasoning",
+      displayName: "Reasoning",
+      values: [
+        { value: "none", displayName: "None" },
+        { value: "low", displayName: "Low" },
+        { value: "medium", displayName: "Medium" },
+        { value: "high", displayName: "High" },
+        { value: "extra-high", displayName: "Extra High" },
+      ],
+    },
+    {
+      id: "fast",
+      displayName: "Fast",
+      values: [{ value: "false" }, { value: "true", displayName: "Fast" }],
+    },
+  ],
+};
+
+export const GEMINI_3_8_FLASH: ModelListItem = {
+  id: "gemini-3.8-flash",
+  displayName: "Gemini 3.8 Flash",
+  parameters: [
+    {
+      id: "reasoning_effort",
+      displayName: "Effort",
+      values: [
+        { value: "low", displayName: "Low" },
+        { value: "medium", displayName: "Medium" },
+        { value: "high", displayName: "High" },
+      ],
+    },
+  ],
+};
+
+export const CLAUDE_OPUS_5: ModelListItem = {
+  id: "claude-opus-5",
+  displayName: "Claude Opus 5",
+  aliases: ["opus-latest", "opus", "opus-5"],
+  parameters: [
+    { id: "thinking", displayName: "Thinking", values: [{ value: "false" }, { value: "true" }] },
+    {
+      id: "context",
+      displayName: "Context",
+      values: [
+        { value: "300k", displayName: "300K" },
+        { value: "1m", displayName: "1M" },
+      ],
+    },
+    {
+      id: "effort",
+      displayName: "Effort",
+      values: [
+        { value: "low", displayName: "Low" },
+        { value: "medium", displayName: "Medium" },
+        { value: "high", displayName: "High" },
+        { value: "xhigh", displayName: "Extra High" },
+        { value: "max", displayName: "Max" },
+      ],
+    },
+    {
+      id: "fast",
+      displayName: "Fast",
+      values: [{ value: "false" }, { value: "true", displayName: "Fast" }],
+    },
+  ],
+};
+
+export const GEMINI_3_1_PRO: ModelListItem = {
+  id: "gemini-3.1-pro",
+  displayName: "Gemini 3.1 Pro",
+  aliases: ["gemini-latest", "gemini-pro-latest", "gemini", "gemini-pro"],
+};
+
+export const CATALOG: ReadonlyArray<ModelListItem> = [
+  GROK_4_6,
+  COMPOSER_2_5,
+  GPT_5_5,
+  GEMINI_3_8_FLASH,
+  CLAUDE_OPUS_5,
+  GEMINI_3_1_PRO,
+];

--- a/test/support/fake-cursor.ts
+++ b/test/support/fake-cursor.ts
@@ -1,11 +1,11 @@
-import type { ModelSelection } from "@cursor/sdk";
 import { Effect, Layer } from "effect";
 import * as Cursor from "../../src/ctrl/cursor.ts";
+import type * as Domain from "../../src/shared/domain.ts";
 import type * as Errors from "../../src/shared/errors.ts";
 
 export type PromptCall = {
   readonly text: string;
-  readonly model: ModelSelection | undefined;
+  readonly choice: Domain.ModelChoice | undefined;
 };
 
 export type FakeCursor = {
@@ -19,14 +19,14 @@ export const DEFAULT_AGENT_ID = "bc-11111111-1111-4111-8111-111111111111";
 export const fakeCursor = (
   script: {
     readonly agentId?: string;
-    readonly failure?: Errors.CursorAgentFailed;
+    readonly failure?: Errors.CursorAgentFailed | Errors.ModelUnavailable;
   } = {},
 ): FakeCursor => {
   const calls: Array<PromptCall> = [];
   const service: Cursor.CursorAgentsService = {
-    prompt: (text, model) =>
+    prompt: (text, choice) =>
       Effect.suspend(() => {
-        calls.push({ text, model });
+        calls.push({ text, choice });
         return script.failure === undefined
           ? Effect.succeed({ agentId: script.agentId ?? DEFAULT_AGENT_ID })
           : Effect.fail(script.failure);

--- a/test/support/stub-cursor.ts
+++ b/test/support/stub-cursor.ts
@@ -1,5 +1,7 @@
 import { once } from "node:events";
 import { createServer, type Server } from "node:http";
+import type { ModelListItem } from "@cursor/sdk";
+import * as Catalog from "./cursor-catalog.ts";
 
 export type CursorRequest = {
   readonly method: string | undefined;
@@ -26,13 +28,14 @@ const readBody = (incoming: import("node:http").IncomingMessage): Promise<string
     incoming.on("end", () => resolve(body));
   });
 
-// A stand-in for api.cursor.com that @cursor/sdk reaches through CURSOR_BACKEND_URL: it lists one
-// model and creates whatever agent it is asked for, echoing the id the SDK minted.
+// A stand-in for api.cursor.com that @cursor/sdk reaches through CURSOR_BACKEND_URL: it lists the
+// catalog it is given (grok-4.6 with its knobs, as captured) and creates whatever agent it is
+// asked for, echoing the id the SDK minted.
 export const startStubCursor = async (
-  options: { readonly models?: ReadonlyArray<string> } = {},
+  options: { readonly models?: ReadonlyArray<ModelListItem> } = {},
 ): Promise<StubCursor> => {
   const requests: Array<CursorRequest> = [];
-  const models = options.models ?? ["grok-4.6"];
+  const models = options.models ?? [Catalog.GROK_4_6];
   const server: Server = createServer((incoming, response) => {
     void readBody(incoming).then((body) => {
       requests.push({
@@ -43,11 +46,7 @@ export const startStubCursor = async (
       });
       if (incoming.method === "GET" && incoming.url === "/v1/models") {
         response.writeHead(200, { "Content-Type": "application/json" });
-        response.end(
-          JSON.stringify({
-            items: models.map((id) => ({ id, displayName: `Cursor ${id}` })),
-          }),
-        );
+        response.end(JSON.stringify({ items: models }));
         return;
       }
       if (incoming.method === "POST" && incoming.url === "/v1/agents") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The reverse proxy gains one intelligent route: `POST /agent`. Behind the shared bearer (`Authorization: Bearer <OLIGARCHY_TOKEN>`, the key every route of the process already requires) it takes

```json
{ "task": "OLI-42", "type": "driving-agent" | "diagnosing-agent", "model"?: "grok-4.6", "reasoning"?: "none|low|medium|high|xhigh|max", "fast"?: true }
```

renders the driving or diagnosing prompt for the task (the Linear ticket for a driver, the session id for a reviewer), starts one Cursor cloud agent on the model asked for (`grok-4.6` at `high`, `fast` when none is named), and answers `{ "id", "url", "model" }` where `model` is the label the agent was told to record (`grok-4.6-high-fast`). It logs `agent spawned; <type>; <task>; <model>; <url>`.

`CursorAgents.prompt(text, choice?)` is the spawning interface: a vendor-neutral `ModelChoice` `{ model, reasoning?, fast? }` mapped onto Cursor's catalog (`Cursor.models.list()`) at spawn time by a pure `select()`. A model the catalog does not list, a reasoning level the model does not offer, or `fast` on a model without the switch is refused with `ModelUnavailable` (400) naming what the model does take; a Cursor failure is `CursorAgentFailed` (502). Each vendor's spelling of the knob (`effort`, `reasoning`, `reasoning_effort`, `extra-high`) is the mapping's business, not the caller's.

## Also

- The driving and diagnosing prompts both carry the model label the agent must record; `ctrl diagnose run` takes `--model` like `test run`.
- The default model moves from `grok-4.6` xhigh fast to `grok-4.6` high fast.
- The reverse proxy reads `CURSOR_API_TOKEN` at startup, reported after `OLIGARCHY_TOKEN` and `DATABASE_URL`.
- `SERVER_VS_REVERSE_PROXY.md` documents the route, its refusals, the decisions and what was deliberately left out; `ctrl.md` the flag changes.

## Tests and evidence

Written first: `test/shared/{domain,errors,api}.unit.test.ts`, `test/ctrl/{cursor,prompts,command}.unit.test.ts`, `test/reverse-proxy/http.unit.test.ts` (nine `/agent` cases, happy and unhappy), the ctrl and reverse-proxy integration lanes against the stub Cursor API with a catalog fixture captured from `Cursor.models.list()`.

- `npm run check:fast`: 42 files, 872 tests green.
- ctrl and reverse-proxy integration lanes: 38/38 green against a local Postgres (the serving test POSTs `/agent` through the real `@cursor/sdk` to the stub).
- Black-box: `./reverse-proxy` against a local database and the stub, nine `curl` cases (200s with the link and label, the catalog's 400s, the uuid 400, the contract's 400, 401), the `logs` rows they left.
- The mapping run read-only against Cursor's live catalog (40 models): defaults, aliases, every knob spelling, and the refusals come out as specified. No real agent was created.

Reviewed by a Sol subagent per `development.md`; one finding applied (a refusal lists levels in our vocabulary), three declined and recorded under "Deliberately not done".

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-307b1faa-207e-41f9-a03d-cfdaaf0631cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-307b1faa-207e-41f9-a03d-cfdaaf0631cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

