### PR TITLE
Automation service: POST /automate on 127.0.0.1:54321 records the Linear ticket and the model

### DIFF
--- a/automation
+++ b/automation
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node --experimental-strip-types --import "$(dirname "$0")/src/observability/instrument.ts" "$(dirname "$0")/src/automation/main.ts" "$@"

--- a/development.md
+++ b/development.md
@@ -741,8 +741,9 @@ statement inside with `Client.attempt("endSession", () => tx.update(...))`.
   finalizer runs `flush` before the drain fiber is interrupted, and `Log.layer` (over `LogStore`)
   sits above `Database` so the flush completes before the pool closes. `Log.layer` reads
   `ErrorReporter.CurrentErrorReporters` once at build, so `SentryLive` is provided beneath it,
-  never only to callers. `Log.layerStdout` persists nothing and is for tests. A fatal path flushes
-  the log, then Sentry, then exits.
+  never only to callers. `Log.layerStdout` persists nothing: it is for tests and for a process
+  that keeps no rows (the automation service), whose record is stdout and Sentry. A fatal path
+  flushes the log, then Sentry, then exits.
 - `Log` installs no Effect `Logger`; `emit` formats, writes and offers synchronously. `console.*`
   appears only in `src/dashboard/**` and `vitest.global-setup.ts`. Test log output through the
   fake `Log` layer (`test/support/log.ts`) or `Log.layerStdout` with `TestConsole.logLines`.

--- a/development.md
+++ b/development.md
@@ -15,7 +15,7 @@ exist.
 ## Toolchain
 
 - Run on Node 26 with npm. Every executable is a `#!/bin/sh` wrapper running
-  `node --experimental-strip-types` (`./server` and `./reverse-proxy` add
+  `node --experimental-strip-types` (`./server`, `./reverse-proxy` and `./automation` add
   `--import ./src/observability/instrument.ts`); types are stripped, not transformed, so
   `erasableSyntaxOnly` stays on.
 - Install with `npm ci`; `prepare` runs `effect-tsgo patch --oxlint` so the `effecttsgo/*` rules
@@ -69,8 +69,9 @@ Durable preferences from the maintainer; when they conflict with generic best pr
 ## Layout
 
 - The root holds `AGENTS.md`, the executable wrappers (`./client`, `./client-with-image`,
-  `./ctrl`, `./server`, `./reverse-proxy`, `./session`), the tooling files, `drizzle/` (migrations), `public/` and
-  `prompts/`, the operator documents, this document, `src/` and `test/`.
+  `./ctrl`, `./server`, `./reverse-proxy`, `./automation`, `./session`), the tooling files,
+  `drizzle/` (migrations), `public/` and `prompts/`, the operator documents, this document, `src/`
+  and `test/`.
 - `src/` is one directory per process plus the shared kernel (`src/shared/`, `src/config.ts`,
   `src/external-failure.ts`, `src/observability/`, `src/db/`); `main.ts` files are the entries.
 - `src/dashboard/` is a Hono Worker, not Effect: it has no Effect runtime, reaches Postgres
@@ -749,7 +750,7 @@ statement inside with `Client.attempt("endSession", () => tx.update(...))`.
 ## Sentry
 
 - Initialise the SDK before any Effect code in `src/observability/instrument.ts`, loaded by the
-  `server` and `reverse-proxy` wrappers' `--import`: `Sentry.init({ dsn: SENTRY_DSN,
+  `server`, `reverse-proxy` and `automation` wrappers' `--import`: `Sentry.init({ dsn: SENTRY_DSN,
   tracesSampleRate: 1,
   traceLifecycle: "stream", integrations: [Sentry.httpIntegration({ spans: false }),
   Sentry.nativeNodeFetchIntegration({ spans: false })] })`. `SENTRY_DSN` in `dsn.ts` is the one

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "session": "node --experimental-strip-types src/session/main.ts",
     "server": "node --experimental-strip-types --import ./src/observability/instrument.ts src/proxy/main.ts",
     "reverse-proxy": "node --experimental-strip-types --import ./src/observability/instrument.ts src/reverse-proxy/main.ts",
+    "automation": "node --experimental-strip-types --import ./src/observability/instrument.ts src/automation/main.ts",
     "dev": "wrangler dev --remote",
     "check:lint": "oxlint --deny-warnings .",
     "check:format": "oxfmt --check .",

--- a/prompts/linear-issue.html
+++ b/prompts/linear-issue.html
@@ -12,6 +12,7 @@ Test driver. Drive one Omarchy virtual machine through ./client, record the resu
   <rule>Never wait more than 5 seconds between commands. Image instead.</rule>
   <rule>When you are done, spawn a {{SUB_AGENT}} subagent and have it analyze your session to see if the proof is on screen and use ./ctrl test-results to finalize the result, then ./client stop to end the session.</rule>
   <rule>When you believe you have completed a task and it has ended in failure, please write the serial dump to the linear ticket.</rule>
+  <rule>Do not upload images to linear.</rule>
 </rules>
 
 <run>
@@ -55,8 +56,10 @@ Test driver. Drive one Omarchy virtual machine through ./client, record the resu
 
 <example-session>
 ```
+# Use Linear MCP to ensure ticket is "In Progress"
 $ ./client start --agent-id {{LINEAR_TICKET}} --server-url {{SERVER_URL}} --iso {{ISO_URL}}
 6f1c...e2a9
+# Use Linear MCP to make a comment `session-id=6f1c...e2a9`
 # Before starting any intent, always link the test result to the session.
 $ ./ctrl test start --session-id 6f1c...e2a9 --test-result-id {{RESULT_ID}} --model <the Cursor model id you are running as>
 
@@ -73,5 +76,6 @@ $ ./client intent end --agent-id {{LINEAR_TICKET}} --server-url {{SERVER_URL}} -
 # when the proof is on screen, close the result, then the session
 $ ./ctrl test-results --agent-id {{LINEAR_TICKET}} --id {{RESULT_ID}} --status success
 $ ./client stop --agent-id {{LINEAR_TICKET}} --server-url {{SERVER_URL}} --session-id 6f1c...e2a9 --status succeeded
+# Use Linear MCP to ensure ticket is "Needs Review"
 ```
 </example-session>

--- a/src/automation/command.ts
+++ b/src/automation/command.ts
@@ -1,11 +1,8 @@
 import { Deferred, Effect, Layer } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import type { HttpServerError } from "effect/unstable/http";
-import * as Client from "../db/client.ts";
-import * as ExternalFailure from "../external-failure.ts";
 import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
-import * as Errors from "../shared/errors.ts";
 
 // The port the operator's tunnel points at; nothing else of ours is near it.
 const DEFAULT_PORT = 54321;
@@ -17,12 +14,7 @@ export type AutomationServer<RServe> = {
   readonly serverFailed: Deferred.Deferred<never, HttpServerError.ServeError>;
 };
 
-type StartupError = Errors.DatabaseError | HttpServerError.ServeError;
-
-// A ServeError says nothing itself; the bind or accept error it wraps does.
-const detail = (error: StartupError): string =>
-  error._tag === "ServeError" ? Render.errorDetail(error.cause) : Render.errorDetail(error);
-
+// No database to ping and no host to check: the flags parsed, the service listens.
 export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) =>
   Command.make(
     "automation",
@@ -35,25 +27,14 @@ export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) 
     ({ port }) =>
       Effect.gen(function* () {
         const log = yield* Log.Log;
-        const database = yield* Client.Database;
-        const startup = Effect.gen(function* () {
-          // The log is rows: fail at startup, not on the first request, without the database.
-          yield* database.ping.pipe(
-            Effect.mapError((error) =>
-              Errors.DatabaseError.make({
-                operation: "ping",
-                message: `database unreachable: ${Render.errorDetail(ExternalFailure.causeOf(error))}`,
-                cause: error,
-              }),
-            ),
-          );
-          return yield* Effect.raceFirst(
-            Layer.launch(server.serve(port)),
-            Deferred.await(server.serverFailed),
-          );
-        });
-        return yield* startup.pipe(
-          Effect.tapError((error) => log.fatal(`automation: ${detail(error)}`, { cause: error })),
+        return yield* Effect.raceFirst(
+          Layer.launch(server.serve(port)),
+          Deferred.await(server.serverFailed),
+        ).pipe(
+          // A ServeError says nothing itself; the bind or accept error it wraps does.
+          Effect.tapError((error) =>
+            log.fatal(`automation: ${Render.errorDetail(error.cause)}`, { cause: error }),
+          ),
         );
       }),
   ).pipe(

--- a/src/automation/command.ts
+++ b/src/automation/command.ts
@@ -1,0 +1,63 @@
+import { Deferred, Effect, Layer } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import type { HttpServerError } from "effect/unstable/http";
+import * as Client from "../db/client.ts";
+import * as ExternalFailure from "../external-failure.ts";
+import * as Log from "../observability/log.ts";
+import * as Render from "../observability/render.ts";
+import * as Errors from "../shared/errors.ts";
+
+// The port the operator's tunnel points at; nothing else of ours is near it.
+const DEFAULT_PORT = 54321;
+
+// What main.ts hands the command: the listener as a layer for its port, and the signal a server
+// error raises after listen.
+export type AutomationServer<RServe> = {
+  readonly serve: (port: number) => Layer.Layer<never, HttpServerError.ServeError, RServe>;
+  readonly serverFailed: Deferred.Deferred<never, HttpServerError.ServeError>;
+};
+
+type StartupError = Errors.DatabaseError | HttpServerError.ServeError;
+
+// A ServeError says nothing itself; the bind or accept error it wraps does.
+const detail = (error: StartupError): string =>
+  error._tag === "ServeError" ? Render.errorDetail(error.cause) : Render.errorDetail(error);
+
+export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) =>
+  Command.make(
+    "automation",
+    {
+      port: Flag.integer("port").pipe(
+        Flag.withDefault(DEFAULT_PORT),
+        Flag.withDescription("Listen port"),
+      ),
+    },
+    ({ port }) =>
+      Effect.gen(function* () {
+        const log = yield* Log.Log;
+        const database = yield* Client.Database;
+        const startup = Effect.gen(function* () {
+          // The log is rows: fail at startup, not on the first request, without the database.
+          yield* database.ping.pipe(
+            Effect.mapError((error) =>
+              Errors.DatabaseError.make({
+                operation: "ping",
+                message: `database unreachable: ${Render.errorDetail(ExternalFailure.causeOf(error))}`,
+                cause: error,
+              }),
+            ),
+          );
+          return yield* Effect.raceFirst(
+            Layer.launch(server.serve(port)),
+            Deferred.await(server.serverFailed),
+          );
+        });
+        return yield* startup.pipe(
+          Effect.tapError((error) => log.fatal(`automation: ${detail(error)}`, { cause: error })),
+        );
+      }),
+  ).pipe(
+    Command.withDescription(
+      "The oligarchy automation service: POST /automate names a Linear ticket and a model, and each request is recorded as one line in ~/automation-test",
+    ),
+  );

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -1,0 +1,47 @@
+import { Effect, FileSystem, Layer } from "effect";
+import { HttpApiBuilder } from "effect/unstable/httpapi";
+import * as Log from "../observability/log.ts";
+import * as ProxyHandlers from "../proxy/handlers.ts";
+import * as Middleware from "../proxy/middleware.ts";
+import * as Api from "../shared/api.ts";
+import * as Contract from "../shared/contract.ts";
+import * as Errors from "../shared/errors.ts";
+
+const ok = Contract.Ok.make({});
+
+// A request the service accepted is recorded whole or not at all: a client gone mid-request
+// must not leave the line written and the log without it.
+const uninterruptible = { uninterruptible: true } as const;
+
+// POST /automate, for now: one line per request appended to `record`, naming the ticket and the
+// model as they came. Spawning the agent those two describe is the next step and lands here.
+export const AutomationsLive = (record: string) =>
+  HttpApiBuilder.group(Api.AutomationApi, "Automations", (handlers) =>
+    handlers.handle(
+      "automate",
+      ({ payload }) =>
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const log = yield* Log.Log;
+          yield* fs
+            .writeFileString(record, `linear ticket ${payload.ticket}; model ${payload.model}\n`, {
+              flag: "a",
+            })
+            .pipe(
+              Effect.mapError((cause) => Errors.Internal.make({ cause, agentId: payload.ticket })),
+            );
+          yield* log.info(`automation recorded; ${payload.model}`, { agentId: payload.ticket });
+          return ok;
+        }),
+      uninterruptible,
+    ),
+  );
+
+export const routes = (record: string) =>
+  Layer.mergeAll(
+    HttpApiBuilder.layer(Api.AutomationApi).pipe(
+      Layer.provide(AutomationsLive(record)),
+      Layer.provide(Layer.mergeAll(Middleware.BearerAuthLive, Middleware.ApiBoundaryLive)),
+    ),
+    ProxyHandlers.NotFoundRoute,
+  );

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -9,31 +9,24 @@ import * as Errors from "../shared/errors.ts";
 
 const ok = Contract.Ok.make({});
 
-// A request the service accepted is recorded whole or not at all: a client gone mid-request
-// must not leave the line written and the log without it.
-const uninterruptible = { uninterruptible: true } as const;
-
 // POST /automate, for now: one line per request appended to `record`, naming the ticket and the
 // model as they came. Spawning the agent those two describe is the next step and lands here.
 export const AutomationsLive = (record: string) =>
   HttpApiBuilder.group(Api.AutomationApi, "Automations", (handlers) =>
-    handlers.handle(
-      "automate",
-      ({ payload }) =>
-        Effect.gen(function* () {
-          const fs = yield* FileSystem.FileSystem;
-          const log = yield* Log.Log;
-          yield* fs
-            .writeFileString(record, `linear ticket ${payload.ticket}; model ${payload.model}\n`, {
-              flag: "a",
-            })
-            .pipe(
-              Effect.mapError((cause) => Errors.Internal.make({ cause, agentId: payload.ticket })),
-            );
-          yield* log.info(`automation recorded; ${payload.model}`, { agentId: payload.ticket });
-          return ok;
-        }),
-      uninterruptible,
+    handlers.handle("automate", ({ payload }) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const log = yield* Log.Log;
+        yield* fs
+          .writeFileString(record, `linear ticket ${payload.ticket}; model ${payload.model}\n`, {
+            flag: "a",
+          })
+          .pipe(
+            Effect.mapError((cause) => Errors.Internal.make({ cause, agentId: payload.ticket })),
+          );
+        yield* log.info(`automation recorded; ${payload.model}`, { agentId: payload.ticket });
+        return ok;
+      }),
     ),
   );
 

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -37,11 +37,12 @@ export const AutomationsLive = (record: string) =>
     ),
   );
 
+// The bearer is left to the graph: this service has no ProxyConfig to read the token from.
 export const routes = (record: string) =>
   Layer.mergeAll(
     HttpApiBuilder.layer(Api.AutomationApi).pipe(
       Layer.provide(AutomationsLive(record)),
-      Layer.provide(Layer.mergeAll(Middleware.BearerAuthLive, Middleware.ApiBoundaryLive)),
+      Layer.provide(Middleware.ApiBoundaryLive),
     ),
     ProxyHandlers.NotFoundRoute,
   );

--- a/src/automation/main.ts
+++ b/src/automation/main.ts
@@ -1,0 +1,87 @@
+import { createServer } from "node:http";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Cause, Deferred, Effect, Exit, Layer, type Runtime } from "effect";
+import { Command } from "effect/unstable/cli";
+import { HttpMiddleware, HttpRouter, HttpServerError } from "effect/unstable/http";
+import * as Config from "../config.ts";
+import * as Client from "../db/client.ts";
+import * as Logs from "../db/logs.ts";
+import * as Log from "../observability/log.ts";
+import * as Render from "../observability/render.ts";
+import * as Sentry from "../observability/sentry.ts";
+import * as Api from "../shared/api.ts";
+import * as AutomationCommand from "./command.ts";
+import * as Handlers from "./handlers.ts";
+
+const HOST = "127.0.0.1";
+
+// Where every request lands, one line each, in the operator's home directory as they asked.
+const RECORD = join(homedir(), "automation-test");
+
+// stdout is the convenience copy of the log; the rows and Sentry are the record. A write refused
+// by a full filesystem is dropped, never an uncaught exception per line (see the proxy's main).
+process.stdout.on("error", () => {});
+process.stderr.on("error", () => {});
+
+// The platform drops its error listener once the server is up; a later error still needs the
+// fatal line and exit 1. Only the first counts.
+const server = createServer();
+const serverFailed = Deferred.makeUnsafe<never, HttpServerError.ServeError>();
+server.on("error", (cause) => {
+  Deferred.doneUnsafe(serverFailed, Exit.fail(new HttpServerError.ServeError({ cause })));
+});
+
+const ServerLive = (port: number) =>
+  Layer.effectDiscard(
+    Effect.gen(function* () {
+      const log = yield* Log.Log;
+      yield* log.info(
+        `oligarchy automation listening on ${HOST}:${String(port)}; recording to ${RECORD}`,
+      );
+    }),
+  ).pipe(
+    Layer.provide(
+      HttpRouter.serve(Handlers.routes(RECORD), {
+        disableLogger: true,
+        disableListenLog: true,
+      }).pipe(Layer.provide(NodeHttpServer.layer(() => server, { host: HOST, port }))),
+    ),
+    // As on the proxy: no http.server span reaches Sentry.
+    Layer.provide(Layer.succeed(HttpMiddleware.TracerDisabledWhen)(() => true)),
+  );
+
+const DatabaseLive = Layer.unwrap(
+  Effect.map(Config.ProxyConfig, (config) => Client.Database.layer(config.databaseUrl)),
+);
+
+// Sentry sits beneath Log so the log rows flush before Sentry does, and Log captures the reporter.
+const MainLive = Log.Log.layer.pipe(
+  Layer.provideMerge(Logs.LogStore.layer),
+  Layer.provideMerge(DatabaseLive),
+  Layer.provideMerge(Config.ProxyConfig.layer),
+  Layer.provideMerge(Sentry.SentryLive),
+  Layer.provideMerge(Config.providerLayer),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const command = AutomationCommand.makeAutomationCommand({ serve: ServerLive, serverFailed });
+
+// The graph is built before the command runs: a missing variable or a bad DATABASE_URL is the one
+// failure no Log exists to record, so it is printed here. Every later failure logs its own fatal
+// line; a defect has nothing else to say for it.
+const program = Effect.gen(function* () {
+  const services = yield* Layer.build(MainLive).pipe(Effect.tapCause(Render.reportFailure));
+  yield* Command.run(command, { version: Api.VERSION }).pipe(
+    Effect.provide(services),
+    Effect.tapDefect((defect) => Render.reportFailure(Cause.die(defect))),
+  );
+}).pipe(Effect.scoped);
+
+// SIGINT and SIGTERM interrupt the program and exit 0; nothing of this process's own is stopping.
+const teardown: Runtime.Teardown = (exit, onExit) => {
+  onExit(Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause) ? 1 : 0);
+};
+
+NodeRuntime.runMain(program, { disableErrorReporting: true, teardown });

--- a/src/automation/main.ts
+++ b/src/automation/main.ts
@@ -6,11 +6,10 @@ import { Cause, Deferred, Effect, Exit, Layer, type Runtime } from "effect";
 import { Command } from "effect/unstable/cli";
 import { HttpMiddleware, HttpRouter, HttpServerError } from "effect/unstable/http";
 import * as Config from "../config.ts";
-import * as Client from "../db/client.ts";
-import * as Logs from "../db/logs.ts";
 import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
 import * as Sentry from "../observability/sentry.ts";
+import * as Middleware from "../proxy/middleware.ts";
 import * as Api from "../shared/api.ts";
 import * as AutomationCommand from "./command.ts";
 import * as Handlers from "./handlers.ts";
@@ -20,8 +19,8 @@ const HOST = "127.0.0.1";
 // Where every request lands, one line each, in the operator's home directory as they asked.
 const RECORD = join(homedir(), "automation-test");
 
-// stdout is the convenience copy of the log; the rows and Sentry are the record. A write refused
-// by a full filesystem is dropped, never an uncaught exception per line (see the proxy's main).
+// stdout is the convenience copy of the log; Sentry is the record. A write refused by a full
+// filesystem is dropped, never an uncaught exception per line (see the proxy's main).
 process.stdout.on("error", () => {});
 process.stderr.on("error", () => {});
 
@@ -52,15 +51,12 @@ const ServerLive = (port: number) =>
     Layer.provide(Layer.succeed(HttpMiddleware.TracerDisabledWhen)(() => true)),
   );
 
-const DatabaseLive = Layer.unwrap(
-  Effect.map(Config.ProxyConfig, (config) => Client.Database.layer(config.databaseUrl)),
-);
+// OLIGARCHY_TOKEN is the one variable this process reads.
+const BearerLive = Layer.unwrap(Effect.map(Config.oligarchyToken, Middleware.bearerAuth));
 
-// Sentry sits beneath Log so the log rows flush before Sentry does, and Log captures the reporter.
-const MainLive = Log.Log.layer.pipe(
-  Layer.provideMerge(Logs.LogStore.layer),
-  Layer.provideMerge(DatabaseLive),
-  Layer.provideMerge(Config.ProxyConfig.layer),
+// No database: this service keeps no rows, so its log is stdout and Sentry. Sentry sits beneath
+// Log so Log captures the reporter.
+const MainLive = Layer.mergeAll(Log.Log.layerStdout, BearerLive).pipe(
   Layer.provideMerge(Sentry.SentryLive),
   Layer.provideMerge(Config.providerLayer),
   Layer.provideMerge(NodeServices.layer),
@@ -68,9 +64,9 @@ const MainLive = Log.Log.layer.pipe(
 
 const command = AutomationCommand.makeAutomationCommand({ serve: ServerLive, serverFailed });
 
-// The graph is built before the command runs: a missing variable or a bad DATABASE_URL is the one
-// failure no Log exists to record, so it is printed here. Every later failure logs its own fatal
-// line; a defect has nothing else to say for it.
+// The graph is built before the command runs: a missing OLIGARCHY_TOKEN is the one failure no Log
+// exists to record, so it is printed here. Every later failure logs its own fatal line; a defect
+// has nothing else to say for it.
 const program = Effect.gen(function* () {
   const services = yield* Layer.build(MainLive).pipe(Effect.tapCause(Render.reportFailure));
   yield* Command.run(command, { version: Api.VERSION }).pipe(

--- a/src/observability/log.ts
+++ b/src/observability/log.ts
@@ -206,7 +206,7 @@ export class Log extends Context.Service<Log>()("@oligarchy/observability/Log", 
   }),
 }) {
   static readonly layer: Layer.Layer<Log, never, Logs.LogStore> = Layer.effect(this)(this.make);
-  // stdout only, no rows: tests and the CLIs that have no database.
+  // stdout only, no rows: tests and the processes that have no database (the automation service).
   static readonly layerStdout: Layer.Layer<Log> = Layer.effect(this)(
     makeLog(() => Effect.succeed(stdoutOnly)),
   );

--- a/src/proxy/middleware.ts
+++ b/src/proxy/middleware.ts
@@ -10,19 +10,20 @@ import * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 
 // Every route carries `Authorization: Bearer <OLIGARCHY_TOKEN>`; the compare is exact, as it
-// always was.
-export const BearerAuthLive: Layer.Layer<Api.BearerAuth, never, Config.ProxyConfig> = Layer.effect(
-  Api.BearerAuth,
-)(
-  Effect.gen(function* () {
-    const config = yield* Config.ProxyConfig;
-    return Api.BearerAuth.of({
+// always was. The token comes in as a value: the servers read it from ProxyConfig beside their
+// database url, the automation service reads it alone.
+export const bearerAuth = (token: Redacted.Redacted): Layer.Layer<Api.BearerAuth> =>
+  Layer.succeed(Api.BearerAuth)(
+    Api.BearerAuth.of({
       bearer: (httpEffect, { credential }) =>
-        Redacted.value(credential) === Redacted.value(config.token)
+        Redacted.value(credential) === Redacted.value(token)
           ? httpEffect
           : Effect.fail(Errors.Unauthorized.make({})),
-    });
-  }),
+    }),
+  );
+
+export const BearerAuthLive: Layer.Layer<Api.BearerAuth, never, Config.ProxyConfig> = Layer.unwrap(
+  Effect.map(Config.ProxyConfig, (config) => bearerAuth(config.token)),
 );
 
 const isApiError: (value: unknown) => value is Errors.ApiError = Schema.is(

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -163,4 +163,18 @@ export class ReverseProxyApi extends HttpApi.make("OligarchyReverseProxy")
   .add(RoutedSessions)
   .add(Servers) {}
 
+// The automation service: one request names the Linear ticket to drive and the model to drive
+// it with; bearer required. It neither forwards nor places, so the proxy's own boundary suffices.
+export const automate = HttpApiEndpoint.post("automate", "/automate", {
+  payload: Contract.AutomateBody,
+  success: Contract.Ok,
+});
+
+export class Automations extends HttpApiGroup.make("Automations")
+  .add(automate)
+  .middleware(BearerAuth)
+  .middleware(ApiBoundary) {}
+
+export class AutomationApi extends HttpApi.make("OligarchyAutomation").add(Automations) {}
+
 export const VERSION = "0.0.0";

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -101,6 +101,15 @@ export class Servers extends Schema.Class<Servers>("@oligarchy/shared/contract/S
   servers: Schema.Array(Server),
 }) {}
 
+// POST /automate on the automation service: the Linear ticket to drive and the model to drive it
+// with, both as the caller spelled them.
+export class AutomateBody extends Schema.Class<AutomateBody>(
+  "@oligarchy/shared/contract/AutomateBody",
+)({
+  ticket: Schema.NonEmptyString,
+  model: Schema.NonEmptyString,
+}) {}
+
 const STORED_IMAGE_ORIGIN = "https://oligarchy.trm.sh";
 
 export const StoredImageUrl = (id: string): string => `${STORED_IMAGE_ORIGIN}/images/${id}`;

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -101,13 +101,18 @@ export class Servers extends Schema.Class<Servers>("@oligarchy/shared/contract/S
   servers: Schema.Array(Server),
 }) {}
 
+// The record is one line per request, so a value with a line break in it is refused, not folded.
+const oneLine = Schema.NonEmptyString.check(
+  Schema.isPattern(/^[^\r\n]*$/, { message: "must not contain a line break" }),
+);
+
 // POST /automate on the automation service: the Linear ticket to drive and the model to drive it
 // with, both as the caller spelled them.
 export class AutomateBody extends Schema.Class<AutomateBody>(
   "@oligarchy/shared/contract/AutomateBody",
 )({
-  ticket: Schema.NonEmptyString,
-  model: Schema.NonEmptyString,
+  ticket: oneLine,
+  model: oneLine,
 }) {}
 
 const STORED_IMAGE_ORIGIN = "https://oligarchy.trm.sh";

--- a/test/automation/command.unit.test.ts
+++ b/test/automation/command.unit.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import {
+  Cause,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Layer,
+  Path,
+  Redacted,
+  Stdio,
+  Terminal,
+} from "effect";
+import { TestConsole } from "effect/testing";
+import { Command } from "effect/unstable/cli";
+import { HttpServerError } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import * as AutomationCommand from "../../src/automation/command.ts";
+import * as Client from "../../src/db/client.ts";
+import * as Api from "../../src/shared/api.ts";
+import * as Errors from "../../src/shared/errors.ts";
+import * as FakeLog from "../support/log.ts";
+
+const CliTestLayer = Layer.mergeAll(
+  FileSystem.layerNoop({}),
+  Path.layer,
+  Stdio.layerTest({}),
+  Layer.succeed(Terminal.Terminal)(
+    Terminal.make({
+      columns: Effect.succeed(80),
+      rows: Effect.succeed(24),
+      readInput: Effect.die("unused"),
+      readLine: Effect.die("unused"),
+      display: () => Effect.void,
+    }),
+  ),
+  Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+    ChildProcessSpawner.make(() => Effect.die("unused")),
+  ),
+);
+
+const UNREACHABLE = "postgres://user:pw@127.0.0.1:1/oligarchy";
+
+// A Database whose ping is scripted; the pool never connects, so nothing touches the network.
+const fakeDatabase = (ping: Effect.Effect<void, Errors.DatabaseError>) =>
+  Layer.effect(Client.Database)(
+    Effect.map(Client.Database.make(Redacted.make(UNREACHABLE)), (database) => ({
+      ...database,
+      ping,
+    })),
+  );
+
+const refused = Errors.DatabaseError.make({
+  operation: "ping",
+  message: "Failed query: select 1",
+  cause: new Error("connect ECONNREFUSED 127.0.0.1:1"),
+});
+
+// The server layer and the failure signal the command is built from.
+const fakeServer = () => {
+  const served: Array<number> = [];
+  const listening = Deferred.makeUnsafe<void>();
+  const serverFailed = Deferred.makeUnsafe<never, HttpServerError.ServeError>();
+  const server: AutomationCommand.AutomationServer<never> = {
+    serve: (port) =>
+      Layer.effectDiscard(
+        Effect.gen(function* () {
+          served.push(port);
+          yield* Deferred.succeed(listening, undefined);
+        }),
+      ),
+    serverFailed,
+  };
+  return { served, listening, serverFailed, server };
+};
+
+const run = (
+  server: AutomationCommand.AutomationServer<never>,
+  args: ReadonlyArray<string>,
+  log: FakeLog.FakeLog,
+  ping: Effect.Effect<void, Errors.DatabaseError> = Effect.void,
+) =>
+  Command.runWith(AutomationCommand.makeAutomationCommand(server), { version: Api.VERSION })(
+    args,
+  ).pipe(Effect.provide(Layer.mergeAll(CliTestLayer, log.layer, fakeDatabase(ping))));
+
+describe("automation command flags", () => {
+  it.effect("--port must be an integer", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(run(fake.server, ["--port", "forty"], log));
+      expect(error._tag).toBe("ShowHelp");
+      expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("--help prints the help, succeeds and touches nothing", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const exit = yield* Effect.exit(run(fake.server, ["--help"], log, Effect.fail(refused)));
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([]);
+      const stdout = yield* TestConsole.logLines;
+      expect(stdout.join("\n")).toContain("--port");
+      expect(stdout.join("\n")).not.toContain("--diagnostics-port");
+      expect(stdout.join("\n")).not.toContain("--display");
+    }),
+  );
+
+  it.effect("defaults to port 54321 and pings the database first", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const fiber = yield* Effect.forkChild(run(fake.server, [], log));
+      yield* Deferred.await(fake.listening);
+      yield* Fiber.interrupt(fiber);
+      const exit = yield* Fiber.await(fiber);
+      expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+      expect(fake.served).toEqual([54321]);
+      expect(log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("--port 1234 reaches the server as given", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const fiber = yield* Effect.forkChild(run(fake.server, ["--port", "1234"], log));
+      yield* Deferred.await(fake.listening);
+      yield* Fiber.interrupt(fiber);
+      expect(fake.served).toEqual([1234]);
+    }),
+  );
+});
+
+describe("automation command startup failures", () => {
+  it.effect("an unreachable database fails before listening as database unreachable", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(run(fake.server, [], log, Effect.fail(refused)));
+      expect(error).toMatchObject({
+        _tag: "DatabaseError",
+        operation: "ping",
+        message: "database unreachable: connect ECONNREFUSED 127.0.0.1:1",
+      });
+      expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([
+        {
+          level: "fatal",
+          text: "automation: database unreachable: connect ECONNREFUSED 127.0.0.1:1",
+          sessionId: undefined,
+          agentId: undefined,
+          skipSentry: false,
+          cause: error,
+        },
+      ]);
+    }),
+  );
+
+  it.effect("a ping failure without a nested cause reports the driver's own message", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(
+        run(
+          fake.server,
+          [],
+          log,
+          Effect.fail(Errors.DatabaseError.make({ operation: "ping", message: "pool ended" })),
+        ),
+      );
+      expect(error).toMatchObject({ message: "database unreachable: pool ended" });
+      expect(log.lines[0]?.text).toBe("automation: database unreachable: pool ended");
+    }),
+  );
+
+  it.effect("a server error after listen fails the handler with the error's detail", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const fiber = yield* Effect.forkChild(run(fake.server, [], log));
+      yield* Deferred.await(fake.listening);
+      const cause = new Error("accept EMFILE: too many open files");
+      yield* Deferred.fail(fake.serverFailed, new HttpServerError.ServeError({ cause }));
+      const exit = yield* Fiber.await(fiber);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasInterruptsOnly(exit.cause)).toBe(false);
+        expect(Cause.squash(exit.cause)).toMatchObject({ _tag: "ServeError", cause });
+      }
+      expect(log.lines).toHaveLength(1);
+      expect(log.lines[0]).toMatchObject({
+        level: "fatal",
+        text: "automation: accept EMFILE: too many open files",
+        skipSentry: false,
+      });
+      expect(log.lines[0]?.cause).toMatchObject({ _tag: "ServeError", cause });
+    }),
+  );
+
+  it.effect("a listen failure is fatal with the bind error's message", () =>
+    Effect.gen(function* () {
+      const cause = new Error("listen EADDRINUSE: address already in use 127.0.0.1:54321");
+      const fake = fakeServer();
+      const failing: AutomationCommand.AutomationServer<never> = {
+        ...fake.server,
+        serve: () => Layer.effectDiscard(Effect.fail(new HttpServerError.ServeError({ cause }))),
+      };
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(run(failing, ["--port", "54321"], log));
+      expect(error).toMatchObject({ _tag: "ServeError", cause });
+      expect(log.lines.map((line) => [line.level, line.text])).toEqual([
+        ["fatal", "automation: listen EADDRINUSE: address already in use 127.0.0.1:54321"],
+      ]);
+    }),
+  );
+});

--- a/test/automation/command.unit.test.ts
+++ b/test/automation/command.unit.test.ts
@@ -9,7 +9,6 @@ import {
   FileSystem,
   Layer,
   Path,
-  Redacted,
   Stdio,
   Terminal,
 } from "effect";
@@ -18,9 +17,7 @@ import { Command } from "effect/unstable/cli";
 import { HttpServerError } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as AutomationCommand from "../../src/automation/command.ts";
-import * as Client from "../../src/db/client.ts";
 import * as Api from "../../src/shared/api.ts";
-import * as Errors from "../../src/shared/errors.ts";
 import * as FakeLog from "../support/log.ts";
 
 const CliTestLayer = Layer.mergeAll(
@@ -41,23 +38,6 @@ const CliTestLayer = Layer.mergeAll(
   ),
 );
 
-const UNREACHABLE = "postgres://user:pw@127.0.0.1:1/oligarchy";
-
-// A Database whose ping is scripted; the pool never connects, so nothing touches the network.
-const fakeDatabase = (ping: Effect.Effect<void, Errors.DatabaseError>) =>
-  Layer.effect(Client.Database)(
-    Effect.map(Client.Database.make(Redacted.make(UNREACHABLE)), (database) => ({
-      ...database,
-      ping,
-    })),
-  );
-
-const refused = Errors.DatabaseError.make({
-  operation: "ping",
-  message: "Failed query: select 1",
-  cause: new Error("connect ECONNREFUSED 127.0.0.1:1"),
-});
-
 // The server layer and the failure signal the command is built from.
 const fakeServer = () => {
   const served: Array<number> = [];
@@ -76,15 +56,15 @@ const fakeServer = () => {
   return { served, listening, serverFailed, server };
 };
 
+// No Database in the layer: the command has none to ping, and one it asked for would not compile.
 const run = (
   server: AutomationCommand.AutomationServer<never>,
   args: ReadonlyArray<string>,
   log: FakeLog.FakeLog,
-  ping: Effect.Effect<void, Errors.DatabaseError> = Effect.void,
 ) =>
   Command.runWith(AutomationCommand.makeAutomationCommand(server), { version: Api.VERSION })(
     args,
-  ).pipe(Effect.provide(Layer.mergeAll(CliTestLayer, log.layer, fakeDatabase(ping))));
+  ).pipe(Effect.provide(Layer.mergeAll(CliTestLayer, log.layer)));
 
 describe("automation command flags", () => {
   it.effect("--port must be an integer", () =>
@@ -102,7 +82,7 @@ describe("automation command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const exit = yield* Effect.exit(run(fake.server, ["--help"], log, Effect.fail(refused)));
+      const exit = yield* Effect.exit(run(fake.server, ["--help"], log));
       expect(Exit.isSuccess(exit)).toBe(true);
       expect(fake.served).toEqual([]);
       expect(log.lines).toEqual([]);
@@ -113,7 +93,7 @@ describe("automation command flags", () => {
     }),
   );
 
-  it.effect("defaults to port 54321 and pings the database first", () =>
+  it.effect("defaults to port 54321 and listens with nothing to ping first", () =>
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
@@ -140,47 +120,6 @@ describe("automation command flags", () => {
 });
 
 describe("automation command startup failures", () => {
-  it.effect("an unreachable database fails before listening as database unreachable", () =>
-    Effect.gen(function* () {
-      const fake = fakeServer();
-      const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, [], log, Effect.fail(refused)));
-      expect(error).toMatchObject({
-        _tag: "DatabaseError",
-        operation: "ping",
-        message: "database unreachable: connect ECONNREFUSED 127.0.0.1:1",
-      });
-      expect(fake.served).toEqual([]);
-      expect(log.lines).toEqual([
-        {
-          level: "fatal",
-          text: "automation: database unreachable: connect ECONNREFUSED 127.0.0.1:1",
-          sessionId: undefined,
-          agentId: undefined,
-          skipSentry: false,
-          cause: error,
-        },
-      ]);
-    }),
-  );
-
-  it.effect("a ping failure without a nested cause reports the driver's own message", () =>
-    Effect.gen(function* () {
-      const fake = fakeServer();
-      const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(
-        run(
-          fake.server,
-          [],
-          log,
-          Effect.fail(Errors.DatabaseError.make({ operation: "ping", message: "pool ended" })),
-        ),
-      );
-      expect(error).toMatchObject({ message: "database unreachable: pool ended" });
-      expect(log.lines[0]?.text).toBe("automation: database unreachable: pool ended");
-    }),
-  );
-
   it.effect("a server error after listen fails the handler with the error's detail", () =>
     Effect.gen(function* () {
       const fake = fakeServer();

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -213,6 +213,33 @@ describe("POST /automate refusals", () => {
     }),
   );
 
+  it.effect("a ticket or model with a line break in it is 400 and records nothing", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const headers = { authorization: AUTHORIZATION };
+        const ticket = yield* http.post("/automate", {
+          headers,
+          body: HttpBody.jsonUnsafe({ ticket: "OLI-1\nlinear ticket OLI-2", model: MODEL }),
+        });
+        expect(ticket.status).toBe(400);
+        const refusedTicket = yield* ticket.json;
+        expect(refusedTicket).toMatchObject({ error: expect.stringContaining("line break") });
+        expect(refusedTicket).toMatchObject({ error: expect.stringContaining('["ticket"]') });
+        const model = yield* http.post("/automate", {
+          headers,
+          body: HttpBody.jsonUnsafe({ ticket: TICKET, model: "grok-4.6\r\n" }),
+        });
+        expect(model.status).toBe(400);
+        expect(yield* model.json).toMatchObject({ error: expect.stringContaining('["model"]') });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes).toEqual([]);
+      expect(fixed.log.lines).toHaveLength(2);
+      expect(fixed.log.lines.every((line) => line.level === "error" && line.skipSentry)).toBe(true);
+    }),
+  );
+
   it.effect(
     "a record file that cannot be written is 500 internal error, logged with Node's reason",
     () =>

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, FileSystem, Layer, Redacted } from "effect";
+import { HttpBody, HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http";
+import { HttpApiClient, HttpApiMiddleware } from "effect/unstable/httpapi";
+import { NodeHttpServer } from "@effect/platform-node";
+import * as Handlers from "../../src/automation/handlers.ts";
+import * as Config from "../../src/config.ts";
+import * as Api from "../../src/shared/api.ts";
+import * as Contract from "../../src/shared/contract.ts";
+import * as FakeFs from "../support/fake-fs.ts";
+import * as FakeLog from "../support/log.ts";
+import * as Reporter from "../support/reporter.ts";
+
+const TOKEN = "test-token";
+const AUTHORIZATION = `Bearer ${TOKEN}`;
+const RECORD = "/home/operator/automation-test";
+const TICKET = "OLI-61";
+const MODEL = "grok-4.6";
+
+const ProxyConfigLive = Layer.succeed(Config.ProxyConfig)({
+  token: Redacted.make(TOKEN),
+  databaseUrl: Redacted.make("postgres://unused"),
+});
+
+const bearer = (token: string) =>
+  HttpApiMiddleware.layerClient(Api.BearerAuth, ({ next, request }) =>
+    next(HttpClientRequest.bearerToken(request, token)),
+  );
+
+type Write = {
+  readonly path: string;
+  readonly data: string;
+  readonly flag: FileSystem.OpenFlag | undefined;
+};
+
+type RecordFile = {
+  readonly writes: Array<Write>;
+  readonly layer: Layer.Layer<FileSystem.FileSystem>;
+};
+
+// A FileSystem that records every string written, or refuses each write as a file it may not open.
+const recordFile = (refuse = false): RecordFile => {
+  const writes: Array<Write> = [];
+  const layer = FileSystem.layerNoop({
+    writeFileString: (path, data, options) =>
+      refuse
+        ? Effect.fail(FakeFs.permissionDenied("open", path))
+        : Effect.sync(() => {
+            writes.push({ path, data, flag: options?.flag });
+          }),
+  });
+  return { writes, layer };
+};
+
+type Fixture = {
+  readonly file: RecordFile;
+  readonly log: FakeLog.FakeLog;
+  readonly reporter: Reporter.Collector;
+};
+
+const fixture = (file: RecordFile = recordFile()): Fixture => ({
+  file,
+  log: FakeLog.fakeLog(),
+  reporter: Reporter.collect(),
+});
+
+const serve = (fixed: Fixture) =>
+  HttpRouter.serve(Handlers.routes(RECORD), { disableLogger: true, disableListenLog: true }).pipe(
+    Layer.provide(Layer.mergeAll(fixed.file.layer, fixed.log.layer, ProxyConfigLive)),
+    Layer.provideMerge(NodeHttpServer.layerTest),
+    Layer.provideMerge(fixed.reporter.layer),
+    Layer.provideMerge(bearer(TOKEN)),
+  );
+
+const client = HttpApiClient.make(Api.AutomationApi);
+
+const body = (ticket: string, model: string) => Contract.AutomateBody.make({ ticket, model });
+
+describe("POST /automate", () => {
+  it.effect("appends the ticket and the model to the record file, answers ok and logs it", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const api = yield* client;
+        const [ok, response] = yield* api.Automations.automate({
+          payload: body(TICKET, MODEL),
+          responseMode: "decoded-and-response",
+        });
+        expect(ok).toEqual(Contract.Ok.make({}));
+        expect(response.status).toBe(200);
+        expect(yield* response.json).toEqual({ ok: "true" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes).toEqual([
+        { path: RECORD, data: `linear ticket ${TICKET}; model ${MODEL}\n`, flag: "a" },
+      ]);
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "info",
+          text: `automation recorded; ${MODEL}`,
+          sessionId: undefined,
+          agentId: TICKET,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
+  it.effect("every request appends its own line, in order, and overwrites nothing", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const api = yield* client;
+        yield* api.Automations.automate({ payload: body("OLI-1", "grok-4.6-high") });
+        yield* api.Automations.automate({ payload: body("OLI-2", "claude-opus-5") });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes.map((write) => [write.data, write.flag])).toEqual([
+        ["linear ticket OLI-1; model grok-4.6-high\n", "a"],
+        ["linear ticket OLI-2; model claude-opus-5\n", "a"],
+      ]);
+      expect(FakeLog.texts(fixed.log)).toEqual([
+        "automation recorded; grok-4.6-high",
+        "automation recorded; claude-opus-5",
+      ]);
+    }),
+  );
+});
+
+describe("POST /automate refusals", () => {
+  it.effect(
+    "a missing or wrong bearer is 401 unauthorized, records nothing and logs one line each",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture();
+        yield* Effect.gen(function* () {
+          const http = yield* HttpClient.HttpClient;
+          const payload = HttpBody.jsonUnsafe({ ticket: TICKET, model: MODEL });
+          const missing = yield* http.post("/automate", { body: payload });
+          expect(missing.status).toBe(401);
+          expect(yield* missing.json).toEqual({ error: "unauthorized" });
+          const wrong = yield* http.post("/automate", {
+            headers: { authorization: "Bearer wrong" },
+            body: payload,
+          });
+          expect(wrong.status).toBe(401);
+          expect(yield* wrong.json).toEqual({ error: "unauthorized" });
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.file.writes).toEqual([]);
+        expect(fixed.log.lines).toEqual([
+          {
+            level: "error",
+            text: "POST /automate failed: unauthorized",
+            sessionId: undefined,
+            agentId: undefined,
+            skipSentry: true,
+            cause: undefined,
+          },
+          {
+            level: "error",
+            text: "POST /automate failed: unauthorized",
+            sessionId: undefined,
+            agentId: undefined,
+            skipSentry: true,
+            cause: undefined,
+          },
+        ]);
+        expect(fixed.reporter.reported).toEqual([]);
+      }),
+  );
+
+  it.effect("a malformed body, a missing field and an empty one are 400 and record nothing", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const headers = { authorization: AUTHORIZATION };
+        const malformed = yield* http.post("/automate", {
+          headers,
+          body: HttpBody.text("{bad", "application/json"),
+        });
+        expect(malformed.status).toBe(400);
+        expect(yield* malformed.json).toEqual({ error: "Expected a valid JSON body" });
+        const noModel = yield* http.post("/automate", {
+          headers,
+          body: HttpBody.jsonUnsafe({ ticket: TICKET }),
+        });
+        expect(noModel.status).toBe(400);
+        expect(yield* noModel.json).toMatchObject({
+          error: expect.stringContaining('["model"]'),
+        });
+        const noTicket = yield* http.post("/automate", {
+          headers,
+          body: HttpBody.jsonUnsafe({ model: MODEL }),
+        });
+        expect(noTicket.status).toBe(400);
+        expect(yield* noTicket.json).toMatchObject({
+          error: expect.stringContaining('["ticket"]'),
+        });
+        const emptyTicket = yield* http.post("/automate", {
+          headers,
+          body: HttpBody.jsonUnsafe({ ticket: "", model: MODEL }),
+        });
+        expect(emptyTicket.status).toBe(400);
+        expect(yield* emptyTicket.json).toMatchObject({
+          error: expect.stringContaining('["ticket"]'),
+        });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes).toEqual([]);
+      expect(fixed.log.lines).toHaveLength(4);
+      expect(fixed.log.lines[0]?.text).toBe("POST /automate failed: Expected a valid JSON body");
+      expect(fixed.log.lines.every((line) => line.level === "error" && line.skipSentry)).toBe(true);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
+  it.effect(
+    "a record file that cannot be written is 500 internal error, logged with Node's reason",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture(recordFile(true));
+        yield* Effect.gen(function* () {
+          const api = yield* client;
+          const error = yield* Effect.flip(
+            api.Automations.automate({ payload: body(TICKET, MODEL) }),
+          );
+          expect(error).toMatchObject({ _tag: "Internal", message: "internal error" });
+          const http = yield* HttpClient.HttpClient;
+          const raw = yield* http.post("/automate", {
+            headers: { authorization: AUTHORIZATION },
+            body: HttpBody.jsonUnsafe({ ticket: TICKET, model: MODEL }),
+          });
+          expect(raw.status).toBe(500);
+          expect(yield* raw.json).toEqual({ error: "internal error" });
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.file.writes).toEqual([]);
+        expect(fixed.log.lines).toHaveLength(2);
+        for (const line of fixed.log.lines) {
+          expect(line).toMatchObject({
+            level: "error",
+            text: `POST /automate failed: EACCES: permission denied, open '${RECORD}'`,
+            sessionId: undefined,
+            agentId: TICKET,
+            skipSentry: false,
+          });
+          expect(line.cause).toMatchObject({ _tag: "PlatformError" });
+        }
+        // The boundary's line is the one report; HttpApiBuilder's own is silenced.
+        expect(fixed.reporter.reported).toEqual([]);
+      }),
+  );
+
+  it.effect("GET /automate and anything unrouted are 404 not found and never logged", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const headers = { authorization: AUTHORIZATION };
+        for (const path of ["/automate", "/start", "/servers", "/nope"]) {
+          const response = yield* http.get(path, { headers });
+          expect(response.status, path).toBe(404);
+          expect(yield* response.json).toEqual({ error: "not found" });
+        }
+        const noToken = yield* http.get("/automate");
+        expect(noToken.status).toBe(404);
+        const start = yield* http.post("/start", {
+          headers,
+          body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: TICKET }),
+        });
+        expect(start.status).toBe(404);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes).toEqual([]);
+      expect(fixed.log.lines).toEqual([]);
+    }),
+  );
+});

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -5,7 +5,7 @@ import { HttpBody, HttpClient, HttpClientRequest, HttpRouter } from "effect/unst
 import { HttpApiClient, HttpApiMiddleware } from "effect/unstable/httpapi";
 import { NodeHttpServer } from "@effect/platform-node";
 import * as Handlers from "../../src/automation/handlers.ts";
-import * as Config from "../../src/config.ts";
+import * as Middleware from "../../src/proxy/middleware.ts";
 import * as Api from "../../src/shared/api.ts";
 import * as Contract from "../../src/shared/contract.ts";
 import * as FakeFs from "../support/fake-fs.ts";
@@ -18,10 +18,8 @@ const RECORD = "/home/operator/automation-test";
 const TICKET = "OLI-61";
 const MODEL = "grok-4.6";
 
-const ProxyConfigLive = Layer.succeed(Config.ProxyConfig)({
-  token: Redacted.make(TOKEN),
-  databaseUrl: Redacted.make("postgres://unused"),
-});
+// The service's bearer is the token alone: no ProxyConfig, no database url, as in its main.
+const BearerLive = Middleware.bearerAuth(Redacted.make(TOKEN));
 
 const bearer = (token: string) =>
   HttpApiMiddleware.layerClient(Api.BearerAuth, ({ next, request }) =>
@@ -67,7 +65,7 @@ const fixture = (file: RecordFile = recordFile()): Fixture => ({
 
 const serve = (fixed: Fixture) =>
   HttpRouter.serve(Handlers.routes(RECORD), { disableLogger: true, disableListenLog: true }).pipe(
-    Layer.provide(Layer.mergeAll(fixed.file.layer, fixed.log.layer, ProxyConfigLive)),
+    Layer.provide(Layer.mergeAll(fixed.file.layer, fixed.log.layer, BearerLive)),
     Layer.provideMerge(NodeHttpServer.layerTest),
     Layer.provideMerge(fixed.reporter.layer),
     Layer.provideMerge(bearer(TOKEN)),

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -4,16 +4,13 @@ import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, inject } from "vitest";
+import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect } from "effect";
 
 const AUTOMATION = fileURLToPath(new URL("../../automation", import.meta.url));
 const TOKEN = "t";
-const UNREACHABLE = "postgres://user:sentinel-pw@127.0.0.1:1/oligarchy";
 const EXIT_WITHIN_MS = 60_000;
-
-const dbUrl = inject("dbUrl");
 
 type Process = {
   readonly child: ChildProcess;
@@ -26,19 +23,21 @@ type Process = {
 };
 
 // Sentry is initialised by the wrapper's --import; a proxy nobody listens on keeps the test
-// run's fatal lines out of the real project without touching the code under test.
+// run's fatal lines out of the real project without touching the code under test. The service
+// has no database, so a DATABASE_URL in the developer's environment is removed: it must not be
+// what makes these pass.
 const environment = (home: string, overrides: Record<string, string>): NodeJS.ProcessEnv => {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     HOME: home,
     OLIGARCHY_TOKEN: TOKEN,
-    DATABASE_URL: dbUrl === "" ? UNREACHABLE : dbUrl,
     https_proxy: "http://127.0.0.1:1",
     http_proxy: "http://127.0.0.1:1",
     no_proxy: "",
     ...overrides,
   };
   delete env.FORCE_COLOR;
+  delete env.DATABASE_URL;
   return env;
 };
 
@@ -172,27 +171,11 @@ describe("automation startup refusals", () => {
       const { code } = await process.exited;
       expect(code).toBe(1);
       expect(process.stderr()).toContain("OLIGARCHY_TOKEN is not set");
-      expect(process.stderr()).not.toContain("sentinel-pw");
-    }),
-  );
-
-  it.live("an unreachable database exits 1 with the fatal line and never the password", () =>
-    Effect.promise(async () => {
-      const process = spawnAutomation([], { DATABASE_URL: UNREACHABLE });
-      const { code } = await process.exited;
-      expect(code).toBe(1);
-      const fatal = lines(process.stdout()).find((line) =>
-        line.startsWith("[global] fatal: automation: database unreachable:"),
-      );
-      expect(fatal, process.stdout()).toBeDefined();
-      expect(fatal).toContain("ECONNREFUSED");
-      expect(process.stdout()).not.toContain("sentinel-pw");
-      expect(process.stderr()).not.toContain("sentinel-pw");
       expect(process.stdout()).not.toContain("listening");
     }),
   );
 
-  it.live.skipIf(dbUrl === "")("an occupied port exits 1 with EADDRINUSE", () =>
+  it.live("an occupied port exits 1 with EADDRINUSE", () =>
     Effect.promise(async () => {
       const { port, release } = await occupy();
       try {
@@ -290,12 +273,9 @@ describe("automation serving", () => {
     expect(code, process.stdout()).toBe(0);
     const output = lines(process.stdout());
     expect(output).toContain("[global] error: POST /automate failed: unauthorized");
-    expect(
-      output.some(
-        (line) =>
-          line.startsWith("[global] error: POST /automate failed: ") && line.includes('["model"]'),
-      ),
-    ).toBe(true);
+    // The schema's detail spans two lines: the missing key, then where.
+    expect(output).toContain("[global] error: POST /automate failed: Missing key");
+    expect(output).toContain('  at ["model"]');
     expect(output).toContain("[OLI-1] automation recorded; grok-4.6");
     expect(output).toContain("[OLI-2] automation recorded; claude-opus-5");
     expect(output.some((line) => line.includes("/start"))).toBe(false);
@@ -304,15 +284,11 @@ describe("automation serving", () => {
     await expect(request(port, "GET", "/automate")).rejects.toThrow();
   };
 
-  it.live.skipIf(dbUrl === "")(
-    "listens, records each request, answers 401, 400 and 404, and exits 0 on SIGINT",
+  it.live(
+    "listens without a database, records each request, answers 401, 400 and 404, and exits 0 on SIGINT",
     () => Effect.promise(() => served("SIGINT")),
     120_000,
   );
 
-  it.live.skipIf(dbUrl === "")(
-    "exits 0 on SIGTERM",
-    () => Effect.promise(() => served("SIGTERM")),
-    120_000,
-  );
+  it.live("exits 0 on SIGTERM", () => Effect.promise(() => served("SIGTERM")), 120_000);
 });

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -1,0 +1,318 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, inject } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+
+const AUTOMATION = fileURLToPath(new URL("../../automation", import.meta.url));
+const TOKEN = "t";
+const UNREACHABLE = "postgres://user:sentinel-pw@127.0.0.1:1/oligarchy";
+const EXIT_WITHIN_MS = 60_000;
+
+const dbUrl = inject("dbUrl");
+
+type Process = {
+  readonly child: ChildProcess;
+  // The process's HOME: an empty directory of its own, where the record file lands.
+  readonly home: string;
+  readonly stdout: () => string;
+  readonly stderr: () => string;
+  readonly exited: Promise<{ readonly code: number | null; readonly signal: string | null }>;
+  readonly waitFor: (pattern: RegExp, timeoutMs?: number) => Promise<void>;
+};
+
+// Sentry is initialised by the wrapper's --import; a proxy nobody listens on keeps the test
+// run's fatal lines out of the real project without touching the code under test.
+const environment = (home: string, overrides: Record<string, string>): NodeJS.ProcessEnv => {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: home,
+    OLIGARCHY_TOKEN: TOKEN,
+    DATABASE_URL: dbUrl === "" ? UNREACHABLE : dbUrl,
+    https_proxy: "http://127.0.0.1:1",
+    http_proxy: "http://127.0.0.1:1",
+    no_proxy: "",
+    ...overrides,
+  };
+  delete env.FORCE_COLOR;
+  return env;
+};
+
+// Each process runs in its own empty directory (no `.env` to read) that is also its HOME, so the
+// record file is the test's own; removed once it has exited.
+const spawnAutomation = (
+  args: ReadonlyArray<string>,
+  overrides: Record<string, string> = {},
+): Process => {
+  const dir = mkdtempSync(join(tmpdir(), "oligarchy-automation-test-"));
+  const child = spawn(AUTOMATION, args, {
+    cwd: dir,
+    env: environment(dir, overrides),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  const listeners = new Set<() => void>();
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (data: string) => {
+    stdout += data;
+    for (const listener of listeners) listener();
+  });
+  child.stderr.on("data", (data: string) => {
+    stderr += data;
+    for (const listener of listeners) listener();
+  });
+  const exited = new Promise<{ code: number | null; signal: string | null }>((resolve, reject) => {
+    const timer = setTimeout(() => child.kill("SIGKILL"), EXIT_WITHIN_MS);
+    child.on("error", (cause) => {
+      clearTimeout(timer);
+      reject(cause);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      rmSync(dir, { recursive: true, force: true });
+      for (const listener of listeners) listener();
+      resolve({ code, signal });
+    });
+  });
+  const waitFor = (pattern: RegExp, timeoutMs = 30_000) =>
+    new Promise<void>((resolve, reject) => {
+      const check = () => {
+        if (pattern.test(stdout) || pattern.test(stderr)) {
+          listeners.delete(check);
+          clearTimeout(timer);
+          resolve();
+        } else if (child.exitCode !== null) {
+          listeners.delete(check);
+          clearTimeout(timer);
+          reject(
+            new Error(
+              `automation exited ${String(child.exitCode)} before ${pattern.source}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+            ),
+          );
+        }
+      };
+      const timer = setTimeout(() => {
+        listeners.delete(check);
+        reject(new Error(`no ${pattern.source} within ${String(timeoutMs)}ms\nstdout:\n${stdout}`));
+      }, timeoutMs);
+      listeners.add(check);
+      check();
+    });
+  return { child, home: dir, stdout: () => stdout, stderr: () => stderr, exited, waitFor };
+};
+
+const portOf = (address: string | AddressInfo | null): number =>
+  typeof address === "object" && address !== null ? address.port : 0;
+
+// A loopback port held open for as long as `release` is not called; released at once for a free one.
+const occupy = (): Promise<{ readonly port: number; readonly release: () => Promise<void> }> =>
+  new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        port: portOf(server.address()),
+        release: () => new Promise((done) => server.close(() => done())),
+      });
+    });
+  });
+
+const freePort = async (): Promise<number> => {
+  const { port, release } = await occupy();
+  await release();
+  return port;
+};
+
+const lines = (output: string): ReadonlyArray<string> =>
+  output.split("\n").filter((line) => line !== "");
+
+const request = (
+  port: number,
+  method: string,
+  path: string,
+  headers: Record<string, string> = {},
+  body?: string,
+) =>
+  fetch(
+    `http://127.0.0.1:${String(port)}${path}`,
+    body === undefined ? { method, headers } : { method, headers, body },
+  );
+
+describe("automation startup refusals", () => {
+  it.live("--help exits 0 and lists --port alone", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomation(["--help"]);
+      const { code } = await process.exited;
+      expect(code).toBe(0);
+      expect(process.stdout()).toContain("--port");
+      expect(process.stdout()).not.toContain("--diagnostics-port");
+      expect(process.stdout()).not.toContain("--display");
+    }),
+  );
+
+  it.live("a --port that is not an integer exits 1 with a usage error", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomation(["--port", "forty"]);
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("forty");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live("a missing OLIGARCHY_TOKEN exits 1 with OLIGARCHY_TOKEN is not set", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomation([], { OLIGARCHY_TOKEN: "" });
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("OLIGARCHY_TOKEN is not set");
+      expect(process.stderr()).not.toContain("sentinel-pw");
+    }),
+  );
+
+  it.live("an unreachable database exits 1 with the fatal line and never the password", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomation([], { DATABASE_URL: UNREACHABLE });
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      const fatal = lines(process.stdout()).find((line) =>
+        line.startsWith("[global] fatal: automation: database unreachable:"),
+      );
+      expect(fatal, process.stdout()).toBeDefined();
+      expect(fatal).toContain("ECONNREFUSED");
+      expect(process.stdout()).not.toContain("sentinel-pw");
+      expect(process.stderr()).not.toContain("sentinel-pw");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live.skipIf(dbUrl === "")("an occupied port exits 1 with EADDRINUSE", () =>
+    Effect.promise(async () => {
+      const { port, release } = await occupy();
+      try {
+        const process = spawnAutomation(["--port", String(port)]);
+        const { code } = await process.exited;
+        expect(code).toBe(1);
+        const fatal = lines(process.stdout()).find((line) =>
+          line.startsWith("[global] fatal: automation: "),
+        );
+        expect(fatal, process.stdout()).toBeDefined();
+        expect(fatal).toContain("EADDRINUSE");
+        expect(fatal).toContain(`127.0.0.1:${String(port)}`);
+        expect(process.stdout()).not.toContain("listening");
+      } finally {
+        await release();
+      }
+    }),
+  );
+});
+
+describe("automation serving", () => {
+  const served = async (signal: "SIGINT" | "SIGTERM") => {
+    const port = await freePort();
+    const process = spawnAutomation(["--port", String(port)]);
+    const record = join(process.home, "automation-test");
+    try {
+      await process.waitFor(/oligarchy automation listening/);
+      expect(lines(process.stdout())).toContain(
+        `[global] oligarchy automation listening on 127.0.0.1:${String(port)}; recording to ${record}`,
+      );
+      expect(existsSync(record)).toBe(false);
+
+      const unauthorized = await request(
+        port,
+        "POST",
+        "/automate",
+        { "content-type": "application/json" },
+        '{"ticket":"OLI-1","model":"grok-4.6"}',
+      );
+      expect(unauthorized.status).toBe(401);
+      expect(await unauthorized.json()).toEqual({ error: "unauthorized" });
+      expect(existsSync(record)).toBe(false);
+
+      const incomplete = await request(
+        port,
+        "POST",
+        "/automate",
+        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        '{"ticket":"OLI-1"}',
+      );
+      expect(incomplete.status).toBe(400);
+      expect(await incomplete.json()).toMatchObject({
+        error: expect.stringContaining('["model"]'),
+      });
+      expect(existsSync(record)).toBe(false);
+
+      const first = await request(
+        port,
+        "POST",
+        "/automate",
+        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        '{"ticket":"OLI-1","model":"grok-4.6"}',
+      );
+      expect(first.status).toBe(200);
+      expect(first.headers.get("content-type")).toContain("application/json");
+      expect(await first.json()).toEqual({ ok: "true" });
+      const second = await request(
+        port,
+        "POST",
+        "/automate",
+        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        '{"ticket":"OLI-2","model":"claude-opus-5"}',
+      );
+      expect(second.status).toBe(200);
+      expect(readFileSync(record, "utf8")).toBe(
+        "linear ticket OLI-1; model grok-4.6\nlinear ticket OLI-2; model claude-opus-5\n",
+      );
+
+      const start = await request(
+        port,
+        "POST",
+        "/start",
+        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        '{"iso":"omarchy.iso","agent":"OLI-1"}',
+      );
+      expect(start.status).toBe(404);
+      expect(await start.json()).toEqual({ error: "not found" });
+      const nope = await request(port, "GET", "/automate");
+      expect(nope.status).toBe(404);
+    } finally {
+      // A failed expectation must not leave the process listening past the test.
+      process.child.kill(signal);
+    }
+    const { code } = await process.exited;
+    expect(code, process.stdout()).toBe(0);
+    const output = lines(process.stdout());
+    expect(output).toContain("[global] error: POST /automate failed: unauthorized");
+    expect(
+      output.some(
+        (line) =>
+          line.startsWith("[global] error: POST /automate failed: ") && line.includes('["model"]'),
+      ),
+    ).toBe(true);
+    expect(output).toContain("[OLI-1] automation recorded; grok-4.6");
+    expect(output).toContain("[OLI-2] automation recorded; claude-opus-5");
+    expect(output.some((line) => line.includes("/start"))).toBe(false);
+    expect(process.stderr()).toBe("");
+
+    await expect(request(port, "GET", "/automate")).rejects.toThrow();
+  };
+
+  it.live.skipIf(dbUrl === "")(
+    "listens, records each request, answers 401, 400 and 404, and exits 0 on SIGINT",
+    () => Effect.promise(() => served("SIGINT")),
+    120_000,
+  );
+
+  it.live.skipIf(dbUrl === "")(
+    "exits 0 on SIGTERM",
+    () => Effect.promise(() => served("SIGTERM")),
+    120_000,
+  );
+});

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -231,3 +231,30 @@ describe("ReverseProxyApi", () => {
     }
   });
 });
+
+describe("AutomationApi", () => {
+  const automation = Api.AutomationApi;
+
+  it("declares POST /automate and nothing else", () => {
+    const table = routes(automation).map(({ method, path }) => `${method} ${path}`);
+    expect(table).toEqual(["POST /automate"]);
+    expect(HttpApiClient.urlBuilder(automation).Automations.automate()).toBe("/automate");
+  });
+
+  it("requires the bearer and applies BearerAuth then ApiBoundary", () => {
+    const spec = OpenApi.fromApi(automation);
+    expect(spec.components.securitySchemes).toEqual({
+      bearer: { type: "http", scheme: "Bearer" },
+    });
+    const route = byIdentifier(automation, "automate");
+    expect(route.group).toBe("Automations");
+    expect(route.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);
+    expect(spec.paths["/automate"]?.post?.security).toEqual([{ bearer: [] }]);
+    expect(route.errors).toEqual([400, 401, 500]);
+  });
+
+  it("is its own api: neither the proxy nor the reverse proxy answers /automate", () => {
+    expect(routes(Api.ProxyApi).map(({ path }) => path)).not.toContain("/automate");
+    expect(routes(Api.ReverseProxyApi).map(({ path }) => path)).not.toContain("/automate");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

A new process, `./automation` (`src/automation/`), built the way the reverse proxy is but as a plain service on its own port, for the Cloudflare zero-trust pass-through to point at. It needs no database.

- Listens on `127.0.0.1:54321` (`--port` to change it).
- One route, `POST /automate`, JSON body `{ "ticket": "OLI-123", "model": "grok-4.6" }`, behind the same `Authorization: Bearer <OLIGARCHY_TOKEN>` as the proxy and reverse proxy (the same `BearerAuth` middleware and compare).
- For now it records rather than spawns: each request appends one line to `~/automation-test` — `linear ticket OLI-123; model grok-4.6` — answers `{"ok":"true"}` and logs `automation recorded; grok-4.6` attributed to the ticket. Spawning the agent those two describe is the next step and lands in `src/automation/handlers.ts`.
- Refusals through the proxy's `ApiBoundary`: 400 for a body the contract refuses (a missing field, an empty value, a line break — the record is one line per request), 401 for a missing or wrong bearer, 500 (`internal error`, Node's reason on the log line) when the record file cannot be written; anything unrouted is the catch-all's 404.
- Reads `OLIGARCHY_TOKEN` alone. No `DATABASE_URL`, no ping: the service keeps no rows, so its log is `Log.layerStdout` — stdout plus the Sentry reporter — and a missing token is printed as `OLIGARCHY_TOKEN is not set` with exit 1. Fatal line and exit 1 on a bind or accept error, exit 0 on SIGINT/SIGTERM.
- `src/proxy/middleware.ts` gains `bearerAuth(token)`: the one compare over a `Redacted` token; `BearerAuthLive` maps `ProxyConfig` onto it, unchanged in behaviour for the two servers.

## Run it

```sh
OLIGARCHY_TOKEN=… ./automation            # 127.0.0.1:54321
curl -X POST http://127.0.0.1:54321/automate \
  -H "authorization: Bearer $OLIGARCHY_TOKEN" -H "content-type: application/json" \
  -d '{"ticket":"OLI-123","model":"grok-4.6"}'
cat ~/automation-test
```

## Tests (written first; none touch Postgres)

- `test/shared/api.unit.test.ts`: `AutomationApi` declares only `POST /automate`, bearer + `BearerAuth`/`ApiBoundary`, errors 400/401/500; neither other api answers `/automate`.
- `test/automation/http.unit.test.ts`: the append, the answer and the log line; two requests append two lines; 401, 400 (missing/empty/line break), a refused write as 500 with the cause, 404s unlogged. The file system is a recording `FileSystem.layerNoop`, the bearer `bearerAuth(token)`.
- `test/automation/command.unit.test.ts`: `--port` default 54321, `--help`, the fatal lines for a listen failure and a server error after listen; the layer under test has no `Database` at all.
- `test/integration/automation.integration.test.ts`: the black-box process — exit codes, first lines, the record file under `$HOME`, 401/400/200/404, SIGINT/SIGTERM — spawned with `DATABASE_URL` removed from its environment, so it runs everywhere without Postgres or Docker.

Reviewed by a GPT-5.6 Sol subagent per `development.md`: the line-break refusal and the interruptible handler come from it; its ephemeral-port nit is declined (same pattern as `reverse-proxy.integration.test.ts`).

The five failing tests in `test/ctrl/*` are pre-existing on master (the "small failing unit test" commits) and untouched here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75ed28f7-0c95-4529-9398-035b14cd98c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75ed28f7-0c95-4529-9398-035b14cd98c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

