### PR TITLE
proxy: delete the servers row on shutdown

### DIFF
--- a/SERVER_VS_REVERSE_PROXY.md
+++ b/SERVER_VS_REVERSE_PROXY.md
@@ -375,9 +375,10 @@ Every surface has a happy and an unhappy test:
 - `test/proxy/heartbeat.unit.test.ts` runs the loop under the `TestClock` over the fake
   `Sessions` and `ServerStore`: a write at once and every thirty seconds with the stats cut to
   the row's shape, the loop ending with its scope, the row deleted on that close (other servers
-  left), a refused write as one `heartbeat failed: <driver's reason>` line with the next tick
-  still writing, a defect logged the same way, a refused delete as one `unannounce failed:
-  <driver's reason>` line that still lets the scope close, a missing row not an error.
+  left), a write in flight finishing before the delete, a refused write as one `heartbeat
+  failed: <driver's reason>` line with the next tick still writing, a defect logged the same way,
+  a refused delete as one `unannounce failed: <driver's reason>` line that still lets the scope
+  close, a missing row not an error.
   `test/proxy/command.unit.test.ts` pins `--url` reaching the server, its absence as none, a url
   the rule refuses as a usage error touching nothing, and `--help` listing it.
   `test/qemu/stats.unit.test.ts` pins the three means over the newest 12, 24 and 36 samples.

--- a/SERVER_VS_REVERSE_PROXY.md
+++ b/SERVER_VS_REVERSE_PROXY.md
@@ -22,7 +22,7 @@ are served from.
 | Writes | `sessions`, `agent_runs`, `actions`, `images`, `debug_logs`, `logs`, its `servers` row | `servers`, `session_servers`, `logs` |
 | Serves images | No: `GET /images/:id` is the catch-all's 404 | No: the same 404 |
 | Background work | The 10 s timeout sweep, the cpu sampler, the 30 s heartbeat, the log drain | The log drain only |
-| At shutdown | Drains every session (`aborted`, `proxy shutdown`) | Nothing: the sessions are the servers' and the routes are rows |
+| At shutdown | Drains every session (`aborted`, `proxy shutdown`); deletes its `servers` row | Nothing: the sessions are the servers' and the routes are rows |
 | Sentry spans | `QEMU session`, the intent, `QMP <cmd>` | None; only error lines report |
 
 ## Responsibilities
@@ -42,13 +42,15 @@ Started with `--url <url>`, the server also announces itself: once its listener 
 thirty seconds after, it rewrites its own row in `servers` (keyed by that url) with what `/stats`
 would answer, cut to what the fleet page shows — its qemu count, memory in use and the cpu's one,
 two and three minute means — stamps `heartbeat_at` with the database's clock and counts
-`generation` up by one. Every write is a ping: a generation that stops moving is a server that
-stopped heartbeating — the process is down, or it cannot reach the database (its own log then has
-the `heartbeat failed` lines) — and the dashboard says so either way. The url is the address the
-reverse proxy reaches the server at (a tunnel's local port, say), which the server cannot see for
-itself, hence a flag and no default; without it the server announces nothing and is not on the
-page, which is what a development server wants. A heartbeat that fails is one `heartbeat failed:
-<reason>` error line, and the next one runs. `/stats` carries the three means too (`cpu.mean1m`,
+`generation` up by one. A shutdown deletes that row, so a process that left is gone from the
+fleet and from placement. Every write is a ping: a generation that stops moving is a server that
+stopped without deleting — killed, or it cannot reach the database (its own log then has the
+`heartbeat failed` lines, and a delete that fails is `unannounce failed: <reason>`) — and the
+dashboard says so either way. The url is the address the reverse proxy reaches the server at (a
+tunnel's local port, say), which the server cannot see for itself, hence a flag and no default;
+without it the server announces nothing and is not on the page, which is what a development
+server wants. A heartbeat that fails is one `heartbeat failed: <reason>` error line, and the next
+one runs. `/stats` carries the three means too (`cpu.mean1m`,
 `mean2m`, `mean3m`, the newest 12, 24 and 36 of the sampler's 5 s samples beside `mean` over all
 60); they are required fields of `Contract.Stats`, so a reverse proxy of this version treats an
 older server's `/stats` as `answered 200 without stats` and skips it — deploy the servers before
@@ -80,7 +82,7 @@ probes a server: what it shows is what the servers said, and the reverse proxy i
 or https url`, 400 otherwise, the reason on top of the page); `POST /servers/delete` removes one
 (404 `<url> is not registered` when there is none). A server still running announces itself back
 within thirty seconds of being deleted: the row is the server's word, the button is for the ones
-that stopped talking. A database failure is a 500 page with `error: internal error` and no fleet
+that stopped without deleting. A database failure is a 500 page with `error: internal error` and no fleet
 section, so it never claims an empty fleet. The page is unstyled text outside the dashboard's
 shell and is served whole; access control is the dashboard's, not the page's.
 
@@ -372,8 +374,10 @@ Every surface has a happy and an unhappy test:
   gone, never the password).
 - `test/proxy/heartbeat.unit.test.ts` runs the loop under the `TestClock` over the fake
   `Sessions` and `ServerStore`: a write at once and every thirty seconds with the stats cut to
-  the row's shape, the loop ending with its scope, a refused write as one `heartbeat failed:
-  <driver's reason>` line with the next tick still writing, a defect logged the same way.
+  the row's shape, the loop ending with its scope, the row deleted on that close (other servers
+  left), a refused write as one `heartbeat failed: <driver's reason>` line with the next tick
+  still writing, a defect logged the same way, a refused delete as one `unannounce failed:
+  <driver's reason>` line that still lets the scope close, a missing row not an error.
   `test/proxy/command.unit.test.ts` pins `--url` reaching the server, its absence as none, a url
   the rule refuses as a usage error touching nothing, and `--help` listing it.
   `test/qemu/stats.unit.test.ts` pins the three means over the newest 12, 24 and 36 samples.
@@ -473,4 +477,5 @@ Sentry reports are the record. The lines to know: `server registered; <url>`,
 `routed; <url>` (attributed to the new session and its agent), `forward cut short; <reason>`, and
 `<METHOD> <url> failed: <reason>` for every request it refused itself. On a server started with
 `--url`, the listen line ends `; announcing <url>` and a heartbeat that could not be written is
-`heartbeat failed: <reason>`.
+`heartbeat failed: <reason>`. A shutdown deletes the row; a delete that could not be written is
+`unannounce failed: <reason>`.

--- a/development.md
+++ b/development.md
@@ -491,7 +491,7 @@ NodeRuntime.runMain(main, { disableErrorReporting: true });
   page is the dashboard's (`src/dashboard/`), behind its access control, and reads rows. What it
   shows of a process is what that process wrote on a schedule (the server's `servers` row every
   thirty seconds, its `generation` counting the writes, so a number that stops moving is a process
-  that stopped), never a call into the process from the Worker. The page is text: a table, a
+  that stopped without deleting its row), never a call into the process from the Worker. The page is text: a table, a
   form, and htmx polling one fragment at the interval the rows are written at; a value from a
   row goes into it through JSX, never a string template.
 - Declare endpoints as `HttpApiEndpoint.get/post(name, path, { params, query, payload, success,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -184,9 +184,10 @@ export type ServerStats = {
 // The fleet the reverse proxy places sessions on: one row per server, keyed by the url exactly
 // as given, written by an operator (the dashboard, POST /servers) or by the server itself. A
 // server announces itself every thirty seconds: the write rewrites stats, stamps heartbeat_at
-// and counts generation up, so a generation that stops moving is a server that stopped
-// heartbeating — down, or cut off from the database. stats and heartbeat_at are null together,
-// for a row an operator added that no server has claimed.
+// and counts generation up, and a shutdown deletes the row. A generation that stops moving is
+// a server that stopped without a chance to leave — killed, or cut off from the database.
+// stats and heartbeat_at are null together, for a row an operator added that no server has
+// claimed.
 export const servers = pgTable("servers", {
   url: text("url").primaryKey(),
   stats: jsonb("stats").$type<ServerStats>(),

--- a/src/proxy/command.ts
+++ b/src/proxy/command.ts
@@ -61,7 +61,7 @@ export const makeProxyCommand = <RHost, RServe>(server: ProxyServer<RHost, RServ
         Flag.withSchema(Domain.ServerUrl),
         Flag.optional,
         Flag.withDescription(
-          "Announce this server to the fleet under this url, every 30 seconds, as the reverse proxy reaches it",
+          "Announce this server to the fleet under this url, every 30 seconds, and delete the row on shutdown",
         ),
       ),
     },

--- a/src/proxy/heartbeat.ts
+++ b/src/proxy/heartbeat.ts
@@ -20,7 +20,11 @@ const detail = (error: unknown): string =>
 
 // Announces this server under `url`: its `servers` row is written now and every thirty seconds
 // with what it knows of itself, and the row's generation counts the writes, so a number that
-// stops moving is a server that stopped. A tick that fails is one error line; the next tick runs.
+// stops moving is a server that stopped without a chance to leave. A tick that fails is one
+// error line; the next tick runs. The row is this process's word on itself, so a shutdown
+// deletes it: registered before the loop so the fiber is interrupted first, a write in flight
+// finishes (the write is uninterruptible), then the row goes. A delete that fails is one
+// `unannounce failed` line; the process still exits.
 export const announce = (
   url: string,
 ): Effect.Effect<void, never, Scope.Scope | Sessions.Sessions | Servers.ServerStore | Log.Log> =>
@@ -30,16 +34,28 @@ export const announce = (
     const log = yield* Log.Log;
     const tick = sessions.stats.pipe(
       Effect.flatMap((stats) =>
-        store.heartbeat(url, {
-          qemus: stats.qemus,
-          memory: { totalBytes: stats.memory.totalBytes, usedBytes: stats.memory.usedBytes },
-          cpu: { mean1m: stats.cpu.mean1m, mean2m: stats.cpu.mean2m, mean3m: stats.cpu.mean3m },
-        }),
+        Effect.uninterruptible(
+          store.heartbeat(url, {
+            qemus: stats.qemus,
+            memory: { totalBytes: stats.memory.totalBytes, usedBytes: stats.memory.usedBytes },
+            cpu: { mean1m: stats.cpu.mean1m, mean2m: stats.cpu.mean2m, mean3m: stats.cpu.mean3m },
+          }),
+        ),
       ),
       Effect.catchCause((cause) => {
         const error = Cause.squash(cause);
         return log.error(`heartbeat failed: ${detail(error)}`, { cause: error });
       }),
+    );
+    // Before the loop: close interrupts the fiber first, then this runs.
+    yield* Effect.addFinalizer(() =>
+      store.removeServer(url).pipe(
+        Effect.catchCause((cause) => {
+          const error = Cause.squash(cause);
+          return log.error(`unannounce failed: ${detail(error)}`, { cause: error });
+        }),
+        Effect.asVoid,
+      ),
     );
     yield* tick.pipe(
       Effect.repeat(Schedule.spaced(HEARTBEAT_INTERVAL)),

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -47,7 +47,7 @@ server.on("error", (cause) => {
 });
 
 // The heartbeat starts once the listener is up, in the same scope: a port refusal announces
-// nothing, and the row stops being written when the server stops.
+// nothing, and a shutdown deletes the row it wrote.
 const ServerLive = (
   display: Domain.QemuDisplay,
   automation: boolean,

--- a/test/integration/proxy.integration.test.ts
+++ b/test/integration/proxy.integration.test.ts
@@ -449,7 +449,7 @@ describe("proxy serving", () => {
     }).pipe(Effect.provide(Postgres.DatabaseLive(dbUrl)));
 
   it.live.skipIf(!hasQemu || dbUrl === "")(
-    "--url names the url on the listen line and writes the server's row as its first heartbeat",
+    "--url names the url on the listen line, writes the server's row as its first heartbeat, and deletes it on SIGTERM",
     () =>
       Effect.gen(function* () {
         const port = yield* Effect.promise(freePort);
@@ -481,6 +481,8 @@ describe("proxy serving", () => {
         const { code } = yield* Effect.promise(() => proxy.exited);
         expect(code, proxy.stdout()).toBe(0);
         expect(proxy.stdout()).not.toContain("heartbeat failed");
+        expect(proxy.stdout()).not.toContain("unannounce failed");
+        expect(yield* announced(url)).toBeUndefined();
       }),
     120_000,
   );

--- a/test/proxy/heartbeat.unit.test.ts
+++ b/test/proxy/heartbeat.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
-import { Effect, Exit, Layer, Scope } from "effect";
+import { Deferred, Effect, Exit, Fiber, Layer, Scope } from "effect";
 import { TestClock } from "effect/testing";
 import * as Heartbeat from "../../src/proxy/heartbeat.ts";
 import * as Errors from "../../src/shared/errors.ts";
@@ -77,6 +77,36 @@ describe("heartbeat happy path", () => {
       yield* Scope.close(scope, Exit.void);
       expect(store.servers).toEqual([other]);
       expect(log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("a write in flight finishes before the row is deleted", () =>
+    Effect.gen(function* () {
+      const writing = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const order: Array<string> = [];
+      const store = Stores.fakeServerStore({
+        heartbeat: () =>
+          Effect.gen(function* () {
+            order.push("write");
+            yield* Deferred.succeed(writing, undefined);
+            yield* Deferred.await(release);
+          }),
+        removeServer: () =>
+          Effect.sync(() => {
+            order.push("delete");
+            return true;
+          }),
+      });
+      const { scope } = yield* start(store);
+      yield* Deferred.await(writing);
+      const closed = yield* Effect.forkChild(Scope.close(scope, Exit.void));
+      yield* Effect.yieldNow;
+      expect(closed.pollUnsafe()).toBeUndefined();
+      expect(order).toEqual(["write"]);
+      yield* Deferred.succeed(release, undefined);
+      yield* Fiber.join(closed);
+      expect(order).toEqual(["write", "delete"]);
     }),
   );
 });

--- a/test/proxy/heartbeat.unit.test.ts
+++ b/test/proxy/heartbeat.unit.test.ts
@@ -66,6 +66,19 @@ describe("heartbeat happy path", () => {
       expect(store.heartbeats).toHaveLength(2);
     }),
   );
+
+  it.effect("deletes its own row when the scope closes, and leaves every other server", () =>
+    Effect.gen(function* () {
+      const store = Stores.fakeServerStore();
+      const other = "http://127.0.0.1:1";
+      store.servers.push(other);
+      const { scope, log } = yield* start(store);
+      expect(store.servers).toEqual([other, URL]);
+      yield* Scope.close(scope, Exit.void);
+      expect(store.servers).toEqual([other]);
+      expect(log.lines).toEqual([]);
+    }),
+  );
 });
 
 describe("heartbeat unhappy path", () => {
@@ -126,5 +139,51 @@ describe("heartbeat unhappy path", () => {
         expect(store.heartbeats).toEqual([{ url: URL, stats: ROW_STATS }]);
         expect(log.lines).toHaveLength(1);
       }),
+  );
+
+  it.effect(
+    "a refused delete is one error line with the driver's reason, and the scope still closes",
+    () =>
+      Effect.gen(function* () {
+        const refusedDelete = Errors.DatabaseError.make({
+          operation: "removeServer",
+          message: "Failed query: delete from servers",
+          cause: new Error("connect ECONNREFUSED 127.0.0.1:5432"),
+        });
+        const store = Stores.fakeServerStore({
+          removeServer: () => Effect.fail(refusedDelete),
+        });
+        const { scope, log } = yield* start(store);
+        expect(store.servers).toEqual([URL]);
+        yield* Scope.close(scope, Exit.void);
+        expect(store.servers).toEqual([URL]);
+        expect(log.lines).toEqual([
+          {
+            level: "error",
+            text: "unannounce failed: connect ECONNREFUSED 127.0.0.1:5432",
+            sessionId: undefined,
+            agentId: undefined,
+            skipSentry: false,
+            cause: refusedDelete,
+          },
+        ]);
+      }),
+  );
+
+  it.effect("a missing row is not an error", () =>
+    Effect.gen(function* () {
+      const removals: Array<string> = [];
+      const store = Stores.fakeServerStore({
+        removeServer: (url) =>
+          Effect.sync(() => {
+            removals.push(url);
+            return false;
+          }),
+      });
+      const { scope, log } = yield* start(store);
+      yield* Scope.close(scope, Exit.void);
+      expect(removals).toEqual([URL]);
+      expect(log.lines).toEqual([]);
+    }),
   );
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A qemu proxy started with `--url` writes its own `servers` row and rewrites it every 30 seconds. Until now a graceful shutdown left that row in place, so the fleet page showed it as silent and the reverse proxy kept probing it for placement.

On SIGINT, SIGTERM, or a listener death the announce scope now deletes that row. A delete that fails is one `unannounce failed: <reason>` line; the process still exits. A crash or a cut database still leaves the row, and the existing silent detection covers that.

## Tests
- Unit: closing the announce scope deletes only this server's row
- Unit: a refused delete is one error line and the scope still closes
- Unit: a missing row is not an error
- Integration: `--url` writes the row, SIGTERM removes it

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8f59fcb-0453-4bb3-adca-e5d4981169a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8f59fcb-0453-4bb3-adca-e5d4981169a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

