### PR TITLE
ctrl: session --search --test-result-id, and SESSION_ID for --session-id

### DIFF
--- a/ctrl.md
+++ b/ctrl.md
@@ -51,7 +51,7 @@ If you are an agent driving a guest, you need two of these: [test start](#test-s
 The action comes first. Every value is a flag; there are no positional arguments. Flags may sit in any order after the action.
 
 - `DATABASE_URL` — read from the environment by every action; it is the only variable most of them need. `test new` and `test list` also read `LINEAR_API_TOKEN`; `test run` and `diagnose run` also read `CURSOR_API_TOKEN`. No action reads `OLIGARCHY_TOKEN`. A `.env` in the current directory fills in missing variables only. A missing variable means exit 1.
-- `--session-id <id>` — taken by `test start`, `session`, `diagnose` and `diagnose run`. Omitted, it is read from `SESSION_ID` in the environment; the flag wins when both are given, and an empty `SESSION_ID` counts as unset. Export it once — `export SESSION_ID=$(./ctrl session --search --test-result-id <id>)` — and every command that follows is about that session. Neither given is a usage error, or on `session` the refusal `session: --session-id or SESSION_ID is required`.
+- `--session-id <id>` — taken by `test start`, `session`, `diagnose` and `diagnose run`. Omitted, it is read from `SESSION_ID` in the environment; the flag wins when both are given, and an empty `SESSION_ID` counts as unset. Set it once — `SESSION_ID=$(./ctrl session --search --test-result-id <id>) && export SESSION_ID`, so a failed search stops there instead of exporting nothing — and every command that follows is about that session. Neither given is a usage error; on `session` without `--search` it is the refusal `session: --session-id or SESSION_ID is required`.
 - `--server-url <url>` — taken by `test new` alone: the proxy the driving agents will talk to, a full http or https URL, stored on the run and written into every ticket. Falls back to `SERVER_URL` from the environment; there is no default. `test start` and `test-results` accept it and ignore it, so a ticket written before it went still runs; every other action refuses it as an unrecognized flag.
 
 A command that works exits 0. A command that fails exits 1 and prints the error: one headline, then the stack trace and the cause behind it. Read the headline first. `./ctrl <action> --help` prints that action's flags.
@@ -220,11 +220,11 @@ The other way round from [session](#session): a test result id in, the id of the
 
 - `--search` — required; the verb of this form.
 - `--test-result-id <id>` — the result UUID from the Linear issue. Without `--search` it is refused (`session: --test-result-id needs --search`); `--search` without it likewise (`session: --search needs --test-result-id`).
-- The selectors are refused (`session: --search takes no selector`): inspect through the id printed. `--session-id` and `SESSION_ID` are not read; the result names the session.
+- The selectors are refused (`session: --search takes no selector`): inspect through the id printed. `--session-id` and `SESSION_ID` do not affect a search; the result names the session.
 
 ```bash
 ./ctrl session --search --test-result-id 2222...2222
-export SESSION_ID=$(./ctrl session --search --test-result-id 2222...2222)
+SESSION_ID=$(./ctrl session --search --test-result-id 2222...2222) && export SESSION_ID
 ./ctrl session --all
 ```
 

--- a/ctrl.md
+++ b/ctrl.md
@@ -4,21 +4,22 @@ Consult this table of contents first. Read only the section you need.
 
 | Section | Line |
 |---------|-----:|
-| [Important](#important) | 23 |
-| [Synopsis](#synopsis) | 29 |
-| [test --list](#test---list) | 56 |
-| [test define](#test-define) | 74 |
-| [test new](#test-new) | 90 |
-| [test list](#test-list) | 106 |
-| [test run](#test-run) | 118 |
-| [test start](#test-start) | 134 |
-| [test-results](#test-results) | 151 |
-| [session list](#session-list) | 169 |
-| [session](#session) | 185 |
-| [error-type new](#error-type-new) | 210 |
-| [error-type list](#error-type-list) | 225 |
-| [diagnose](#diagnose) | 239 |
-| [diagnose run](#diagnose-run) | 258 |
+| [Important](#important) | 24 |
+| [Synopsis](#synopsis) | 30 |
+| [test --list](#test---list) | 59 |
+| [test define](#test-define) | 77 |
+| [test new](#test-new) | 93 |
+| [test list](#test-list) | 109 |
+| [test run](#test-run) | 121 |
+| [test start](#test-start) | 137 |
+| [test-results](#test-results) | 154 |
+| [session list](#session-list) | 172 |
+| [session](#session) | 188 |
+| [session --search](#session---search) | 213 |
+| [error-type new](#error-type-new) | 231 |
+| [error-type list](#error-type-list) | 246 |
+| [diagnose](#diagnose) | 260 |
+| [diagnose run](#diagnose-run) | 279 |
 
 ## Important
 
@@ -40,6 +41,7 @@ If you are an agent driving a guest, you need two of these: [test start](#test-s
 ./ctrl test-results   --agent-id <agent> --id <id> --status success|failed [--reason <text>]
 ./ctrl session list   [--count <n>] [--active] [--json]
 ./ctrl session        --session-id <id> --status|--logs|--test-def|--test-results|--test-run|--actions|--images|--debug-logs|--diagnosis|--all
+./ctrl session        --search --test-result-id <id>
 ./ctrl error-type new  --key <key> --description <text>
 ./ctrl error-type list [--json]
 ./ctrl diagnose       --session-id <id> --verdict passed|failed [--type <key>] --summary <text> --model <id>
@@ -49,6 +51,7 @@ If you are an agent driving a guest, you need two of these: [test start](#test-s
 The action comes first. Every value is a flag; there are no positional arguments. Flags may sit in any order after the action.
 
 - `DATABASE_URL` — read from the environment by every action; it is the only variable most of them need. `test new` and `test list` also read `LINEAR_API_TOKEN`; `test run` and `diagnose run` also read `CURSOR_API_TOKEN`. No action reads `OLIGARCHY_TOKEN`. A `.env` in the current directory fills in missing variables only. A missing variable means exit 1.
+- `--session-id <id>` — taken by `test start`, `session`, `diagnose` and `diagnose run`. Omitted, it is read from `SESSION_ID` in the environment; the flag wins when both are given, and an empty `SESSION_ID` counts as unset. Export it once — `export SESSION_ID=$(./ctrl session --search --test-result-id <id>)` — and every command that follows is about that session. Neither given is a usage error, or on `session` the refusal `session: --session-id or SESSION_ID is required`.
 - `--server-url <url>` — taken by `test new` alone: the proxy the driving agents will talk to, a full http or https URL, stored on the run and written into every ticket. Falls back to `SERVER_URL` from the environment; there is no default. `test start` and `test-results` accept it and ignore it, so a ticket written before it went still runs; every other action refuses it as an unrecognized flag.
 
 A command that works exits 0. A command that fails exits 1 and prints the error: one headline, then the stack trace and the cause behind it. Read the headline first. `./ctrl <action> --help` prints that action's flags.
@@ -139,7 +142,7 @@ Spawns a Cursor cloud agent that drives one Linear ticket. The ticket carries th
 
 Ties a pending test result to the session that is running it and records the Cursor model that is running it. The result already names its definition. An unknown session, or a result that is missing or not pending, is a failure.
 
-- `--session-id <id>` — the id printed by `./client start`.
+- `--session-id <id>` — the id printed by `./client start`; `SESSION_ID` when omitted.
 - `--test-result-id <id>` — the result UUID from the Linear issue.
 - `--model <id>` — the Cursor model id that is running this result.
 - `--server-url <url>` — accepted and ignored; tickets written before it went still name it.
@@ -188,9 +191,9 @@ Prints the most recent sessions, newest first, one per line: the status, colored
 ./ctrl session --session-id <id> --status|--logs|--test-def|--test-results|--test-run|--actions|--images|--debug-logs|--diagnosis|--all
 ```
 
-Prints what is stored for one session, as JSON. At least one selector is required; one selector prints that value, several print an object keyed by them. An unknown session is a failure. Not used while driving a guest; a reviewing agent starts here, and the session id is all it needs — everything else is reached from it.
+Prints what is stored for one session, as JSON. At least one selector is required; one selector prints that value, several print an object keyed by them. An unknown session is a failure. Not used while driving a guest; a reviewing agent starts here, and the session id is all it needs — everything else is reached from it. With only a test result id in hand, [session --search](#session---search) finds the session first.
 
-- `--session-id <id>` — the session.
+- `--session-id <id>` — the session; `SESSION_ID` when omitted.
 - `--status` — the session row: `{ id, config, status, reason, startedAt, endedAt }`. `status` and `reason` are the driver's verdict as `./client stop` recorded it; `config` is what it booted.
 - `--logs` — its log lines, oldest first.
 - `--test-def` — the test definition its result ran, in the wording it ran (a later `test define` does not change it), or `null`.
@@ -205,6 +208,24 @@ Prints what is stored for one session, as JSON. At least one selector is require
 ```bash
 ./ctrl session --session-id 6f1c...e2a9 --all
 ./ctrl session --session-id 6f1c...e2a9 --debug-logs
+```
+
+## session --search
+
+```
+./ctrl session --search --test-result-id <id>
+```
+
+The other way round from [session](#session): a test result id in, the id of the session that ran it out, as one bare line and nothing else, so a shell can capture it into `SESSION_ID` and every command after reads it. A result nobody has (`session: no test result <id>`), or one no session has started yet (`session: result <id> has no session yet`), is a failure. Not used while driving a guest.
+
+- `--search` — required; the verb of this form.
+- `--test-result-id <id>` — the result UUID from the Linear issue. Without `--search` it is refused (`session: --test-result-id needs --search`); `--search` without it likewise (`session: --search needs --test-result-id`).
+- The selectors are refused (`session: --search takes no selector`): inspect through the id printed. `--session-id` and `SESSION_ID` are not read; the result names the session.
+
+```bash
+./ctrl session --search --test-result-id 2222...2222
+export SESSION_ID=$(./ctrl session --search --test-result-id 2222...2222)
+./ctrl session --all
 ```
 
 ## error-type new
@@ -244,7 +265,7 @@ Prints every error type, ordered by key, one per line: the key, two spaces, the 
 
 Records the post-run diagnosis: a reviewer's verdict on one session that has ended, whatever the driver said about it: a `succeeded`, `failed` or `aborted` stop, or the ten-minute timeout. Read the evidence first (`session --all`; the final image through `./session image --image-id <id> -o <file>`, and the images around any step the logs or actions make suspect, against the definition's proof; the debug log), then say whether the proof landed. A `failed` verdict names its cause with the matching type from [error-type list](#error-type-list); only when none matches is one minted with [error-type new](#error-type-new), rarely. One diagnosis per session: a second is a failure and the first stands. Not used while driving a guest.
 
-- `--session-id <id>` — the session. Unknown, or still running or downloading, is a failure (`diagnose: session <id> is still running`).
+- `--session-id <id>` — the session; `SESSION_ID` when omitted. Unknown, or still running or downloading, is a failure (`diagnose: session <id> is still running`).
 - `--verdict <verdict>` — `passed` when the proof is on screen, `failed` when it is not or the session never got there. The reviewer's own answer; it may contradict the session status and the test result.
 - `--type <key>` — the cause of a `failed` verdict, an existing error type key. Required with `failed` (`diagnose: --verdict failed needs --type`), refused with `passed` (`diagnose: --verdict passed takes no --type`). A key that is not in the table is a failure: `diagnose: no error type <key>; create it with ./ctrl error-type new`.
 - `--summary <text>` — what happened, in the reviewer's words, from the evidence.
@@ -263,7 +284,7 @@ Records the post-run diagnosis: a reviewer's verdict on one session that has end
 
 Spawns a Cursor cloud agent that reviews one ended session and records its verdict with [diagnose](#diagnose). The agent is handed the session id and the reviewer's guide (`ctrl-diagnose.md`), nothing else: it reads the rest back from the database with [session](#session). Prints a link to the agent as soon as it starts; does not wait for it. Not used while driving a guest. Reads `CURSOR_API_TOKEN`.
 
-- `--session-id <id>` — the session. Unknown, still running or downloading, or already diagnosed is a failure (`diagnose run: session <id> already has a diagnosis`), before any agent is spawned.
+- `--session-id <id>` — the session; `SESSION_ID` when omitted. Unknown, still running or downloading, or already diagnosed is a failure (`diagnose run: session <id> already has a diagnosis`), before any agent is spawned.
 
 ```bash
 ./ctrl diagnose run --session-id 6f1c...e2a9

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,10 @@ export const cursorApiToken = requiredRedacted("CURSOR_API_TOKEN");
 // For Flag.withFallbackConfig: SERVER_URL="" is unset and the flag's default applies.
 export const serverUrl: EffectConfig.Config<string> = EffectConfig.string("SERVER_URL");
 
+// For Flag.withFallbackConfig on ctrl's --session-id: SESSION_ID="" is unset and the flag's own
+// rule applies, so a shell can `export SESSION_ID=$(./ctrl session --search ...)` once.
+export const sessionId: EffectConfig.Config<string> = EffectConfig.string("SESSION_ID");
+
 export class ProxyConfig extends Context.Service<ProxyConfig>()("@oligarchy/config/ProxyConfig", {
   // Sequential on purpose: OLIGARCHY_TOKEN is reported before DATABASE_URL.
   make: Effect.all({ token: oligarchyToken, databaseUrl }),

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,7 +47,8 @@ export const cursorApiToken = requiredRedacted("CURSOR_API_TOKEN");
 export const serverUrl: EffectConfig.Config<string> = EffectConfig.string("SERVER_URL");
 
 // For Flag.withFallbackConfig on ctrl's --session-id: SESSION_ID="" is unset and the flag's own
-// rule applies, so a shell can `export SESSION_ID=$(./ctrl session --search ...)` once.
+// rule applies, so a shell can `SESSION_ID=$(./ctrl session --search ...) && export SESSION_ID`
+// once.
 export const sessionId: EffectConfig.Config<string> = EffectConfig.string("SESSION_ID");
 
 export class ProxyConfig extends Context.Service<ProxyConfig>()("@oligarchy/config/ProxyConfig", {

--- a/src/ctrl/command.ts
+++ b/src/ctrl/command.ts
@@ -113,9 +113,11 @@ const legacyServerUrlFlag = Flag.string("server-url").pipe(
   Flag.withDescription("Ignored; tickets written before it went still name it"),
 );
 
+// The flag wins; SESSION_ID stands in when it is omitted, so a shell exports the id once.
 const sessionIdFlag = Flag.string("session-id").pipe(
+  Flag.withFallbackConfig(Config.sessionId),
   Flag.withSchema(Schema.NonEmptyString),
-  Flag.withDescription("Session id"),
+  Flag.withDescription("Session id; SESSION_ID when omitted"),
 );
 
 const nameFlag = (description: string) =>
@@ -613,9 +615,23 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     yield* printLines(Render.renderSessions(rows, input.json, now));
   });
 
+  // session --search --test-result-id <id>: the id of the session that ran the result, as one bare
+  // line a shell captures into SESSION_ID for the commands that follow.
+  const sessionSearch = Effect.fn("ctrl.session.search")(function* (resultId: string) {
+    const tests = yield* Tests.TestStore;
+    const row = yield* orRefuse(tests.findResult(resultId), `session: no test result ${resultId}`);
+    if (row.sessionId === null) {
+      return yield* refuse(`session: result ${resultId} has no session yet`);
+    }
+    return yield* Console.log(row.sessionId);
+  });
+
   // session --session-id <id> --status|--logs|--test-def|--test-results|--test-run|--actions|--images|--debug-logs|--diagnosis|--all
+  // session --search --test-result-id <id>
   const sessionInspect = Effect.fn("ctrl.session.inspect")(function* (input: {
-    readonly sessionId: string;
+    readonly sessionId: Option.Option<string>;
+    readonly search: boolean;
+    readonly testResultId: Option.Option<string>;
     readonly status: boolean;
     readonly logs: boolean;
     readonly testDef: boolean;
@@ -638,12 +654,29 @@ export const makeCtrlCommand = (deps: Deps = live) => {
       input.debugLogs ||
       input.diagnosis ||
       input.all;
+    // A search names its session through the result: --session-id and SESSION_ID are not read.
+    if (input.search) {
+      const resultId = yield* orRefuse(
+        Effect.succeed(input.testResultId),
+        "session: --search needs --test-result-id",
+      );
+      if (selected) {
+        return yield* refuse("session: --search takes no selector");
+      }
+      return yield* sessionSearch(resultId);
+    }
+    if (Option.isSome(input.testResultId)) {
+      return yield* refuse("session: --test-result-id needs --search");
+    }
+    const id = yield* orRefuse(
+      Effect.succeed(input.sessionId),
+      "session: --session-id or SESSION_ID is required",
+    );
     if (!selected) {
       return yield* refuse(
         "session: --status, --logs, --test-def, --test-results, --test-run, --actions, --images, --debug-logs, --diagnosis, or --all is required",
       );
     }
-    const id = input.sessionId;
     const sessions = yield* Sessions.SessionStore;
     const logs = yield* Logs.LogStore;
     const tests = yield* Tests.TestStore;
@@ -863,7 +896,14 @@ export const makeCtrlCommand = (deps: Deps = live) => {
   const sessionCommand = Command.make(
     "session",
     {
-      sessionId: sessionIdFlag,
+      // Optional here alone: a search names its session through the result.
+      sessionId: sessionIdFlag.pipe(Flag.optional),
+      search: toggle("search", "Print the id of the session that ran --test-result-id"),
+      testResultId: Flag.string("test-result-id").pipe(
+        Flag.withSchema(Schema.NonEmptyString),
+        Flag.optional,
+        Flag.withDescription("Test result id from the Linear ticket; with --search"),
+      ),
       status: toggle("status", "Print the session row: how it ended, why, and what it booted"),
       logs: toggle("logs", "Print session logs"),
       testDef: toggle("test-def", "Print the session's test definition"),
@@ -884,7 +924,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     sessionInspect,
   ).pipe(
     Command.withDescription(
-      "session --session-id <id> --status|--logs|--test-def|--test-results|--test-run|--actions|--images|--debug-logs|--diagnosis|--all; or list",
+      "session --session-id <id> --status|--logs|--test-def|--test-results|--test-run|--actions|--images|--debug-logs|--diagnosis|--all; session --search --test-result-id <id>; or list",
     ),
     Command.provide(withDb),
     Command.withSubcommands([sessionListCommand]),

--- a/src/ctrl/command.ts
+++ b/src/ctrl/command.ts
@@ -654,7 +654,8 @@ export const makeCtrlCommand = (deps: Deps = live) => {
       input.debugLogs ||
       input.diagnosis ||
       input.all;
-    // A search names its session through the result: --session-id and SESSION_ID are not read.
+    // A search names its session through the result: a parsed --session-id or SESSION_ID has no
+    // say in it.
     if (input.search) {
       const resultId = yield* orRefuse(
         Effect.succeed(input.testResultId),

--- a/src/db/tests.ts
+++ b/src/db/tests.ts
@@ -189,6 +189,14 @@ export class TestStore extends Context.Service<TestStore>()("@oligarchy/db/TestS
       return rows.length > 0;
     });
 
+    // The result by its id, whether or not a session has run it yet.
+    const findResult = Effect.fn("db.findResult")(function* (resultId: string) {
+      const rows = yield* database.run("findResult", (db) =>
+        db.select().from(DbSchema.testResults).where(eq(DbSchema.testResults.id, resultId)),
+      );
+      return Arr.head(rows);
+    });
+
     // The result a session ran, with the definition it tested and the run it belongs to.
     const resultForSession = Effect.fn("db.resultForSession")(function* (sessionId: string) {
       return yield* database.run("resultForSession", (db) =>
@@ -218,6 +226,7 @@ export class TestStore extends Context.Service<TestStore>()("@oligarchy/db/TestS
       failRun,
       startResult,
       closeResult,
+      findResult,
       resultForSession,
     };
   }),

--- a/test/config/config.unit.test.ts
+++ b/test/config/config.unit.test.ts
@@ -56,6 +56,7 @@ describe("requiredRedacted", () => {
       expect(Redacted.value(yield* Config.linearApiToken)).toBe("c");
       expect(Redacted.value(yield* Config.cursorApiToken)).toBe("d");
       expect(yield* Config.serverUrl).toBe("e");
+      expect(yield* Config.sessionId).toBe("f");
     }).pipe(
       Effect.provide(
         Support.withEnv({
@@ -64,6 +65,7 @@ describe("requiredRedacted", () => {
           LINEAR_API_TOKEN: "c",
           CURSOR_API_TOKEN: "d",
           SERVER_URL: "e",
+          SESSION_ID: "f",
         }),
       ),
     ),
@@ -75,6 +77,14 @@ describe("requiredRedacted", () => {
       expect(error._tag).toBe("ConfigError");
       expect(Config.DEFAULT_SERVER_URL).toBe("http://127.0.0.1:42069");
     }).pipe(Effect.provide(Support.withEnv({ SERVER_URL: "" }))),
+  );
+
+  // A flag fallback, like SERVER_URL: an empty SESSION_ID is unset, so the flag's own rule applies.
+  it.effect("sessionId treats an empty SESSION_ID as unset", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(Config.sessionId);
+      expect(error._tag).toBe("ConfigError");
+    }).pipe(Effect.provide(Support.withEnv({ SESSION_ID: "" }))),
   );
 });
 

--- a/test/ctrl/command.unit.test.ts
+++ b/test/ctrl/command.unit.test.ts
@@ -2489,7 +2489,7 @@ describe("session --search", () => {
     }),
   );
 
-  it.effect("reads neither --session-id nor SESSION_ID: the result names the session (happy)", () =>
+  it.effect("--session-id and SESSION_ID have no say: the result names the session (happy)", () =>
     Effect.gen(function* () {
       const h = harness();
       h.stores.tests.results.push(result(RESULT_ID, "passed", SESSION_ID));

--- a/test/ctrl/command.unit.test.ts
+++ b/test/ctrl/command.unit.test.ts
@@ -2456,6 +2456,127 @@ describe("session inspect", () => {
 });
 
 // ---------------------------------------------------------------------------
+// session --search
+// ---------------------------------------------------------------------------
+
+// The other way round from inspection: a result id in, the session that ran it out, as one bare
+// line a shell can capture into SESSION_ID.
+const SEARCH = ["session", "--search", `--test-result-id=${RESULT_ID}`];
+
+describe("session --search", () => {
+  it.effect("prints the bare id of the session a result ran in (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.tests.results.push(
+        result(OTHER_RESULT_ID, "passed", OTHER_SESSION_ID),
+        result(RESULT_ID, "passed", SESSION_ID),
+      );
+      const exit = yield* h.run(SEARCH);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* stdout).toEqual([SESSION_ID]);
+      expect(h.log.lines).toEqual([]);
+      expect(h.touched).toEqual(["database"]);
+    }),
+  );
+
+  it.effect("finds a result still running, with --test-result-id spaced (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.tests.results.push(result(RESULT_ID, "running", SESSION_ID));
+      const exit = yield* h.run(["session", "--search", "--test-result-id", RESULT_ID]);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* stdout).toEqual([SESSION_ID]);
+    }),
+  );
+
+  it.effect("reads neither --session-id nor SESSION_ID: the result names the session (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.tests.results.push(result(RESULT_ID, "passed", SESSION_ID));
+      const flagged = yield* h.run([...SEARCH, "--session-id", OTHER_SESSION_ID]);
+      expect(Exit.isSuccess(flagged)).toBe(true);
+      const fromEnv = yield* h.run(SEARCH, { ...WITH_DB, SESSION_ID: OTHER_SESSION_ID });
+      expect(Exit.isSuccess(fromEnv)).toBe(true);
+      expect(yield* stdout).toEqual([SESSION_ID, SESSION_ID]);
+    }),
+  );
+
+  it.effect("rejects a result nobody has (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.tests.results.push(result(OTHER_RESULT_ID, "passed", SESSION_ID));
+      expect(yield* h.fail(SEARCH)).toMatchObject({
+        _tag: "CommandError",
+        message: `session: no test result ${RESULT_ID}`,
+      });
+      expect(yield* stdout).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects a result no session has run yet (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.tests.results.push(result(RESULT_ID, "pending", null));
+      expect(yield* h.fail(SEARCH)).toMatchObject({
+        _tag: "CommandError",
+        message: `session: result ${RESULT_ID} has no session yet`,
+      });
+      expect(yield* stdout).toEqual([]);
+    }),
+  );
+
+  it.effect("--search needs --test-result-id, and --test-result-id needs --search (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      seedInspect(h);
+      h.stores.tests.results.push(result(RESULT_ID, "passed", SESSION_ID));
+      expect(yield* h.fail(["session", "--search"])).toMatchObject({
+        _tag: "CommandError",
+        message: "session: --search needs --test-result-id",
+      });
+      expect(
+        yield* h.fail([
+          "session",
+          "--session-id",
+          SESSION_ID,
+          "--test-result-id",
+          RESULT_ID,
+          "--logs",
+        ]),
+      ).toMatchObject({
+        _tag: "CommandError",
+        message: "session: --test-result-id needs --search",
+      });
+      expect(yield* stdout).toEqual([]);
+    }),
+  );
+
+  it.effect("--search takes no selector: inspection goes through the id it prints (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.tests.results.push(result(RESULT_ID, "passed", SESSION_ID));
+      expect(yield* h.fail([...SEARCH, "--all"])).toMatchObject({
+        _tag: "CommandError",
+        message: "session: --search takes no selector",
+      });
+      expect(yield* h.fail([...SEARCH, "--logs", "--status"])).toMatchObject({
+        message: "session: --search takes no selector",
+      });
+      expect(yield* stdout).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects an empty --test-result-id before touching the database (unhappy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      const exit = yield* h.run(["session", "--search", "--test-result-id", ""]);
+      expect(helpErrors(exit).join("\n")).toMatch(/--test-result-id.*length of at least 1/s);
+      expect(h.touched).toEqual([]);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Environment, server url, help
 // ---------------------------------------------------------------------------
 
@@ -2515,6 +2636,7 @@ describe("environment order", () => {
           ["test-results", "--agent-id", "a", "--id", RESULT_ID, "--status", "success"],
           ["session", "list"],
           ["session", "--session-id", SESSION_ID, "--logs"],
+          SEARCH,
           NEW_TYPE,
           ["error-type", "list"],
           DIAGNOSE,
@@ -2568,6 +2690,7 @@ describe("--server-url", () => {
     ["test", "run", "--ticket", "OLI-42"],
     ["session", "list"],
     ["session", "--session-id", SESSION_ID, "--logs"],
+    SEARCH,
     NEW_TYPE,
     ["error-type", "list"],
     DIAGNOSE,
@@ -2652,6 +2775,7 @@ describe("--server-url", () => {
         TEST_RESULTS,
         ["session", "list"],
         ["session", "--session-id", SESSION_ID, "--logs"],
+        SEARCH,
         NEW_TYPE,
         ["error-type", "list"],
         DIAGNOSE_RUN,
@@ -2696,6 +2820,132 @@ describe("--server-url", () => {
       expect(Exit.isSuccess(good)).toBe(true);
       expect(h.stores.tests.runs[0]?.serverUrl).toBe(SERVER);
     }),
+  );
+});
+
+// The session a command is about may come from the environment: SESSION_ID stands in for
+// --session-id on every action that takes it, and the flag wins when both are given.
+describe("SESSION_ID", () => {
+  const WITH_SESSION = { ...WITH_DB, SESSION_ID };
+
+  it.effect("stands in for --session-id on session (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      seedInspect(h);
+      const exit = yield* h.run(["session", "--status"], WITH_SESSION);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* lastJson).toMatchObject({ id: SESSION_ID, status: "succeeded" });
+    }),
+  );
+
+  it.effect("stands in for --session-id on test start (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      h.stores.sessions.sessions.push(session(SESSION_ID, "running", ago(10)));
+      h.stores.tests.results.push(result(RESULT_ID, "pending", null));
+      const exit = yield* h.run(
+        ["test", "start", "--test-result-id", RESULT_ID, "--model", MODEL],
+        WITH_SESSION,
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(h.stores.tests.results[0]).toMatchObject({
+        status: "running",
+        sessionId: SESSION_ID,
+        model: MODEL,
+      });
+      expect(h.log.lines.map((line) => [line.text, line.sessionId])).toEqual([
+        [`test result ${RESULT_ID}: running`, SESSION_ID],
+      ]);
+    }),
+  );
+
+  it.effect("stands in for --session-id on diagnose run and diagnose (happy)", () =>
+    Effect.gen(function* () {
+      // A template of this test's own: the session is what reaches the reviewer, whatever else the
+      // checkout's kickoff template asks for.
+      const fs = promptFs(/never/, "<session_id>{{SESSION_ID}}</session_id>\n");
+      const h = harness({ cursor: FakeCursor.fakeCursor({ agentId: "bc-42" }), fs: fs.layer });
+      h.stores.sessions.sessions.push(session(SESSION_ID, "failed", ago(500)));
+      const run = yield* h.run(["diagnose", "run"], { ...WITH_SESSION, CURSOR_API_TOKEN: "c" });
+      expect(Exit.isSuccess(run)).toBe(true);
+      expect(h.cursor.calls).toHaveLength(1);
+      expect(h.cursor.calls[0]?.text).toContain(`<session_id>${SESSION_ID}</session_id>`);
+      h.stores.diagnosis.errorTypes.push(bootHang);
+      const written = yield* h.run(
+        [
+          "diagnose",
+          "--verdict",
+          "failed",
+          "--type",
+          bootHang.key,
+          "--summary",
+          diagnosis.summary,
+          "--model",
+          MODEL,
+        ],
+        WITH_SESSION,
+      );
+      expect(Exit.isSuccess(written)).toBe(true);
+      expect(h.stores.diagnosis.diagnoses.map((row) => row.sessionId)).toEqual([SESSION_ID]);
+      expect(h.log.lines.map((line) => line.sessionId)).toEqual([SESSION_ID]);
+    }),
+  );
+
+  it.effect("the flag wins over SESSION_ID (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      seedInspect(h);
+      h.stores.sessions.sessions.push(session(OTHER_SESSION_ID, "failed", ago(100)));
+      const exit = yield* h.run(
+        ["session", "--session-id", OTHER_SESSION_ID, "--status"],
+        WITH_SESSION,
+      );
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* lastJson).toMatchObject({ id: OTHER_SESSION_ID, status: "failed" });
+    }),
+  );
+
+  it.effect(
+    "session with neither is refused before the selector check, an empty SESSION_ID counting as unset (unhappy)",
+    () =>
+      Effect.gen(function* () {
+        const h = harness();
+        seedInspect(h);
+        expect(yield* h.fail(["session", "--status"])).toMatchObject({
+          _tag: "CommandError",
+          message: "session: --session-id or SESSION_ID is required",
+        });
+        expect(
+          yield* h.fail(["session", "--status"], { ...WITH_DB, SESSION_ID: "" }),
+        ).toMatchObject({
+          _tag: "CommandError",
+          message: "session: --session-id or SESSION_ID is required",
+        });
+        expect(yield* h.fail(["session"])).toMatchObject({
+          message: "session: --session-id or SESSION_ID is required",
+        });
+        expect(yield* stdout).toEqual([]);
+      }),
+  );
+
+  it.effect(
+    "test start, diagnose and diagnose run with neither are usage errors that touch nothing (unhappy)",
+    () =>
+      Effect.gen(function* () {
+        const h = harness();
+        for (const args of [
+          ["test", "start", "--test-result-id", RESULT_ID, "--model", MODEL],
+          ["diagnose", "--verdict", "passed", "--summary", "s", "--model", MODEL],
+          ["diagnose", "run"],
+        ]) {
+          const exit = yield* h.run(args, { ...WITH_DB, CURSOR_API_TOKEN: "c", SESSION_ID: "" });
+          expect(helpErrors(exit).join("\n"), args.join(" ")).toMatch(
+            /Missing required flag: --session-id/,
+          );
+        }
+        expect(h.touched).toEqual([]);
+        expect(h.cursor.calls).toEqual([]);
+      }),
   );
 });
 

--- a/test/integration/ctrl.integration.test.ts
+++ b/test/integration/ctrl.integration.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import * as DbSchema from "../../src/db/schema.ts";
@@ -43,6 +44,8 @@ const runCtrl = (args: ReadonlyArray<string>, env: Record<string, string> = {}):
         SERVER_URL: "",
         LINEAR_API_TOKEN: "",
         CURSOR_API_TOKEN: "",
+        // The session comes from the flag unless a test names it here.
+        SESSION_ID: "",
         ...env,
       },
     });
@@ -85,6 +88,46 @@ const seedEndedSession = async (
     await client.end();
   }
   return sessionId;
+};
+
+// A run with one result for the seeded definition, tied to the session given, or to none: the
+// row `test new` would create, without Linear.
+const seedResult = async (sessionId: string | null): Promise<string> => {
+  const client = new Client({ connectionString: Postgres.getDbUrl() });
+  await client.connect();
+  try {
+    const db = drizzle({ client });
+    const [definition] = await db
+      .select({ id: DbSchema.testDefinitions.id })
+      .from(DbSchema.testDefinitions)
+      .where(eq(DbSchema.testDefinitions.name, DEFINITION))
+      .limit(1);
+    if (definition === undefined) {
+      throw new Error(`seed: no test definition ${DEFINITION}`);
+    }
+    const [run] = await db
+      .insert(DbSchema.testRuns)
+      .values({ name: "seed", iso: "https://example.com/omarchy.iso", serverUrl: SERVER })
+      .returning({ id: DbSchema.testRuns.id });
+    if (run === undefined) {
+      throw new Error("seed: no run inserted");
+    }
+    const [result] = await db
+      .insert(DbSchema.testResults)
+      .values({
+        runId: run.id,
+        definitionId: definition.id,
+        sessionId,
+        status: sessionId === null ? "pending" : "running",
+      })
+      .returning({ id: DbSchema.testResults.id });
+    if (result === undefined) {
+      throw new Error("seed: no result inserted");
+    }
+    return result.id;
+  } finally {
+    await client.end();
+  }
 };
 
 const lines = (text: string): ReadonlyArray<string> =>
@@ -278,6 +321,7 @@ describe("./ctrl without a database", () => {
       ],
       ["session", "list"],
       ["session", "--session-id", SUCCEEDED_ID, "--logs"],
+      ["session", "--search", "--test-result-id", randomUUID()],
       ["error-type", "new", "--key", "k", "--description", "d"],
       ["error-type", "list"],
       [
@@ -303,6 +347,45 @@ describe("./ctrl without a database", () => {
       expect(result.code).toBe(1);
       expect(result.stdout).toBe("");
       expect(firstLine(result.stderr)).toBe("DATABASE_URL is not set");
+    }
+  });
+
+  it("session refuses the flag pairs that cannot combine before any query, and wants a session from somewhere", async () => {
+    const env = { DATABASE_URL: UNUSED_DB };
+    const cases: ReadonlyArray<readonly [ReadonlyArray<string>, string]> = [
+      [["session", "--search"], "session: --search needs --test-result-id"],
+      [
+        ["session", "--search", "--test-result-id", randomUUID(), "--all"],
+        "session: --search takes no selector",
+      ],
+      [
+        ["session", "--session-id", randomUUID(), "--test-result-id", randomUUID(), "--logs"],
+        "session: --test-result-id needs --search",
+      ],
+      [["session", "--status"], "session: --session-id or SESSION_ID is required"],
+      [["session"], "session: --session-id or SESSION_ID is required"],
+    ];
+    for (const [args, headline] of cases) {
+      const result = await runCtrl(args, env);
+      expect(result.code, args.join(" ")).toBe(1);
+      expect(result.stdout, args.join(" ")).toBe("");
+      expect(firstLine(result.stderr), args.join(" ")).toBe(headline);
+      expect(result.stderr, args.join(" ")).toMatch(/CommandError/);
+      expect(result.stderr, args.join(" ")).not.toMatch(/ECONNREFUSED/);
+    }
+  });
+
+  it("test start, diagnose and diagnose run without --session-id or SESSION_ID are usage errors", async () => {
+    const env = { DATABASE_URL: UNUSED_DB, CURSOR_API_TOKEN: TOKEN };
+    for (const args of [
+      ["test", "start", "--test-result-id", randomUUID(), "--model", "m"],
+      ["diagnose", "--verdict", "passed", "--summary", "s", "--model", "m"],
+      ["diagnose", "run"],
+    ]) {
+      const result = await runCtrl(args, env);
+      expect(result.code, args.join(" ")).toBe(1);
+      expect(result.stdout.includes("{"), args.join(" ")).toBe(false);
+      expect(result.stderr, args.join(" ")).toMatch(/Missing required flag: --session-id/);
     }
   });
 
@@ -443,6 +526,16 @@ describe("./ctrl without a database", () => {
       [
         ["session", "--session-id", randomUUID(), "--logs", "--count", "3"],
         /Unrecognized flag: --count/,
+        env,
+      ],
+      [
+        ["session", "--search", "--test-result-id", ""],
+        /--test-result-id[\s\S]*length of at least 1/,
+        env,
+      ],
+      [
+        ["session", "--search", "--test-result-id", randomUUID(), "--server-url", SERVER],
+        /Unrecognized flag: --server-url/,
         env,
       ],
       [
@@ -960,6 +1053,64 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
       `diagnose run: session ${diagnosed} already has a diagnosis`,
     );
     expect(StubCursor.createdAgents(stub)).toEqual([]);
+  });
+
+  it("session --search prints the session a result ran in, which SESSION_ID then names for inspection", async () => {
+    const sessionId = await seedEndedSession("succeeded", "lock screen on screen");
+    const resultId = await seedResult(sessionId);
+    const found = await runCtrl(["session", "--search", `--test-result-id=${resultId}`]);
+    expect(found.stderr).toBe("");
+    expect(found.code).toBe(0);
+    expect(found.stdout).toBe(`${sessionId}\n`);
+
+    // The bare line is made to be captured: SESSION_ID=$(./ctrl session --search ...).
+    const inspected = await runCtrl(["session", "--status"], { SESSION_ID: sessionId });
+    expect(inspected.stderr).toBe("");
+    expect(inspected.code).toBe(0);
+    expect(JSON.parse(inspected.stdout)).toMatchObject({ id: sessionId, status: "succeeded" });
+
+    // The flag wins over the environment.
+    const flagged = await runCtrl(["session", "--session-id", SUCCEEDED_ID, "--status"], {
+      SESSION_ID: sessionId,
+    });
+    expect(flagged.code).toBe(0);
+    expect(JSON.parse(flagged.stdout)).toMatchObject({ id: SUCCEEDED_ID });
+
+    // SESSION_ID names the session for test start and diagnose too; here it starts the result
+    // a second seeded run holds and then reviews the same session.
+    const pendingId = await seedResult(null);
+    const startSession = await seedEndedSession("failed");
+    const started = await runCtrl(
+      ["test", "start", "--test-result-id", pendingId, "--model", "composer-2.5"],
+      { SESSION_ID: startSession },
+    );
+    expect(started.stderr).toBe("");
+    expect(started.code).toBe(0);
+    const startedSearch = await runCtrl(["session", "--search", "--test-result-id", pendingId]);
+    expect(startedSearch.code).toBe(0);
+    expect(startedSearch.stdout).toBe(`${startSession}\n`);
+    const diagnosed = await runCtrl(
+      ["diagnose", "--verdict", "passed", "--summary", "s", "--model", "composer-2.5"],
+      { SESSION_ID: startSession },
+    );
+    expect(diagnosed.stderr).toBe("");
+    expect(diagnosed.code).toBe(0);
+    expect(diagnosed.stdout).toBe(`[global] ${startSession}: diagnosed; passed; composer-2.5\n`);
+  });
+
+  it("session --search refuses a result nobody has and one no session has run yet", async () => {
+    const unknownId = randomUUID();
+    const unknown = await runCtrl(["session", "--search", "--test-result-id", unknownId]);
+    expect(unknown.code).toBe(1);
+    expect(unknown.stdout).toBe("");
+    expect(firstLine(unknown.stderr)).toBe(`session: no test result ${unknownId}`);
+    expect(unknown.stderr).toMatch(/CommandError/);
+
+    const pendingId = await seedResult(null);
+    const pending = await runCtrl(["session", "--search", "--test-result-id", pendingId]);
+    expect(pending.code).toBe(1);
+    expect(pending.stdout).toBe("");
+    expect(firstLine(pending.stderr)).toBe(`session: result ${pendingId} has no session yet`);
   });
 
   it("session requires a selector and rejects an unknown session", async () => {

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -793,12 +793,25 @@ Postgres.describeWithDatabase("database", () => {
         expect(created.results).toHaveLength(1);
         const [result] = created.results;
         expect(result?.definitionId).toBe(definition.id);
+        // A result is found by its id from creation on; it names no session until start.
+        expect(Option.getOrThrow(yield* tests.findResult(result.id))).toMatchObject({
+          id: result.id,
+          runId: created.runId,
+          sessionId: null,
+          status: "pending",
+        });
 
         const sessionId = uuid();
         yield* sessions.insertSession(sessionId, { iso: "x" }, "running");
         expect(yield* tests.startResult(result.id, sessionId, "composer-2.5")).toBe(true);
         expect(yield* tests.startResult(result.id, sessionId, "composer-2.5")).toBe(false);
         expect(yield* tests.startResult(uuid(), sessionId, "composer-2.5")).toBe(false);
+        expect(Option.getOrThrow(yield* tests.findResult(result.id))).toMatchObject({
+          sessionId,
+          status: "running",
+          model: "composer-2.5",
+        });
+        expect(Option.isNone(yield* tests.findResult(uuid()))).toBe(true);
 
         // A newer wording of the same name does not move the result: it pinned the row it ran.
         const revised = yield* tests.defineTestDefinition({

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -456,6 +456,8 @@ export const fakeTestStore = (
         row.finishedAt = new Date();
         return true;
       }),
+    findResult: (resultId) =>
+      Effect.sync(() => Option.fromUndefinedOr(results.find((row) => sameId(row.id, resultId)))),
     // Inner joins, as the real query: a result whose definition or run is missing is no row.
     resultForSession: (sessionId) =>
       Effect.sync(() =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Two additions to `./ctrl`:

1. `./ctrl session --search --test-result-id <id>` prints the id of the session that ran a test result, as one bare line, so a shell can `SESSION_ID=$(./ctrl session --search --test-result-id <id>) && export SESSION_ID`.
2. `--session-id` on `test start`, `session`, `diagnose` and `diagnose run` falls back to `SESSION_ID` from the environment when omitted. The flag wins; an empty value counts as unset (same shape as `SERVER_URL`).

## How

- `Config.sessionId` (`src/config.ts`) — `Flag.withFallbackConfig` on the shared `--session-id` flag.
- `TestStore.findResult` (`src/db/tests.ts`) — the result row by id, `Option`; `session_id` is null until `test start`, so the CLI can tell "no test result" from "no session yet". Fake in `test/support/stores.ts`.
- `session` command (`src/ctrl/command.ts`) — `--session-id` is optional there alone (a search needs none), plus `--search` and `--test-result-id`. Refusals, in order: `--search needs --test-result-id`, `--search takes no selector`, `--test-result-id needs --search`, `--session-id or SESSION_ID is required`, then the selector check, then the query. A parsed `--session-id`/`SESSION_ID` has no say in a search.
- `ctrl.md` — new `session --search` section, the `SESSION_ID` paragraph, fallback notes on each `--session-id` bullet, TOC line numbers.

## Tests (written first)

- `test/config/config.unit.test.ts`: `Config.sessionId` reads `SESSION_ID`; empty is unset.
- `test/ctrl/command.unit.test.ts`: `session --search` happy/unhappy (found, running, unknown result, no session yet, flag pairs, empty id, unaffected by `--session-id`/`SESSION_ID`); `SESSION_ID` on all four actions, flag precedence, neither given; search added to the every-action loops.
- `test/integration/db.integration.test.ts`: `findResult` before/after start and a miss.
- `test/integration/ctrl.integration.test.ts`: black-box exit codes and headlines with and without a database; `SESSION_ID: ""` blanked in the child env.

## Verification

- `npm run check:fast`: lint, format, types green; unit 849 passed, 5 failed — the same 5 that fail on `master` (`prompts/diagnosing-agent.html` asks for `{{LINEAR_TICKET}}`/`{{MODEL}}` which `diagnose run` never supplies; introduced in 2f6eeec, not touched here).
- Integration: no Docker in this environment, so Testcontainers skipped; ran the `ctrl` and `db` integration files against a local Postgres 16 via a throwaway vitest config under `/tmp`. All new tests pass. Remaining failures there are pre-existing on `master` (`diagnose run` prompt drift; `startResult` unique-violation message lacks the index name).
- Reviewed by a GPT-5.6 Sol subagent per `development.md`; its two findings (checked `SESSION_ID` assignment in the docs; "has no say" rather than "not read") are in the third commit.

[ctrl_session_search_and_session_id_demo.log](https://cursor.com/agents/bc-ea23e420-86ca-4107-9a5a-b0629f4137ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fctrl_session_search_and_session_id_demo.log)

## Notes

- Flag spelling is singular `--test-result-id`, matching `test start`.
- `ctrl-linear.md` / `ctrl-diagnose.md` (agent guides embedded in prompts) are unchanged: drivers and reviewers are handed explicit ids.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea23e420-86ca-4107-9a5a-b0629f4137ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea23e420-86ca-4107-9a5a-b0629f4137ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

