### PR TITLE
Add POST /linear webhook and drop automation bearer auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.png
 /OVMF_VARS.fd
 /.env
+/automation-logs
 /node_modules
 /.wrangler
 /v1/node_modules

--- a/src/automation/command.ts
+++ b/src/automation/command.ts
@@ -39,6 +39,6 @@ export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) 
       }),
   ).pipe(
     Command.withDescription(
-      "The oligarchy automation service: POST /automate names a Linear ticket and a model, and each request is recorded as one line in ~/automation-test",
+      "The oligarchy automation service: POST /automate names a Linear ticket and a model; POST /linear records a signed Linear webhook as the exact body, one delivery per line in ~/automation-test",
     ),
   );

--- a/src/automation/command.ts
+++ b/src/automation/command.ts
@@ -39,6 +39,6 @@ export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) 
       }),
   ).pipe(
     Command.withDescription(
-      "The oligarchy automation service: POST /automate names a Linear ticket and a model; POST /linear records a signed Linear webhook as the exact body plus a trailing newline in ./automation-logs",
+      "The oligarchy automation service: POST /linear records a signed Linear webhook as the exact body plus a trailing newline in ./automation-logs",
     ),
   );

--- a/src/automation/command.ts
+++ b/src/automation/command.ts
@@ -39,6 +39,6 @@ export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) 
       }),
   ).pipe(
     Command.withDescription(
-      "The oligarchy automation service: POST /automate names a Linear ticket and a model; POST /linear records a signed Linear webhook as the exact body, one delivery per line in ./automation-logs",
+      "The oligarchy automation service: POST /automate names a Linear ticket and a model; POST /linear records a signed Linear webhook as the exact body plus a trailing newline in ./automation-logs",
     ),
   );

--- a/src/automation/command.ts
+++ b/src/automation/command.ts
@@ -39,6 +39,6 @@ export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) 
       }),
   ).pipe(
     Command.withDescription(
-      "The oligarchy automation service: POST /automate names a Linear ticket and a model; POST /linear records a signed Linear webhook as the exact body, one delivery per line in ~/automation-test",
+      "The oligarchy automation service: POST /automate names a Linear ticket and a model; POST /linear records a signed Linear webhook as the exact body, one delivery per line in ./automation-logs",
     ),
   );

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, FileSystem, Layer, Redacted } from "effect";
 import { HttpServerRequest } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
+import * as Config from "../config.ts";
 import * as Log from "../observability/log.ts";
 import * as ProxyHandlers from "../proxy/handlers.ts";
 import * as Middleware from "../proxy/middleware.ts";
@@ -11,13 +12,15 @@ import * as Signature from "./signature.ts";
 
 const ok = Contract.Ok.make({});
 
-export class LinearWebhookSecret extends Context.Service<LinearWebhookSecret, Redacted.Redacted>()(
+export class LinearWebhookSecret extends Context.Service<LinearWebhookSecret>()(
   "@oligarchy/automation/LinearWebhookSecret",
-) {}
+  { make: Config.linearWebhookSecret },
+) {
+  static readonly layer = Layer.effect(this)(this.make);
+}
 
 // No payload schema: Linear's HMAC is over the raw bytes, and the record is those same bytes
-// plus a trailing newline. A JSON payload would parse and lose the exact body. The request is
-// the HttpServerRequest service: handleRaw's request widens the requirements channel to unknown.
+// plus a trailing newline. A JSON payload would parse and lose the exact body.
 export const LinearLive = (record: string) =>
   HttpApiBuilder.group(Api.AutomationApi, "Linear", (handlers) =>
     handlers.handle("linear", () =>

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -1,4 +1,5 @@
 import { Context, Effect, FileSystem, Layer, Redacted } from "effect";
+import { HttpServerRequest } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import * as Log from "../observability/log.ts";
 import * as ProxyHandlers from "../proxy/handlers.ts";
@@ -35,23 +36,31 @@ export const AutomationsLive = (record: string) =>
     ),
   );
 
-// handleRaw: Linear's HMAC is over the raw bytes, and the record is those same bytes. A JSON
-// payload schema would parse and lose the exact body.
+// No payload schema: Linear's HMAC is over the raw bytes, and the record is that same text. A
+// JSON payload would parse and lose the exact body. The request is the HttpServerRequest
+// service: handleRaw's request widens the requirements channel to unknown.
 export const LinearLive = (record: string) =>
   HttpApiBuilder.group(Api.AutomationApi, "Linear", (handlers) =>
-    handlers.handleRaw("linear", ({ request }) =>
+    handlers.handle("linear", () =>
       Effect.gen(function* () {
         const secret = yield* LinearWebhookSecret;
+        const request = yield* HttpServerRequest.HttpServerRequest;
         const fs = yield* FileSystem.FileSystem;
         const log = yield* Log.Log;
-        const bytes = new Uint8Array(yield* request.arrayBuffer);
-        if (!Signature.matches(Redacted.value(secret), request.headers["linear-signature"], bytes)) {
+        const bytes = new Uint8Array(
+          yield* request.arrayBuffer.pipe(
+            Effect.mapError((cause) => Errors.Internal.make({ cause })),
+          ),
+        );
+        if (
+          !Signature.matches(Redacted.value(secret), request.headers["linear-signature"], bytes)
+        ) {
           return yield* Errors.Unauthorized.make({});
         }
         const text = new TextDecoder().decode(bytes);
-        yield* fs.writeFileString(record, `${text}\n`, { flag: "a" }).pipe(
-          Effect.mapError((cause) => Errors.Internal.make({ cause })),
-        );
+        yield* fs
+          .writeFileString(record, `${text}\n`, { flag: "a" })
+          .pipe(Effect.mapError((cause) => Errors.Internal.make({ cause })));
         yield* log.info("linear webhook recorded");
         return ok;
       }),

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -15,27 +15,6 @@ export class LinearWebhookSecret extends Context.Service<LinearWebhookSecret, Re
   "@oligarchy/automation/LinearWebhookSecret",
 ) {}
 
-// POST /automate, for now: one line per request appended to `record`, naming the ticket and the
-// model as they came. Spawning the agent those two describe is the next step and lands here.
-export const AutomationsLive = (record: string) =>
-  HttpApiBuilder.group(Api.AutomationApi, "Automations", (handlers) =>
-    handlers.handle("automate", ({ payload }) =>
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        const log = yield* Log.Log;
-        yield* fs
-          .writeFileString(record, `linear ticket ${payload.ticket}; model ${payload.model}\n`, {
-            flag: "a",
-          })
-          .pipe(
-            Effect.mapError((cause) => Errors.Internal.make({ cause, agentId: payload.ticket })),
-          );
-        yield* log.info(`automation recorded; ${payload.model}`, { agentId: payload.ticket });
-        return ok;
-      }),
-    ),
-  );
-
 // No payload schema: Linear's HMAC is over the raw bytes, and the record is those same bytes
 // plus a trailing newline. A JSON payload would parse and lose the exact body. The request is
 // the HttpServerRequest service: handleRaw's request widens the requirements channel to unknown.
@@ -69,11 +48,10 @@ export const LinearLive = (record: string) =>
     ),
   );
 
-// The bearer is left off: Linear signs /linear, and /automate is loopback-only.
+// The bearer is left off: Linear signs /linear.
 export const routes = (record: string) =>
   Layer.mergeAll(
     HttpApiBuilder.layer(Api.AutomationApi).pipe(
-      Layer.provide(AutomationsLive(record)),
       Layer.provide(LinearLive(record)),
       Layer.provide(Middleware.ApiBoundaryLive),
     ),

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -36,9 +36,9 @@ export const AutomationsLive = (record: string) =>
     ),
   );
 
-// No payload schema: Linear's HMAC is over the raw bytes, and the record is that same text. A
-// JSON payload would parse and lose the exact body. The request is the HttpServerRequest
-// service: handleRaw's request widens the requirements channel to unknown.
+// No payload schema: Linear's HMAC is over the raw bytes, and the record is those same bytes
+// plus a trailing newline. A JSON payload would parse and lose the exact body. The request is
+// the HttpServerRequest service: handleRaw's request widens the requirements channel to unknown.
 export const LinearLive = (record: string) =>
   HttpApiBuilder.group(Api.AutomationApi, "Linear", (handlers) =>
     handlers.handle("linear", () =>
@@ -57,9 +57,11 @@ export const LinearLive = (record: string) =>
         ) {
           return yield* Errors.Unauthorized.make({});
         }
-        const text = new TextDecoder().decode(bytes);
+        const recorded = new Uint8Array(bytes.length + 1);
+        recorded.set(bytes);
+        recorded[bytes.length] = 0x0a;
         yield* fs
-          .writeFileString(record, `${text}\n`, { flag: "a" })
+          .writeFile(record, recorded, { flag: "a" })
           .pipe(Effect.mapError((cause) => Errors.Internal.make({ cause })));
         yield* log.info("linear webhook recorded");
         return ok;

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -1,4 +1,4 @@
-import { Effect, FileSystem, Layer } from "effect";
+import { Context, Effect, FileSystem, Layer, Redacted } from "effect";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import * as Log from "../observability/log.ts";
 import * as ProxyHandlers from "../proxy/handlers.ts";
@@ -6,8 +6,13 @@ import * as Middleware from "../proxy/middleware.ts";
 import * as Api from "../shared/api.ts";
 import * as Contract from "../shared/contract.ts";
 import * as Errors from "../shared/errors.ts";
+import * as Signature from "./signature.ts";
 
 const ok = Contract.Ok.make({});
+
+export class LinearWebhookSecret extends Context.Service<LinearWebhookSecret, Redacted.Redacted>()(
+  "@oligarchy/automation/LinearWebhookSecret",
+) {}
 
 // POST /automate, for now: one line per request appended to `record`, naming the ticket and the
 // model as they came. Spawning the agent those two describe is the next step and lands here.
@@ -30,11 +35,35 @@ export const AutomationsLive = (record: string) =>
     ),
   );
 
-// The bearer is left to the graph: this service has no ProxyConfig to read the token from.
+// handleRaw: Linear's HMAC is over the raw bytes, and the record is those same bytes. A JSON
+// payload schema would parse and lose the exact body.
+export const LinearLive = (record: string) =>
+  HttpApiBuilder.group(Api.AutomationApi, "Linear", (handlers) =>
+    handlers.handleRaw("linear", ({ request }) =>
+      Effect.gen(function* () {
+        const secret = yield* LinearWebhookSecret;
+        const fs = yield* FileSystem.FileSystem;
+        const log = yield* Log.Log;
+        const bytes = new Uint8Array(yield* request.arrayBuffer);
+        if (!Signature.matches(Redacted.value(secret), request.headers["linear-signature"], bytes)) {
+          return yield* Errors.Unauthorized.make({});
+        }
+        const text = new TextDecoder().decode(bytes);
+        yield* fs.writeFileString(record, `${text}\n`, { flag: "a" }).pipe(
+          Effect.mapError((cause) => Errors.Internal.make({ cause })),
+        );
+        yield* log.info("linear webhook recorded");
+        return ok;
+      }),
+    ),
+  );
+
+// The bearer is left off: Linear signs /linear, and /automate is loopback-only.
 export const routes = (record: string) =>
   Layer.mergeAll(
     HttpApiBuilder.layer(Api.AutomationApi).pipe(
       Layer.provide(AutomationsLive(record)),
+      Layer.provide(LinearLive(record)),
       Layer.provide(Middleware.ApiBoundaryLive),
     ),
     ProxyHandlers.NotFoundRoute,

--- a/src/automation/main.ts
+++ b/src/automation/main.ts
@@ -49,15 +49,9 @@ const ServerLive = (port: number) =>
   );
 
 // LINEAR_WEBHOOK_SECRET is the one variable this process reads: Linear signs POST /linear with it.
-const WebhookSecretLive = Layer.unwrap(
-  Effect.map(Config.linearWebhookSecret, (secret) =>
-    Layer.succeed(Handlers.LinearWebhookSecret)(Handlers.LinearWebhookSecret.of(secret)),
-  ),
-);
-
 // No database: this service keeps no rows, so its log is stdout and Sentry. Sentry sits beneath
 // Log so Log captures the reporter.
-const MainLive = Layer.mergeAll(Log.Log.layerStdout, WebhookSecretLive).pipe(
+const MainLive = Layer.mergeAll(Log.Log.layerStdout, Handlers.LinearWebhookSecret.layer).pipe(
   Layer.provideMerge(Sentry.SentryLive),
   Layer.provideMerge(Config.providerLayer),
   Layer.provideMerge(NodeServices.layer),

--- a/src/automation/main.ts
+++ b/src/automation/main.ts
@@ -1,6 +1,4 @@
 import { createServer } from "node:http";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Cause, Deferred, Effect, Exit, Layer, type Runtime } from "effect";
 import { Command } from "effect/unstable/cli";
@@ -15,8 +13,8 @@ import * as Handlers from "./handlers.ts";
 
 const HOST = "127.0.0.1";
 
-// Where every request lands, one line each, in the operator's home directory as they asked.
-const RECORD = join(homedir(), "automation-test");
+// Where every request lands, one line each, in the working directory as they asked.
+const RECORD = "./automation-logs";
 
 // stdout is the convenience copy of the log; Sentry is the record. A write refused by a full
 // filesystem is dropped, never an uncaught exception per line (see the proxy's main).

--- a/src/automation/main.ts
+++ b/src/automation/main.ts
@@ -9,7 +9,6 @@ import * as Config from "../config.ts";
 import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
 import * as Sentry from "../observability/sentry.ts";
-import * as Middleware from "../proxy/middleware.ts";
 import * as Api from "../shared/api.ts";
 import * as AutomationCommand from "./command.ts";
 import * as Handlers from "./handlers.ts";
@@ -51,12 +50,16 @@ const ServerLive = (port: number) =>
     Layer.provide(Layer.succeed(HttpMiddleware.TracerDisabledWhen)(() => true)),
   );
 
-// OLIGARCHY_TOKEN is the one variable this process reads.
-const BearerLive = Layer.unwrap(Effect.map(Config.oligarchyToken, Middleware.bearerAuth));
+// LINEAR_WEBHOOK_SECRET is the one variable this process reads: Linear signs POST /linear with it.
+const WebhookSecretLive = Layer.unwrap(
+  Effect.map(Config.linearWebhookSecret, (secret) =>
+    Layer.succeed(Handlers.LinearWebhookSecret)(Handlers.LinearWebhookSecret.of(secret)),
+  ),
+);
 
 // No database: this service keeps no rows, so its log is stdout and Sentry. Sentry sits beneath
 // Log so Log captures the reporter.
-const MainLive = Layer.mergeAll(Log.Log.layerStdout, BearerLive).pipe(
+const MainLive = Layer.mergeAll(Log.Log.layerStdout, WebhookSecretLive).pipe(
   Layer.provideMerge(Sentry.SentryLive),
   Layer.provideMerge(Config.providerLayer),
   Layer.provideMerge(NodeServices.layer),
@@ -64,9 +67,9 @@ const MainLive = Layer.mergeAll(Log.Log.layerStdout, BearerLive).pipe(
 
 const command = AutomationCommand.makeAutomationCommand({ serve: ServerLive, serverFailed });
 
-// The graph is built before the command runs: a missing OLIGARCHY_TOKEN is the one failure no Log
-// exists to record, so it is printed here. Every later failure logs its own fatal line; a defect
-// has nothing else to say for it.
+// The graph is built before the command runs: a missing LINEAR_WEBHOOK_SECRET is the one failure
+// no Log exists to record, so it is printed here. Every later failure logs its own fatal line; a
+// defect has nothing else to say for it.
 const program = Effect.gen(function* () {
   const services = yield* Layer.build(MainLive).pipe(Effect.tapCause(Render.reportFailure));
   yield* Command.run(command, { version: Api.VERSION }).pipe(

--- a/src/automation/main.ts
+++ b/src/automation/main.ts
@@ -13,7 +13,7 @@ import * as Handlers from "./handlers.ts";
 
 const HOST = "127.0.0.1";
 
-// Where every request lands, one line each, in the working directory as they asked.
+// Where every request lands, appended in the working directory as they asked.
 const RECORD = "./automation-logs";
 
 // stdout is the convenience copy of the log; Sentry is the record. A write refused by a full

--- a/src/automation/signature.ts
+++ b/src/automation/signature.ts
@@ -1,0 +1,14 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const HEX = /^[0-9a-f]+$/i;
+
+// Linear's Linear-Signature is HMAC-SHA256 of the raw body, hex-encoded. A missing, short, or
+// non-hex header is a miss, never a throw: timingSafeEqual needs equal-length buffers.
+export const matches = (secret: string, signature: string | undefined, body: Uint8Array): boolean => {
+  if (signature === undefined || !HEX.test(signature)) {
+    return false;
+  }
+  const provided = Buffer.from(signature, "hex");
+  const expected = createHmac("sha256", secret).update(body).digest();
+  return provided.length === expected.length && timingSafeEqual(provided, expected);
+};

--- a/src/automation/signature.ts
+++ b/src/automation/signature.ts
@@ -1,18 +1,19 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
-const HEX = /^[0-9a-f]+$/i;
+const SHA256_HEX = /^[0-9a-f]{64}$/i;
 
-// Linear's Linear-Signature is HMAC-SHA256 of the raw body, hex-encoded. A missing, short, or
-// non-hex header is a miss, never a throw: timingSafeEqual needs equal-length buffers.
+// Linear's Linear-Signature is HMAC-SHA256 of the raw body, hex-encoded. A missing, short, long,
+// or non-hex header is a miss, never a throw: timingSafeEqual needs equal-length buffers, and
+// Buffer.from(hex) would otherwise drop an unmatched final nibble.
 export const matches = (
   secret: string,
   signature: string | undefined,
   body: Uint8Array,
 ): boolean => {
-  if (signature === undefined || !HEX.test(signature)) {
+  if (signature === undefined || !SHA256_HEX.test(signature)) {
     return false;
   }
   const provided = Buffer.from(signature, "hex");
   const expected = createHmac("sha256", secret).update(body).digest();
-  return provided.length === expected.length && timingSafeEqual(provided, expected);
+  return timingSafeEqual(provided, expected);
 };

--- a/src/automation/signature.ts
+++ b/src/automation/signature.ts
@@ -4,7 +4,11 @@ const HEX = /^[0-9a-f]+$/i;
 
 // Linear's Linear-Signature is HMAC-SHA256 of the raw body, hex-encoded. A missing, short, or
 // non-hex header is a miss, never a throw: timingSafeEqual needs equal-length buffers.
-export const matches = (secret: string, signature: string | undefined, body: Uint8Array): boolean => {
+export const matches = (
+  secret: string,
+  signature: string | undefined,
+  body: Uint8Array,
+): boolean => {
   if (signature === undefined || !HEX.test(signature)) {
     return false;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ export const requiredRedacted = (
 export const oligarchyToken = requiredRedacted("OLIGARCHY_TOKEN");
 export const databaseUrl = requiredRedacted("DATABASE_URL");
 export const linearApiToken = requiredRedacted("LINEAR_API_TOKEN");
+export const linearWebhookSecret = requiredRedacted("LINEAR_WEBHOOK_SECRET");
 
 // For Flag.withFallbackConfig: SERVER_URL="" is unset and the flag's default applies.
 export const serverUrl: EffectConfig.Config<string> = EffectConfig.string("SERVER_URL");

--- a/src/proxy/middleware.ts
+++ b/src/proxy/middleware.ts
@@ -9,9 +9,9 @@ import * as Api from "../shared/api.ts";
 import * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 
-// Every route carries `Authorization: Bearer <OLIGARCHY_TOKEN>`; the compare is exact, as it
-// always was. The token comes in as a value: the servers read it from ProxyConfig beside their
-// database url, the automation service reads it alone.
+// Every proxy and reverse-proxy route carries `Authorization: Bearer <OLIGARCHY_TOKEN>`; the
+// compare is exact, as it always was. The token comes in as a value: those servers read it from
+// ProxyConfig beside their database url. The automation service does not use this bearer.
 export const bearerAuth = (token: Redacted.Redacted): Layer.Layer<Api.BearerAuth> =>
   Layer.succeed(Api.BearerAuth)(
     Api.BearerAuth.of({

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -163,8 +163,10 @@ export class ReverseProxyApi extends HttpApi.make("OligarchyReverseProxy")
   .add(RoutedSessions)
   .add(Servers) {}
 
-// The automation service: one request names the Linear ticket to drive and the model to drive
-// it with; bearer required. It neither forwards nor places, so the proxy's own boundary suffices.
+// The automation service: POST /automate names a ticket and a model; POST /linear is Linear's
+// signed webhook. Neither carries the oligarchy bearer — Linear signs /linear, and /automate
+// is reached only on the loopback the operator already trusts. The proxy's own boundary
+// suffices: this process neither forwards nor places.
 export const automate = HttpApiEndpoint.post("automate", "/automate", {
   payload: Contract.AutomateBody,
   success: Contract.Ok,
@@ -172,9 +174,17 @@ export const automate = HttpApiEndpoint.post("automate", "/automate", {
 
 export class Automations extends HttpApiGroup.make("Automations")
   .add(automate)
-  .middleware(BearerAuth)
   .middleware(ApiBoundary) {}
 
-export class AutomationApi extends HttpApi.make("OligarchyAutomation").add(Automations) {}
+export const linear = HttpApiEndpoint.post("linear", "/linear", {
+  success: Contract.Ok,
+  error: Errors.UnauthorizedWire,
+});
+
+export class Linear extends HttpApiGroup.make("Linear").add(linear).middleware(ApiBoundary) {}
+
+export class AutomationApi extends HttpApi.make("OligarchyAutomation")
+  .add(Automations)
+  .add(Linear) {}
 
 export const VERSION = "0.0.0";

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -163,19 +163,9 @@ export class ReverseProxyApi extends HttpApi.make("OligarchyReverseProxy")
   .add(RoutedSessions)
   .add(Servers) {}
 
-// The automation service: POST /automate names a ticket and a model; POST /linear is Linear's
-// signed webhook. Neither carries the oligarchy bearer — Linear signs /linear, and /automate
-// is reached only on the loopback the operator already trusts. The proxy's own boundary
-// suffices: this process neither forwards nor places.
-export const automate = HttpApiEndpoint.post("automate", "/automate", {
-  payload: Contract.AutomateBody,
-  success: Contract.Ok,
-});
-
-export class Automations extends HttpApiGroup.make("Automations")
-  .add(automate)
-  .middleware(ApiBoundary) {}
-
+// The automation service: POST /linear is Linear's signed webhook. No oligarchy bearer —
+// Linear signs the body. The proxy's own boundary suffices: this process neither forwards
+// nor places.
 export const linear = HttpApiEndpoint.post("linear", "/linear", {
   success: Contract.Ok,
   error: Errors.UnauthorizedWire,
@@ -183,8 +173,6 @@ export const linear = HttpApiEndpoint.post("linear", "/linear", {
 
 export class Linear extends HttpApiGroup.make("Linear").add(linear).middleware(ApiBoundary) {}
 
-export class AutomationApi extends HttpApi.make("OligarchyAutomation")
-  .add(Automations)
-  .add(Linear) {}
+export class AutomationApi extends HttpApi.make("OligarchyAutomation").add(Linear) {}
 
 export const VERSION = "0.0.0";

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -106,20 +106,6 @@ export class Servers extends Schema.Class<Servers>("@oligarchy/shared/contract/S
   servers: Schema.Array(Server),
 }) {}
 
-// The record is one line per request, so a value with a line break in it is refused, not folded.
-const oneLine = Schema.NonEmptyString.check(
-  Schema.isPattern(/^[^\r\n]*$/, { message: "must not contain a line break" }),
-);
-
-// POST /automate on the automation service: the Linear ticket to drive and the model to drive it
-// with, both as the caller spelled them.
-export class AutomateBody extends Schema.Class<AutomateBody>(
-  "@oligarchy/shared/contract/AutomateBody",
-)({
-  ticket: oneLine,
-  model: oneLine,
-}) {}
-
 const STORED_IMAGE_ORIGIN = "https://oligarchy.trm.sh";
 
 export const StoredImageUrl = (id: string): string => `${STORED_IMAGE_ORIGIN}/images/${id}`;

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -13,7 +13,7 @@ import * as FakeLog from "../support/log.ts";
 import * as Reporter from "../support/reporter.ts";
 
 const WEBHOOK_SECRET = "whsec_test";
-const RECORD = "/home/operator/automation-test";
+const RECORD = "./automation-logs";
 const TICKET = "OLI-61";
 const MODEL = "grok-4.6";
 

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -232,24 +232,26 @@ describe("POST /automate refusals", () => {
       }),
   );
 
-  it.effect("GET /automate, GET /linear and anything unrouted are 404 not found and never logged", () =>
-    Effect.gen(function* () {
-      const fixed = fixture();
-      yield* Effect.gen(function* () {
-        const http = yield* HttpClient.HttpClient;
-        for (const path of ["/automate", "/linear", "/start", "/servers", "/nope"]) {
-          const response = yield* http.get(path);
-          expect(response.status, path).toBe(404);
-          expect(yield* response.json).toEqual({ error: "not found" });
-        }
-        const start = yield* http.post("/start", {
-          body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: TICKET }),
-        });
-        expect(start.status).toBe(404);
-      }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes).toEqual([]);
-      expect(fixed.log.lines).toEqual([]);
-    }),
+  it.effect(
+    "GET /automate, GET /linear and anything unrouted are 404 not found and never logged",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture();
+        yield* Effect.gen(function* () {
+          const http = yield* HttpClient.HttpClient;
+          for (const path of ["/automate", "/linear", "/start", "/servers", "/nope"]) {
+            const response = yield* http.get(path);
+            expect(response.status, path).toBe(404);
+            expect(yield* response.json).toEqual({ error: "not found" });
+          }
+          const start = yield* http.post("/start", {
+            body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: TICKET }),
+          });
+          expect(start.status).toBe(404);
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.file.writes).toEqual([]);
+        expect(fixed.log.lines).toEqual([]);
+      }),
   );
 });
 

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -23,7 +23,7 @@ const SecretLive = Layer.succeed(Handlers.LinearWebhookSecret)(
 
 type Write = {
   readonly path: string;
-  readonly data: string;
+  readonly data: string | Uint8Array;
   readonly flag: FileSystem.OpenFlag | undefined;
 };
 
@@ -32,18 +32,34 @@ type RecordFile = {
   readonly layer: Layer.Layer<FileSystem.FileSystem>;
 };
 
-// A FileSystem that records every string written, or refuses each write as a file it may not open.
+const denied = (path: string) => Effect.fail(FakeFs.permissionDenied("open", path));
+
+// A FileSystem that records every write, or refuses each one as a file it may not open.
 const recordFile = (refuse = false): RecordFile => {
   const writes: Array<Write> = [];
   const layer = FileSystem.layerNoop({
     writeFileString: (path, data, options) =>
       refuse
-        ? Effect.fail(FakeFs.permissionDenied("open", path))
+        ? denied(path)
+        : Effect.sync(() => {
+            writes.push({ path, data, flag: options?.flag });
+          }),
+    writeFile: (path, data, options) =>
+      refuse
+        ? denied(path)
         : Effect.sync(() => {
             writes.push({ path, data, flag: options?.flag });
           }),
   });
   return { writes, layer };
+};
+
+const withNewline = (payload: string | Uint8Array): Uint8Array => {
+  const bytes = typeof payload === "string" ? new TextEncoder().encode(payload) : payload;
+  const out = new Uint8Array(bytes.length + 1);
+  out.set(bytes);
+  out[bytes.length] = 0x0a;
+  return out;
 };
 
 type Fixture = {
@@ -69,16 +85,19 @@ const client = HttpApiClient.make(Api.AutomationApi);
 
 const body = (ticket: string, model: string) => Contract.AutomateBody.make({ ticket, model });
 
-const sign = (payload: string): string =>
+const sign = (payload: string | Uint8Array): string =>
   createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
 
-const webhook = (http: HttpClient.HttpClient, payload: string, signature?: string) =>
+const webhook = (http: HttpClient.HttpClient, payload: string | Uint8Array, signature?: string) =>
   http.post("/linear", {
     headers:
       signature === undefined
         ? { "content-type": "application/json" }
         : { "content-type": "application/json", "linear-signature": signature },
-    body: HttpBody.text(payload, "application/json"),
+    body:
+      typeof payload === "string"
+        ? HttpBody.text(payload, "application/json")
+        : HttpBody.uint8Array(payload, "application/json"),
   });
 
 describe("POST /automate", () => {
@@ -267,7 +286,7 @@ describe("POST /linear", () => {
         expect(response.status).toBe(200);
         expect(yield* response.json).toEqual({ ok: "true" });
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes).toEqual([{ path: RECORD, data: `${payload}\n`, flag: "a" }]);
+      expect(fixed.file.writes).toEqual([{ path: RECORD, data: withNewline(payload), flag: "a" }]);
       expect(fixed.log.lines).toEqual([
         {
           level: "info",
@@ -292,11 +311,27 @@ describe("POST /linear", () => {
         expect((yield* webhook(http, first, sign(first))).status).toBe(200);
         expect((yield* webhook(http, second, sign(second))).status).toBe(200);
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes.map((write) => write.data)).toEqual([`${first}\n`, `${second}\n`]);
+      expect(fixed.file.writes.map((write) => write.data)).toEqual([
+        withNewline(first),
+        withNewline(second),
+      ]);
       expect(FakeLog.texts(fixed.log)).toEqual([
         "linear webhook recorded",
         "linear webhook recorded",
       ]);
+    }),
+  );
+
+  it.effect("appends a UTF-8 BOM body as the exact bytes Linear signed, plus a trailing newline", () =>
+    Effect.gen(function* () {
+      const payload = new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode('{"action":"update"}')]);
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* webhook(http, payload, sign(payload));
+        expect(response.status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes).toEqual([{ path: RECORD, data: withNewline(payload), flag: "a" }]);
     }),
   );
 });

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -1,30 +1,25 @@
+import { createHmac } from "node:crypto";
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect, FileSystem, Layer, Redacted } from "effect";
-import { HttpBody, HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http";
-import { HttpApiClient, HttpApiMiddleware } from "effect/unstable/httpapi";
+import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
+import { HttpApiClient } from "effect/unstable/httpapi";
 import { NodeHttpServer } from "@effect/platform-node";
 import * as Handlers from "../../src/automation/handlers.ts";
-import * as Middleware from "../../src/proxy/middleware.ts";
 import * as Api from "../../src/shared/api.ts";
 import * as Contract from "../../src/shared/contract.ts";
 import * as FakeFs from "../support/fake-fs.ts";
 import * as FakeLog from "../support/log.ts";
 import * as Reporter from "../support/reporter.ts";
 
-const TOKEN = "test-token";
-const AUTHORIZATION = `Bearer ${TOKEN}`;
+const WEBHOOK_SECRET = "whsec_test";
 const RECORD = "/home/operator/automation-test";
 const TICKET = "OLI-61";
 const MODEL = "grok-4.6";
 
-// The service's bearer is the token alone: no ProxyConfig, no database url, as in its main.
-const BearerLive = Middleware.bearerAuth(Redacted.make(TOKEN));
-
-const bearer = (token: string) =>
-  HttpApiMiddleware.layerClient(Api.BearerAuth, ({ next, request }) =>
-    next(HttpClientRequest.bearerToken(request, token)),
-  );
+const SecretLive = Layer.succeed(Handlers.LinearWebhookSecret)(
+  Handlers.LinearWebhookSecret.of(Redacted.make(WEBHOOK_SECRET)),
+);
 
 type Write = {
   readonly path: string;
@@ -65,15 +60,26 @@ const fixture = (file: RecordFile = recordFile()): Fixture => ({
 
 const serve = (fixed: Fixture) =>
   HttpRouter.serve(Handlers.routes(RECORD), { disableLogger: true, disableListenLog: true }).pipe(
-    Layer.provide(Layer.mergeAll(fixed.file.layer, fixed.log.layer, BearerLive)),
+    Layer.provide(Layer.mergeAll(fixed.file.layer, fixed.log.layer, SecretLive)),
     Layer.provideMerge(NodeHttpServer.layerTest),
     Layer.provideMerge(fixed.reporter.layer),
-    Layer.provideMerge(bearer(TOKEN)),
   );
 
 const client = HttpApiClient.make(Api.AutomationApi);
 
 const body = (ticket: string, model: string) => Contract.AutomateBody.make({ ticket, model });
+
+const sign = (payload: string): string =>
+  createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
+
+const webhook = (http: HttpClient.HttpClient, payload: string, signature?: string) =>
+  http.post("/linear", {
+    headers:
+      signature === undefined
+        ? { "content-type": "application/json" }
+        : { "content-type": "application/json", "linear-signature": signature },
+    body: HttpBody.text(payload, "application/json"),
+  });
 
 describe("POST /automate", () => {
   it.effect("appends the ticket and the model to the record file, answers ok and logs it", () =>
@@ -127,61 +133,17 @@ describe("POST /automate", () => {
 });
 
 describe("POST /automate refusals", () => {
-  it.effect(
-    "a missing or wrong bearer is 401 unauthorized, records nothing and logs one line each",
-    () =>
-      Effect.gen(function* () {
-        const fixed = fixture();
-        yield* Effect.gen(function* () {
-          const http = yield* HttpClient.HttpClient;
-          const payload = HttpBody.jsonUnsafe({ ticket: TICKET, model: MODEL });
-          const missing = yield* http.post("/automate", { body: payload });
-          expect(missing.status).toBe(401);
-          expect(yield* missing.json).toEqual({ error: "unauthorized" });
-          const wrong = yield* http.post("/automate", {
-            headers: { authorization: "Bearer wrong" },
-            body: payload,
-          });
-          expect(wrong.status).toBe(401);
-          expect(yield* wrong.json).toEqual({ error: "unauthorized" });
-        }).pipe(Effect.provide(serve(fixed)));
-        expect(fixed.file.writes).toEqual([]);
-        expect(fixed.log.lines).toEqual([
-          {
-            level: "error",
-            text: "POST /automate failed: unauthorized",
-            sessionId: undefined,
-            agentId: undefined,
-            skipSentry: true,
-            cause: undefined,
-          },
-          {
-            level: "error",
-            text: "POST /automate failed: unauthorized",
-            sessionId: undefined,
-            agentId: undefined,
-            skipSentry: true,
-            cause: undefined,
-          },
-        ]);
-        expect(fixed.reporter.reported).toEqual([]);
-      }),
-  );
-
   it.effect("a malformed body, a missing field and an empty one are 400 and record nothing", () =>
     Effect.gen(function* () {
       const fixed = fixture();
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
-        const headers = { authorization: AUTHORIZATION };
         const malformed = yield* http.post("/automate", {
-          headers,
           body: HttpBody.text("{bad", "application/json"),
         });
         expect(malformed.status).toBe(400);
         expect(yield* malformed.json).toEqual({ error: "Expected a valid JSON body" });
         const noModel = yield* http.post("/automate", {
-          headers,
           body: HttpBody.jsonUnsafe({ ticket: TICKET }),
         });
         expect(noModel.status).toBe(400);
@@ -189,7 +151,6 @@ describe("POST /automate refusals", () => {
           error: expect.stringContaining('["model"]'),
         });
         const noTicket = yield* http.post("/automate", {
-          headers,
           body: HttpBody.jsonUnsafe({ model: MODEL }),
         });
         expect(noTicket.status).toBe(400);
@@ -197,7 +158,6 @@ describe("POST /automate refusals", () => {
           error: expect.stringContaining('["ticket"]'),
         });
         const emptyTicket = yield* http.post("/automate", {
-          headers,
           body: HttpBody.jsonUnsafe({ ticket: "", model: MODEL }),
         });
         expect(emptyTicket.status).toBe(400);
@@ -218,9 +178,7 @@ describe("POST /automate refusals", () => {
       const fixed = fixture();
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
-        const headers = { authorization: AUTHORIZATION };
         const ticket = yield* http.post("/automate", {
-          headers,
           body: HttpBody.jsonUnsafe({ ticket: "OLI-1\nlinear ticket OLI-2", model: MODEL }),
         });
         expect(ticket.status).toBe(400);
@@ -228,7 +186,6 @@ describe("POST /automate refusals", () => {
         expect(refusedTicket).toMatchObject({ error: expect.stringContaining("line break") });
         expect(refusedTicket).toMatchObject({ error: expect.stringContaining('["ticket"]') });
         const model = yield* http.post("/automate", {
-          headers,
           body: HttpBody.jsonUnsafe({ ticket: TICKET, model: "grok-4.6\r\n" }),
         });
         expect(model.status).toBe(400);
@@ -253,7 +210,6 @@ describe("POST /automate refusals", () => {
           expect(error).toMatchObject({ _tag: "Internal", message: "internal error" });
           const http = yield* HttpClient.HttpClient;
           const raw = yield* http.post("/automate", {
-            headers: { authorization: AUTHORIZATION },
             body: HttpBody.jsonUnsafe({ ticket: TICKET, model: MODEL }),
           });
           expect(raw.status).toBe(500);
@@ -276,21 +232,17 @@ describe("POST /automate refusals", () => {
       }),
   );
 
-  it.effect("GET /automate and anything unrouted are 404 not found and never logged", () =>
+  it.effect("GET /automate, GET /linear and anything unrouted are 404 not found and never logged", () =>
     Effect.gen(function* () {
       const fixed = fixture();
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
-        const headers = { authorization: AUTHORIZATION };
-        for (const path of ["/automate", "/start", "/servers", "/nope"]) {
-          const response = yield* http.get(path, { headers });
+        for (const path of ["/automate", "/linear", "/start", "/servers", "/nope"]) {
+          const response = yield* http.get(path);
           expect(response.status, path).toBe(404);
           expect(yield* response.json).toEqual({ error: "not found" });
         }
-        const noToken = yield* http.get("/automate");
-        expect(noToken.status).toBe(404);
         const start = yield* http.post("/start", {
-          headers,
           body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: TICKET }),
         });
         expect(start.status).toBe(404);
@@ -298,5 +250,130 @@ describe("POST /automate refusals", () => {
       expect(fixed.file.writes).toEqual([]);
       expect(fixed.log.lines).toEqual([]);
     }),
+  );
+});
+
+describe("POST /linear", () => {
+  const payload = '{"action":"update","type":"Issue","data":{"identifier":"OLI-1"}}';
+
+  it.effect("appends the exact body Linear sent, answers ok and logs it", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* webhook(http, payload, sign(payload));
+        expect(response.status).toBe(200);
+        expect(yield* response.json).toEqual({ ok: "true" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes).toEqual([{ path: RECORD, data: `${payload}\n`, flag: "a" }]);
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "info",
+          text: "linear webhook recorded",
+          sessionId: undefined,
+          agentId: undefined,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
+  it.effect("every signed delivery appends its own exact body, in order", () =>
+    Effect.gen(function* () {
+      const first = '{"action":"create","type":"Issue"}';
+      const second = '{\n  "action": "update",\n  "type": "Comment"\n}';
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        expect((yield* webhook(http, first, sign(first))).status).toBe(200);
+        expect((yield* webhook(http, second, sign(second))).status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes.map((write) => write.data)).toEqual([`${first}\n`, `${second}\n`]);
+      expect(FakeLog.texts(fixed.log)).toEqual([
+        "linear webhook recorded",
+        "linear webhook recorded",
+      ]);
+    }),
+  );
+});
+
+describe("POST /linear refusals", () => {
+  const payload = '{"action":"update"}';
+
+  it.effect(
+    "a missing or wrong signature is 401 unauthorized, records nothing and logs one line each",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture();
+        yield* Effect.gen(function* () {
+          const http = yield* HttpClient.HttpClient;
+          const missing = yield* webhook(http, payload);
+          expect(missing.status).toBe(401);
+          expect(yield* missing.json).toEqual({ error: "unauthorized" });
+          const wrong = yield* webhook(http, payload, "00".repeat(32));
+          expect(wrong.status).toBe(401);
+          expect(yield* wrong.json).toEqual({ error: "unauthorized" });
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.file.writes).toEqual([]);
+        expect(fixed.log.lines).toEqual([
+          {
+            level: "error",
+            text: "POST /linear failed: unauthorized",
+            sessionId: undefined,
+            agentId: undefined,
+            skipSentry: true,
+            cause: undefined,
+          },
+          {
+            level: "error",
+            text: "POST /linear failed: unauthorized",
+            sessionId: undefined,
+            agentId: undefined,
+            skipSentry: true,
+            cause: undefined,
+          },
+        ]);
+        expect(fixed.reporter.reported).toEqual([]);
+      }),
+  );
+
+  it.effect("a valid signature of a different body is 401 and records nothing", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* webhook(http, payload, sign('{"action":"create"}'));
+        expect(response.status).toBe(401);
+        expect(yield* response.json).toEqual({ error: "unauthorized" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes).toEqual([]);
+    }),
+  );
+
+  it.effect(
+    "a record file that cannot be written is 500 internal error, logged with Node's reason",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture(recordFile(true));
+        yield* Effect.gen(function* () {
+          const http = yield* HttpClient.HttpClient;
+          const raw = yield* webhook(http, payload, sign(payload));
+          expect(raw.status).toBe(500);
+          expect(yield* raw.json).toEqual({ error: "internal error" });
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.file.writes).toEqual([]);
+        expect(fixed.log.lines).toHaveLength(1);
+        expect(fixed.log.lines[0]).toMatchObject({
+          level: "error",
+          text: `POST /linear failed: EACCES: permission denied, open '${RECORD}'`,
+          sessionId: undefined,
+          agentId: undefined,
+          skipSentry: false,
+        });
+        expect(fixed.log.lines[0]?.cause).toMatchObject({ _tag: "PlatformError" });
+        expect(fixed.reporter.reported).toEqual([]);
+      }),
   );
 });

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -322,17 +322,24 @@ describe("POST /linear", () => {
     }),
   );
 
-  it.effect("appends a UTF-8 BOM body as the exact bytes Linear signed, plus a trailing newline", () =>
-    Effect.gen(function* () {
-      const payload = new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode('{"action":"update"}')]);
-      const fixed = fixture();
-      yield* Effect.gen(function* () {
-        const http = yield* HttpClient.HttpClient;
-        const response = yield* webhook(http, payload, sign(payload));
-        expect(response.status).toBe(200);
-      }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes).toEqual([{ path: RECORD, data: withNewline(payload), flag: "a" }]);
-    }),
+  it.effect(
+    "appends a UTF-8 BOM body as the exact bytes Linear signed, plus a trailing newline",
+    () =>
+      Effect.gen(function* () {
+        const bom = new Uint8Array([
+          0xef,
+          0xbb,
+          0xbf,
+          ...new TextEncoder().encode('{"action":"update"}'),
+        ]);
+        const fixed = fixture();
+        yield* Effect.gen(function* () {
+          const http = yield* HttpClient.HttpClient;
+          const response = yield* webhook(http, bom, sign(bom));
+          expect(response.status).toBe(200);
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.file.writes).toEqual([{ path: RECORD, data: withNewline(bom), flag: "a" }]);
+      }),
   );
 });
 

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -3,19 +3,14 @@ import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect, FileSystem, Layer, Redacted } from "effect";
 import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
-import { HttpApiClient } from "effect/unstable/httpapi";
 import { NodeHttpServer } from "@effect/platform-node";
 import * as Handlers from "../../src/automation/handlers.ts";
-import * as Api from "../../src/shared/api.ts";
-import * as Contract from "../../src/shared/contract.ts";
 import * as FakeFs from "../support/fake-fs.ts";
 import * as FakeLog from "../support/log.ts";
 import * as Reporter from "../support/reporter.ts";
 
 const WEBHOOK_SECRET = "whsec_test";
 const RECORD = "./automation-logs";
-const TICKET = "OLI-61";
-const MODEL = "grok-4.6";
 
 const SecretLive = Layer.succeed(Handlers.LinearWebhookSecret)(
   Handlers.LinearWebhookSecret.of(Redacted.make(WEBHOOK_SECRET)),
@@ -23,7 +18,7 @@ const SecretLive = Layer.succeed(Handlers.LinearWebhookSecret)(
 
 type Write = {
   readonly path: string;
-  readonly data: string | Uint8Array;
+  readonly data: Uint8Array;
   readonly flag: FileSystem.OpenFlag | undefined;
 };
 
@@ -38,12 +33,6 @@ const denied = (path: string) => Effect.fail(FakeFs.permissionDenied("open", pat
 const recordFile = (refuse = false): RecordFile => {
   const writes: Array<Write> = [];
   const layer = FileSystem.layerNoop({
-    writeFileString: (path, data, options) =>
-      refuse
-        ? denied(path)
-        : Effect.sync(() => {
-            writes.push({ path, data, flag: options?.flag });
-          }),
     writeFile: (path, data, options) =>
       refuse
         ? denied(path)
@@ -81,10 +70,6 @@ const serve = (fixed: Fixture) =>
     Layer.provideMerge(fixed.reporter.layer),
   );
 
-const client = HttpApiClient.make(Api.AutomationApi);
-
-const body = (ticket: string, model: string) => Contract.AutomateBody.make({ ticket, model });
-
 const sign = (payload: string | Uint8Array): string =>
   createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
 
@@ -99,180 +84,6 @@ const webhook = (http: HttpClient.HttpClient, payload: string | Uint8Array, sign
         ? HttpBody.text(payload, "application/json")
         : HttpBody.uint8Array(payload, "application/json"),
   });
-
-describe("POST /automate", () => {
-  it.effect("appends the ticket and the model to the record file, answers ok and logs it", () =>
-    Effect.gen(function* () {
-      const fixed = fixture();
-      yield* Effect.gen(function* () {
-        const api = yield* client;
-        const [ok, response] = yield* api.Automations.automate({
-          payload: body(TICKET, MODEL),
-          responseMode: "decoded-and-response",
-        });
-        expect(ok).toEqual(Contract.Ok.make({}));
-        expect(response.status).toBe(200);
-        expect(yield* response.json).toEqual({ ok: "true" });
-      }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes).toEqual([
-        { path: RECORD, data: `linear ticket ${TICKET}; model ${MODEL}\n`, flag: "a" },
-      ]);
-      expect(fixed.log.lines).toEqual([
-        {
-          level: "info",
-          text: `automation recorded; ${MODEL}`,
-          sessionId: undefined,
-          agentId: TICKET,
-          skipSentry: false,
-          cause: undefined,
-        },
-      ]);
-      expect(fixed.reporter.reported).toEqual([]);
-    }),
-  );
-
-  it.effect("every request appends its own line, in order, and overwrites nothing", () =>
-    Effect.gen(function* () {
-      const fixed = fixture();
-      yield* Effect.gen(function* () {
-        const api = yield* client;
-        yield* api.Automations.automate({ payload: body("OLI-1", "grok-4.6-high") });
-        yield* api.Automations.automate({ payload: body("OLI-2", "claude-opus-5") });
-      }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes.map((write) => [write.data, write.flag])).toEqual([
-        ["linear ticket OLI-1; model grok-4.6-high\n", "a"],
-        ["linear ticket OLI-2; model claude-opus-5\n", "a"],
-      ]);
-      expect(FakeLog.texts(fixed.log)).toEqual([
-        "automation recorded; grok-4.6-high",
-        "automation recorded; claude-opus-5",
-      ]);
-    }),
-  );
-});
-
-describe("POST /automate refusals", () => {
-  it.effect("a malformed body, a missing field and an empty one are 400 and record nothing", () =>
-    Effect.gen(function* () {
-      const fixed = fixture();
-      yield* Effect.gen(function* () {
-        const http = yield* HttpClient.HttpClient;
-        const malformed = yield* http.post("/automate", {
-          body: HttpBody.text("{bad", "application/json"),
-        });
-        expect(malformed.status).toBe(400);
-        expect(yield* malformed.json).toEqual({ error: "Expected a valid JSON body" });
-        const noModel = yield* http.post("/automate", {
-          body: HttpBody.jsonUnsafe({ ticket: TICKET }),
-        });
-        expect(noModel.status).toBe(400);
-        expect(yield* noModel.json).toMatchObject({
-          error: expect.stringContaining('["model"]'),
-        });
-        const noTicket = yield* http.post("/automate", {
-          body: HttpBody.jsonUnsafe({ model: MODEL }),
-        });
-        expect(noTicket.status).toBe(400);
-        expect(yield* noTicket.json).toMatchObject({
-          error: expect.stringContaining('["ticket"]'),
-        });
-        const emptyTicket = yield* http.post("/automate", {
-          body: HttpBody.jsonUnsafe({ ticket: "", model: MODEL }),
-        });
-        expect(emptyTicket.status).toBe(400);
-        expect(yield* emptyTicket.json).toMatchObject({
-          error: expect.stringContaining('["ticket"]'),
-        });
-      }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes).toEqual([]);
-      expect(fixed.log.lines).toHaveLength(4);
-      expect(fixed.log.lines[0]?.text).toBe("POST /automate failed: Expected a valid JSON body");
-      expect(fixed.log.lines.every((line) => line.level === "error" && line.skipSentry)).toBe(true);
-      expect(fixed.reporter.reported).toEqual([]);
-    }),
-  );
-
-  it.effect("a ticket or model with a line break in it is 400 and records nothing", () =>
-    Effect.gen(function* () {
-      const fixed = fixture();
-      yield* Effect.gen(function* () {
-        const http = yield* HttpClient.HttpClient;
-        const ticket = yield* http.post("/automate", {
-          body: HttpBody.jsonUnsafe({ ticket: "OLI-1\nlinear ticket OLI-2", model: MODEL }),
-        });
-        expect(ticket.status).toBe(400);
-        const refusedTicket = yield* ticket.json;
-        expect(refusedTicket).toMatchObject({ error: expect.stringContaining("line break") });
-        expect(refusedTicket).toMatchObject({ error: expect.stringContaining('["ticket"]') });
-        const model = yield* http.post("/automate", {
-          body: HttpBody.jsonUnsafe({ ticket: TICKET, model: "grok-4.6\r\n" }),
-        });
-        expect(model.status).toBe(400);
-        expect(yield* model.json).toMatchObject({ error: expect.stringContaining('["model"]') });
-      }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes).toEqual([]);
-      expect(fixed.log.lines).toHaveLength(2);
-      expect(fixed.log.lines.every((line) => line.level === "error" && line.skipSentry)).toBe(true);
-    }),
-  );
-
-  it.effect(
-    "a record file that cannot be written is 500 internal error, logged with Node's reason",
-    () =>
-      Effect.gen(function* () {
-        const fixed = fixture(recordFile(true));
-        yield* Effect.gen(function* () {
-          const api = yield* client;
-          const error = yield* Effect.flip(
-            api.Automations.automate({ payload: body(TICKET, MODEL) }),
-          );
-          expect(error).toMatchObject({ _tag: "Internal", message: "internal error" });
-          const http = yield* HttpClient.HttpClient;
-          const raw = yield* http.post("/automate", {
-            body: HttpBody.jsonUnsafe({ ticket: TICKET, model: MODEL }),
-          });
-          expect(raw.status).toBe(500);
-          expect(yield* raw.json).toEqual({ error: "internal error" });
-        }).pipe(Effect.provide(serve(fixed)));
-        expect(fixed.file.writes).toEqual([]);
-        expect(fixed.log.lines).toHaveLength(2);
-        for (const line of fixed.log.lines) {
-          expect(line).toMatchObject({
-            level: "error",
-            text: `POST /automate failed: EACCES: permission denied, open '${RECORD}'`,
-            sessionId: undefined,
-            agentId: TICKET,
-            skipSentry: false,
-          });
-          expect(line.cause).toMatchObject({ _tag: "PlatformError" });
-        }
-        // The boundary's line is the one report; HttpApiBuilder's own is silenced.
-        expect(fixed.reporter.reported).toEqual([]);
-      }),
-  );
-
-  it.effect(
-    "GET /automate, GET /linear and anything unrouted are 404 not found and never logged",
-    () =>
-      Effect.gen(function* () {
-        const fixed = fixture();
-        yield* Effect.gen(function* () {
-          const http = yield* HttpClient.HttpClient;
-          for (const path of ["/automate", "/linear", "/start", "/servers", "/nope"]) {
-            const response = yield* http.get(path);
-            expect(response.status, path).toBe(404);
-            expect(yield* response.json).toEqual({ error: "not found" });
-          }
-          const start = yield* http.post("/start", {
-            body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: TICKET }),
-          });
-          expect(start.status).toBe(404);
-        }).pipe(Effect.provide(serve(fixed)));
-        expect(fixed.file.writes).toEqual([]);
-        expect(fixed.log.lines).toEqual([]);
-      }),
-  );
-});
 
 describe("POST /linear", () => {
   const payload = '{"action":"update","type":"Issue","data":{"identifier":"OLI-1"}}';
@@ -418,6 +229,33 @@ describe("POST /linear refusals", () => {
         });
         expect(fixed.log.lines[0]?.cause).toMatchObject({ _tag: "PlatformError" });
         expect(fixed.reporter.reported).toEqual([]);
+      }),
+  );
+
+  it.effect(
+    "POST /automate, GET /linear and anything unrouted are 404 not found and never logged",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture();
+        yield* Effect.gen(function* () {
+          const http = yield* HttpClient.HttpClient;
+          const automate = yield* http.post("/automate", {
+            body: HttpBody.jsonUnsafe({ ticket: "OLI-61", model: "grok-4.6" }),
+          });
+          expect(automate.status).toBe(404);
+          expect(yield* automate.json).toEqual({ error: "not found" });
+          for (const path of ["/automate", "/linear", "/start", "/servers", "/nope"]) {
+            const response = yield* http.get(path);
+            expect(response.status, path).toBe(404);
+            expect(yield* response.json).toEqual({ error: "not found" });
+          }
+          const start = yield* http.post("/start", {
+            body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: "OLI-61" }),
+          });
+          expect(start.status).toBe(404);
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.file.writes).toEqual([]);
+        expect(fixed.log.lines).toEqual([]);
       }),
   );
 });

--- a/test/automation/signature.unit.test.ts
+++ b/test/automation/signature.unit.test.ts
@@ -13,12 +13,13 @@ describe("Signature.matches", () => {
     expect(Signature.matches(SECRET, sign(SECRET, BODY), BODY)).toBe(true);
   });
 
-  it("rejects a missing, empty, non-hex, short or wrong signature, and a different body or secret", () => {
+  it("rejects a missing, empty, non-hex, short, odd-length or wrong signature, and a different body or secret", () => {
     const good = sign(SECRET, BODY);
     expect(Signature.matches(SECRET, undefined, BODY)).toBe(false);
     expect(Signature.matches(SECRET, "", BODY)).toBe(false);
     expect(Signature.matches(SECRET, "not-hex", BODY)).toBe(false);
     expect(Signature.matches(SECRET, good.slice(0, 16), BODY)).toBe(false);
+    expect(Signature.matches(SECRET, `${good}f`, BODY)).toBe(false);
     expect(Signature.matches(SECRET, "00".repeat(32), BODY)).toBe(false);
     expect(Signature.matches(SECRET, good, new TextEncoder().encode("{}"))).toBe(false);
     expect(Signature.matches("other", good, BODY)).toBe(false);

--- a/test/automation/signature.unit.test.ts
+++ b/test/automation/signature.unit.test.ts
@@ -1,0 +1,26 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import * as Signature from "../../src/automation/signature.ts";
+
+const SECRET = "whsec_test";
+const BODY = new TextEncoder().encode('{"action":"update","type":"Issue"}');
+
+const sign = (secret: string, body: Uint8Array): string =>
+  createHmac("sha256", secret).update(body).digest("hex");
+
+describe("Signature.matches", () => {
+  it("accepts Linear's hex HMAC-SHA256 of the raw body", () => {
+    expect(Signature.matches(SECRET, sign(SECRET, BODY), BODY)).toBe(true);
+  });
+
+  it("rejects a missing, empty, non-hex, short or wrong signature, and a different body or secret", () => {
+    const good = sign(SECRET, BODY);
+    expect(Signature.matches(SECRET, undefined, BODY)).toBe(false);
+    expect(Signature.matches(SECRET, "", BODY)).toBe(false);
+    expect(Signature.matches(SECRET, "not-hex", BODY)).toBe(false);
+    expect(Signature.matches(SECRET, good.slice(0, 16), BODY)).toBe(false);
+    expect(Signature.matches(SECRET, "00".repeat(32), BODY)).toBe(false);
+    expect(Signature.matches(SECRET, good, new TextEncoder().encode("{}"))).toBe(false);
+    expect(Signature.matches("other", good, BODY)).toBe(false);
+  });
+});

--- a/test/config/config.unit.test.ts
+++ b/test/config/config.unit.test.ts
@@ -54,6 +54,7 @@ describe("requiredRedacted", () => {
       expect(Redacted.value(yield* Config.oligarchyToken)).toBe("a");
       expect(Redacted.value(yield* Config.databaseUrl)).toBe("b");
       expect(Redacted.value(yield* Config.linearApiToken)).toBe("c");
+      expect(Redacted.value(yield* Config.linearWebhookSecret)).toBe("f");
       expect(yield* Config.serverUrl).toBe("d");
       expect(yield* Config.sessionId).toBe("e");
     }).pipe(
@@ -62,6 +63,7 @@ describe("requiredRedacted", () => {
           OLIGARCHY_TOKEN: "a",
           DATABASE_URL: "b",
           LINEAR_API_TOKEN: "c",
+          LINEAR_WEBHOOK_SECRET: "f",
           SERVER_URL: "d",
           SESSION_ID: "e",
         }),

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -205,11 +205,11 @@ describe("automation serving", () => {
   const served = async (signal: "SIGINT" | "SIGTERM") => {
     const port = await freePort();
     const process = spawnAutomation(["--port", String(port)]);
-    const record = join(process.home, "automation-test");
+    const record = join(process.home, "automation-logs");
     try {
       await process.waitFor(/oligarchy automation listening/);
       expect(lines(process.stdout())).toContain(
-        `[global] oligarchy automation listening on 127.0.0.1:${String(port)}; recording to ${record}`,
+        `[global] oligarchy automation listening on 127.0.0.1:${String(port)}; recording to ./automation-logs`,
       );
       expect(existsSync(record)).toBe(false);
 

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -36,6 +36,7 @@ const environment = (home: string, overrides: Record<string, string>): NodeJS.Pr
     ...process.env,
     HOME: home,
     LINEAR_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --disable-warning=ExperimentalWarning`.trim(),
     https_proxy: "http://127.0.0.1:1",
     http_proxy: "http://127.0.0.1:1",
     no_proxy: "",

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -18,8 +18,9 @@ const sign = (payload: string): string =>
 
 type Process = {
   readonly child: ChildProcess;
-  // The process's HOME: an empty directory of its own, where the record file lands.
+  // Distinct from cwd: a write to $HOME/automation-logs must not satisfy the record-file checks.
   readonly home: string;
+  readonly cwd: string;
   readonly stdout: () => string;
   readonly stderr: () => string;
   readonly exited: Promise<{ readonly code: number | null; readonly signal: string | null }>;
@@ -46,16 +47,17 @@ const environment = (home: string, overrides: Record<string, string>): NodeJS.Pr
   return env;
 };
 
-// Each process runs in its own empty directory (no `.env` to read) that is also its HOME, so the
-// record file is the test's own; removed once it has exited.
+// Each process gets an empty cwd (no `.env`) and a different empty HOME, so a write under
+// $HOME cannot pass as ./automation-logs. Both directories are removed once it has exited.
 const spawnAutomation = (
   args: ReadonlyArray<string>,
   overrides: Record<string, string> = {},
 ): Process => {
-  const dir = mkdtempSync(join(tmpdir(), "oligarchy-automation-test-"));
+  const home = mkdtempSync(join(tmpdir(), "oligarchy-automation-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "oligarchy-automation-cwd-"));
   const child = spawn(AUTOMATION, args, {
-    cwd: dir,
-    env: environment(dir, overrides),
+    cwd,
+    env: environment(home, overrides),
     stdio: ["ignore", "pipe", "pipe"],
   });
   let stdout = "";
@@ -79,7 +81,8 @@ const spawnAutomation = (
     });
     child.on("close", (code, signal) => {
       clearTimeout(timer);
-      rmSync(dir, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
       for (const listener of listeners) listener();
       resolve({ code, signal });
     });
@@ -108,7 +111,7 @@ const spawnAutomation = (
       listeners.add(check);
       check();
     });
-  return { child, home: dir, stdout: () => stdout, stderr: () => stderr, exited, waitFor };
+  return { child, home, cwd, stdout: () => stdout, stderr: () => stderr, exited, waitFor };
 };
 
 const portOf = (address: string | AddressInfo | null): number =>
@@ -205,13 +208,15 @@ describe("automation serving", () => {
   const served = async (signal: "SIGINT" | "SIGTERM") => {
     const port = await freePort();
     const process = spawnAutomation(["--port", String(port)]);
-    const record = join(process.home, "automation-logs");
+    const record = join(process.cwd, "automation-logs");
+    const homeRecord = join(process.home, "automation-logs");
     try {
       await process.waitFor(/oligarchy automation listening/);
       expect(lines(process.stdout())).toContain(
         `[global] oligarchy automation listening on 127.0.0.1:${String(port)}; recording to ./automation-logs`,
       );
       expect(existsSync(record)).toBe(false);
+      expect(existsSync(homeRecord)).toBe(false);
 
       const incomplete = await request(
         port,
@@ -274,6 +279,7 @@ describe("automation serving", () => {
       expect(readFileSync(record, "utf8")).toBe(
         `linear ticket OLI-1; model grok-4.6\nlinear ticket OLI-2; model claude-opus-5\n${webhookBody}\n`,
       );
+      expect(existsSync(homeRecord)).toBe(false);
 
       const start = await request(
         port,

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { createHmac } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -9,8 +10,11 @@ import { it } from "@effect/vitest";
 import { Effect } from "effect";
 
 const AUTOMATION = fileURLToPath(new URL("../../automation", import.meta.url));
-const TOKEN = "t";
+const WEBHOOK_SECRET = "whsec_test";
 const EXIT_WITHIN_MS = 60_000;
+
+const sign = (payload: string): string =>
+  createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
 
 type Process = {
   readonly child: ChildProcess;
@@ -30,7 +34,7 @@ const environment = (home: string, overrides: Record<string, string>): NodeJS.Pr
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     HOME: home,
-    OLIGARCHY_TOKEN: TOKEN,
+    LINEAR_WEBHOOK_SECRET: WEBHOOK_SECRET,
     https_proxy: "http://127.0.0.1:1",
     http_proxy: "http://127.0.0.1:1",
     no_proxy: "",
@@ -38,6 +42,7 @@ const environment = (home: string, overrides: Record<string, string>): NodeJS.Pr
   };
   delete env.FORCE_COLOR;
   delete env.DATABASE_URL;
+  delete env.OLIGARCHY_TOKEN;
   return env;
 };
 
@@ -165,12 +170,12 @@ describe("automation startup refusals", () => {
     }),
   );
 
-  it.live("a missing OLIGARCHY_TOKEN exits 1 with OLIGARCHY_TOKEN is not set", () =>
+  it.live("a missing LINEAR_WEBHOOK_SECRET exits 1 with LINEAR_WEBHOOK_SECRET is not set", () =>
     Effect.promise(async () => {
-      const process = spawnAutomation([], { OLIGARCHY_TOKEN: "" });
+      const process = spawnAutomation([], { LINEAR_WEBHOOK_SECRET: "" });
       const { code } = await process.exited;
       expect(code).toBe(1);
-      expect(process.stderr()).toContain("OLIGARCHY_TOKEN is not set");
+      expect(process.stderr()).toContain("LINEAR_WEBHOOK_SECRET is not set");
       expect(process.stdout()).not.toContain("listening");
     }),
   );
@@ -208,22 +213,11 @@ describe("automation serving", () => {
       );
       expect(existsSync(record)).toBe(false);
 
-      const unauthorized = await request(
-        port,
-        "POST",
-        "/automate",
-        { "content-type": "application/json" },
-        '{"ticket":"OLI-1","model":"grok-4.6"}',
-      );
-      expect(unauthorized.status).toBe(401);
-      expect(await unauthorized.json()).toEqual({ error: "unauthorized" });
-      expect(existsSync(record)).toBe(false);
-
       const incomplete = await request(
         port,
         "POST",
         "/automate",
-        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        { "content-type": "application/json" },
         '{"ticket":"OLI-1"}',
       );
       expect(incomplete.status).toBe(400);
@@ -236,7 +230,7 @@ describe("automation serving", () => {
         port,
         "POST",
         "/automate",
-        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        { "content-type": "application/json" },
         '{"ticket":"OLI-1","model":"grok-4.6"}',
       );
       expect(first.status).toBe(200);
@@ -246,7 +240,7 @@ describe("automation serving", () => {
         port,
         "POST",
         "/automate",
-        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        { "content-type": "application/json" },
         '{"ticket":"OLI-2","model":"claude-opus-5"}',
       );
       expect(second.status).toBe(200);
@@ -254,17 +248,46 @@ describe("automation serving", () => {
         "linear ticket OLI-1; model grok-4.6\nlinear ticket OLI-2; model claude-opus-5\n",
       );
 
+      const webhookBody = '{"action":"update","type":"Issue","data":{"identifier":"OLI-9"}}';
+      const unsigned = await request(
+        port,
+        "POST",
+        "/linear",
+        { "content-type": "application/json" },
+        webhookBody,
+      );
+      expect(unsigned.status).toBe(401);
+      expect(await unsigned.json()).toEqual({ error: "unauthorized" });
+      expect(readFileSync(record, "utf8")).toBe(
+        "linear ticket OLI-1; model grok-4.6\nlinear ticket OLI-2; model claude-opus-5\n",
+      );
+
+      const signed = await request(
+        port,
+        "POST",
+        "/linear",
+        { "content-type": "application/json", "linear-signature": sign(webhookBody) },
+        webhookBody,
+      );
+      expect(signed.status).toBe(200);
+      expect(await signed.json()).toEqual({ ok: "true" });
+      expect(readFileSync(record, "utf8")).toBe(
+        `linear ticket OLI-1; model grok-4.6\nlinear ticket OLI-2; model claude-opus-5\n${webhookBody}\n`,
+      );
+
       const start = await request(
         port,
         "POST",
         "/start",
-        { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+        { "content-type": "application/json" },
         '{"iso":"omarchy.iso","agent":"OLI-1"}',
       );
       expect(start.status).toBe(404);
       expect(await start.json()).toEqual({ error: "not found" });
       const nope = await request(port, "GET", "/automate");
       expect(nope.status).toBe(404);
+      const noGet = await request(port, "GET", "/linear");
+      expect(noGet.status).toBe(404);
     } finally {
       // A failed expectation must not leave the process listening past the test.
       process.child.kill(signal);
@@ -272,12 +295,13 @@ describe("automation serving", () => {
     const { code } = await process.exited;
     expect(code, process.stdout()).toBe(0);
     const output = lines(process.stdout());
-    expect(output).toContain("[global] error: POST /automate failed: unauthorized");
     // The schema's detail spans two lines: the missing key, then where.
     expect(output).toContain("[global] error: POST /automate failed: Missing key");
     expect(output).toContain('  at ["model"]');
     expect(output).toContain("[OLI-1] automation recorded; grok-4.6");
     expect(output).toContain("[OLI-2] automation recorded; claude-opus-5");
+    expect(output).toContain("[global] error: POST /linear failed: unauthorized");
+    expect(output).toContain("[global] linear webhook recorded");
     expect(output.some((line) => line.includes("/start"))).toBe(false);
     expect(process.stderr()).toBe("");
 
@@ -285,7 +309,7 @@ describe("automation serving", () => {
   };
 
   it.live(
-    "listens without a database, records each request, answers 401, 400 and 404, and exits 0 on SIGINT",
+    "listens without a database, records /automate and a signed /linear, answers 401, 400 and 404, and exits 0 on SIGINT",
     () => Effect.promise(() => served("SIGINT")),
     120_000,
   );

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -219,40 +219,16 @@ describe("automation serving", () => {
       expect(existsSync(record)).toBe(false);
       expect(existsSync(homeRecord)).toBe(false);
 
-      const incomplete = await request(
-        port,
-        "POST",
-        "/automate",
-        { "content-type": "application/json" },
-        '{"ticket":"OLI-1"}',
-      );
-      expect(incomplete.status).toBe(400);
-      expect(await incomplete.json()).toMatchObject({
-        error: expect.stringContaining('["model"]'),
-      });
-      expect(existsSync(record)).toBe(false);
-
-      const first = await request(
+      const automate = await request(
         port,
         "POST",
         "/automate",
         { "content-type": "application/json" },
         '{"ticket":"OLI-1","model":"grok-4.6"}',
       );
-      expect(first.status).toBe(200);
-      expect(first.headers.get("content-type")).toContain("application/json");
-      expect(await first.json()).toEqual({ ok: "true" });
-      const second = await request(
-        port,
-        "POST",
-        "/automate",
-        { "content-type": "application/json" },
-        '{"ticket":"OLI-2","model":"claude-opus-5"}',
-      );
-      expect(second.status).toBe(200);
-      expect(readFileSync(record, "utf8")).toBe(
-        "linear ticket OLI-1; model grok-4.6\nlinear ticket OLI-2; model claude-opus-5\n",
-      );
+      expect(automate.status).toBe(404);
+      expect(await automate.json()).toEqual({ error: "not found" });
+      expect(existsSync(record)).toBe(false);
 
       const webhookBody = '{"action":"update","type":"Issue","data":{"identifier":"OLI-9"}}';
       const unsigned = await request(
@@ -264,9 +240,7 @@ describe("automation serving", () => {
       );
       expect(unsigned.status).toBe(401);
       expect(await unsigned.json()).toEqual({ error: "unauthorized" });
-      expect(readFileSync(record, "utf8")).toBe(
-        "linear ticket OLI-1; model grok-4.6\nlinear ticket OLI-2; model claude-opus-5\n",
-      );
+      expect(existsSync(record)).toBe(false);
 
       const signed = await request(
         port,
@@ -276,10 +250,9 @@ describe("automation serving", () => {
         webhookBody,
       );
       expect(signed.status).toBe(200);
+      expect(signed.headers.get("content-type")).toContain("application/json");
       expect(await signed.json()).toEqual({ ok: "true" });
-      expect(readFileSync(record, "utf8")).toBe(
-        `linear ticket OLI-1; model grok-4.6\nlinear ticket OLI-2; model claude-opus-5\n${webhookBody}\n`,
-      );
+      expect(readFileSync(record, "utf8")).toBe(`${webhookBody}\n`);
       expect(existsSync(homeRecord)).toBe(false);
 
       const start = await request(
@@ -302,21 +275,17 @@ describe("automation serving", () => {
     const { code } = await process.exited;
     expect(code, process.stdout()).toBe(0);
     const output = lines(process.stdout());
-    // The schema's detail spans two lines: the missing key, then where.
-    expect(output).toContain("[global] error: POST /automate failed: Missing key");
-    expect(output).toContain('  at ["model"]');
-    expect(output).toContain("[OLI-1] automation recorded; grok-4.6");
-    expect(output).toContain("[OLI-2] automation recorded; claude-opus-5");
     expect(output).toContain("[global] error: POST /linear failed: unauthorized");
     expect(output).toContain("[global] linear webhook recorded");
+    expect(output.some((line) => line.includes("/automate"))).toBe(false);
     expect(output.some((line) => line.includes("/start"))).toBe(false);
     expect(process.stderr()).toBe("");
 
-    await expect(request(port, "GET", "/automate")).rejects.toThrow();
+    await expect(request(port, "GET", "/linear")).rejects.toThrow();
   };
 
   it.live(
-    "listens without a database, records /automate and a signed /linear, answers 401, 400 and 404, and exits 0 on SIGINT",
+    "listens without a database, records a signed /linear, answers 401 and 404, and exits 0 on SIGINT",
     () => Effect.promise(() => served("SIGINT")),
     120_000,
   );

--- a/test/repo/architecture.unit.test.ts
+++ b/test/repo/architecture.unit.test.ts
@@ -31,10 +31,12 @@ const isBoundary = (path: string): boolean =>
 
 // Non-boundary files allowed exactly one node:* import. Effect's Crypto.digest is one-shot, so a
 // multi-gigabyte ISO is hashed with node:crypto's streaming createHash; Effect has no inflate, so
-// a PNG's deflate stream is opened with node:zlib.
+// a PNG's deflate stream is opened with node:zlib. Linear signs the raw webhook body with
+// HMAC-SHA256, which Effect's digest does not compute.
 const NODE_IMPORT_EXCEPTIONS: ReadonlyMap<string, string> = new Map([
   ["src/qemu/iso.ts", "node:crypto"],
   ["src/session/image.ts", "node:zlib"],
+  ["src/automation/signature.ts", "node:crypto"],
 ]);
 
 // Files allowed to call `Effect.run*`, each with the calls it may make.

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -235,26 +235,33 @@ describe("ReverseProxyApi", () => {
 describe("AutomationApi", () => {
   const automation = Api.AutomationApi;
 
-  it("declares POST /automate and nothing else", () => {
+  it("declares POST /automate and POST /linear and nothing else", () => {
     const table = routes(automation).map(({ method, path }) => `${method} ${path}`);
-    expect(table).toEqual(["POST /automate"]);
+    expect(table).toEqual(["POST /automate", "POST /linear"]);
     expect(HttpApiClient.urlBuilder(automation).Automations.automate()).toBe("/automate");
+    expect(HttpApiClient.urlBuilder(automation).Linear.linear()).toBe("/linear");
   });
 
-  it("requires the bearer and applies BearerAuth then ApiBoundary", () => {
+  it("applies ApiBoundary and no bearer, on both routes", () => {
     const spec = OpenApi.fromApi(automation);
-    expect(spec.components.securitySchemes).toEqual({
-      bearer: { type: "http", scheme: "Bearer" },
-    });
-    const route = byIdentifier(automation, "automate");
-    expect(route.group).toBe("Automations");
-    expect(route.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);
-    expect(spec.paths["/automate"]?.post?.security).toEqual([{ bearer: [] }]);
-    expect(route.errors).toEqual([400, 401, 500]);
+    expect(spec.components.securitySchemes).toBeUndefined();
+    const automate = byIdentifier(automation, "automate");
+    expect(automate.group).toBe("Automations");
+    expect(automate.middleware).toEqual([Api.ApiBoundary.key]);
+    expect(spec.paths["/automate"]?.post?.security).toBeUndefined();
+    expect(automate.errors).toEqual([400, 500]);
+    const linear = byIdentifier(automation, "linear");
+    expect(linear.group).toBe("Linear");
+    expect(linear.middleware).toEqual([Api.ApiBoundary.key]);
+    expect(spec.paths["/linear"]?.post?.security).toBeUndefined();
+    expect(linear.errors).toEqual([400, 401, 500]);
   });
 
-  it("is its own api: neither the proxy nor the reverse proxy answers /automate", () => {
-    expect(routes(Api.ProxyApi).map(({ path }) => path)).not.toContain("/automate");
-    expect(routes(Api.ReverseProxyApi).map(({ path }) => path)).not.toContain("/automate");
+  it("is its own api: neither the proxy nor the reverse proxy answers /automate or /linear", () => {
+    for (const api of [Api.ProxyApi, Api.ReverseProxyApi]) {
+      const paths = routes(api).map(({ path }) => path);
+      expect(paths).not.toContain("/automate");
+      expect(paths).not.toContain("/linear");
+    }
   });
 });

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -244,24 +244,23 @@ describe("AutomationApi", () => {
 
   it("applies ApiBoundary and no bearer, on both routes", () => {
     const spec = OpenApi.fromApi(automation);
-    expect(spec.components.securitySchemes).toBeUndefined();
+    expect(spec.components.securitySchemes).toEqual({});
     const automate = byIdentifier(automation, "automate");
     expect(automate.group).toBe("Automations");
     expect(automate.middleware).toEqual([Api.ApiBoundary.key]);
-    expect(spec.paths["/automate"]?.post?.security).toBeUndefined();
+    expect(spec.paths["/automate"]?.post?.security).toEqual([]);
     expect(automate.errors).toEqual([400, 500]);
     const linear = byIdentifier(automation, "linear");
     expect(linear.group).toBe("Linear");
     expect(linear.middleware).toEqual([Api.ApiBoundary.key]);
-    expect(spec.paths["/linear"]?.post?.security).toBeUndefined();
+    expect(spec.paths["/linear"]?.post?.security).toEqual([]);
     expect(linear.errors).toEqual([400, 401, 500]);
   });
 
   it("is its own api: neither the proxy nor the reverse proxy answers /automate or /linear", () => {
-    for (const api of [Api.ProxyApi, Api.ReverseProxyApi]) {
-      const paths = routes(api).map(({ path }) => path);
-      expect(paths).not.toContain("/automate");
-      expect(paths).not.toContain("/linear");
-    }
+    expect(routes(Api.ProxyApi).map(({ path }) => path)).not.toContain("/automate");
+    expect(routes(Api.ProxyApi).map(({ path }) => path)).not.toContain("/linear");
+    expect(routes(Api.ReverseProxyApi).map(({ path }) => path)).not.toContain("/automate");
+    expect(routes(Api.ReverseProxyApi).map(({ path }) => path)).not.toContain("/linear");
   });
 });

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -235,21 +235,15 @@ describe("ReverseProxyApi", () => {
 describe("AutomationApi", () => {
   const automation = Api.AutomationApi;
 
-  it("declares POST /automate and POST /linear and nothing else", () => {
+  it("declares POST /linear and nothing else", () => {
     const table = routes(automation).map(({ method, path }) => `${method} ${path}`);
-    expect(table).toEqual(["POST /automate", "POST /linear"]);
-    expect(HttpApiClient.urlBuilder(automation).Automations.automate()).toBe("/automate");
+    expect(table).toEqual(["POST /linear"]);
     expect(HttpApiClient.urlBuilder(automation).Linear.linear()).toBe("/linear");
   });
 
-  it("applies ApiBoundary and no bearer, on both routes", () => {
+  it("applies ApiBoundary and no bearer", () => {
     const spec = OpenApi.fromApi(automation);
     expect(spec.components.securitySchemes).toEqual({});
-    const automate = byIdentifier(automation, "automate");
-    expect(automate.group).toBe("Automations");
-    expect(automate.middleware).toEqual([Api.ApiBoundary.key]);
-    expect(spec.paths["/automate"]?.post?.security).toEqual([]);
-    expect(automate.errors).toEqual([400, 500]);
     const linear = byIdentifier(automation, "linear");
     expect(linear.group).toBe("Linear");
     expect(linear.middleware).toEqual([Api.ApiBoundary.key]);
@@ -257,10 +251,8 @@ describe("AutomationApi", () => {
     expect(linear.errors).toEqual([400, 401, 500]);
   });
 
-  it("is its own api: neither the proxy nor the reverse proxy answers /automate or /linear", () => {
-    expect(routes(Api.ProxyApi).map(({ path }) => path)).not.toContain("/automate");
+  it("is its own api: neither the proxy nor the reverse proxy answers /linear", () => {
     expect(routes(Api.ProxyApi).map(({ path }) => path)).not.toContain("/linear");
-    expect(routes(Api.ReverseProxyApi).map(({ path }) => path)).not.toContain("/automate");
     expect(routes(Api.ReverseProxyApi).map(({ path }) => path)).not.toContain("/linear");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The automation service now accepts Linear webhooks at `POST /linear` and does nothing else.

Linear POSTs the signed JSON body here. The service verifies `Linear-Signature` as HMAC-SHA256 of the raw bytes using `LINEAR_WEBHOOK_SECRET`, then appends those exact bytes plus a trailing newline to `./automation-logs`. A missing or wrong signature is `401` and writes nothing. An extra hex nibble on an otherwise valid signature is also `401`.

`POST /automate` is gone. `./automation` no longer reads `OLIGARCHY_TOKEN`. Startup requires `LINEAR_WEBHOOK_SECRET`.

Put the signing secret from Linear’s webhook settings in `.env` as:

```
LINEAR_WEBHOOK_SECRET=...
```

Then change a ticket status and read `./automation-logs` for the payload Linear actually sent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-482b95b5-900c-4031-a17d-9eece132b692?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-482b95b5-900c-4031-a17d-9eece132b692&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

