### PR TITLE
Parse Linear Issue identifier and state from signed webhooks

### DIFF
--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, FileSystem, Layer, Redacted } from "effect";
+import { Context, Effect, FileSystem, Layer, Option, Redacted } from "effect";
 import { HttpServerRequest } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import * as Config from "../config.ts";
@@ -9,6 +9,7 @@ import * as Api from "../shared/api.ts";
 import * as Contract from "../shared/contract.ts";
 import * as Errors from "../shared/errors.ts";
 import * as Signature from "./signature.ts";
+import * as Webhook from "./webhook.ts";
 
 const ok = Contract.Ok.make({});
 
@@ -45,7 +46,14 @@ export const LinearLive = (record: string) =>
         yield* fs
           .writeFile(record, recorded, { flag: "a" })
           .pipe(Effect.mapError((cause) => Errors.Internal.make({ cause })));
-        yield* log.info("linear webhook recorded");
+        const parsed = Option.map(Webhook.issue(bytes), Webhook.work);
+        if (Option.isSome(parsed)) {
+          yield* log.info(`linear webhook recorded; ${parsed.value.state}`, {
+            agentId: parsed.value.ticket,
+          });
+        } else {
+          yield* log.info("linear webhook recorded");
+        }
         return ok;
       }),
     ),

--- a/src/automation/webhook.ts
+++ b/src/automation/webhook.ts
@@ -1,0 +1,48 @@
+import { Option, Schema } from "effect";
+
+export const IssueState = Schema.Struct({
+  id: Schema.String,
+  name: Schema.NonEmptyString,
+  type: Schema.NonEmptyString,
+}).annotate({ identifier: "@oligarchy/automation/webhook/IssueState" });
+export type IssueState = typeof IssueState.Type;
+
+export const IssueWebhook = Schema.Struct({
+  action: Schema.Literals(["create", "update", "remove"]),
+  type: Schema.Literal("Issue"),
+  data: Schema.Struct({
+    identifier: Schema.NonEmptyString,
+    state: IssueState,
+  }),
+  updatedFrom: Schema.optionalKey(
+    Schema.Struct({
+      state: Schema.optionalKey(Schema.Unknown),
+    }),
+  ),
+}).annotate({ identifier: "@oligarchy/automation/webhook/IssueWebhook" });
+export type IssueWebhook = typeof IssueWebhook.Type;
+
+export type Work = {
+  readonly ticket: string;
+  readonly state: string;
+  readonly stateId: string;
+  readonly stateType: string;
+  readonly action: IssueWebhook["action"];
+  readonly stateChanged: boolean;
+};
+
+const decodeIssue = Schema.decodeUnknownOption(Schema.fromJsonString(IssueWebhook));
+
+// Linear's body has many keys we do not store yet; the decoder keeps identifier and state
+// and whether updatedFrom named state, which is the queue key once rows exist.
+export const issue = (body: Uint8Array): Option.Option<IssueWebhook> =>
+  decodeIssue(new TextDecoder().decode(body));
+
+export const work = (event: IssueWebhook): Work => ({
+  ticket: event.data.identifier,
+  state: event.data.state.name,
+  stateId: event.data.state.id,
+  stateType: event.data.state.type,
+  action: event.action,
+  stateChanged: event.action === "create" || event.updatedFrom?.state !== undefined,
+});

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -133,6 +133,40 @@ describe("POST /linear", () => {
     }),
   );
 
+  it.effect("logs the ticket and the state name when Linear sent an Issue with both", () =>
+    Effect.gen(function* () {
+      const body = JSON.stringify({
+        action: "update",
+        type: "Issue",
+        data: {
+          identifier: "OLI-1063",
+          state: {
+            id: "a9fe2d89-3cb3-47dd-8645-5d224f997134",
+            name: "Automation Needed",
+            type: "unstarted",
+          },
+        },
+        updatedFrom: { state: { name: "Todo" } },
+      });
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        expect((yield* webhook(http, body, sign(body))).status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.file.writes).toEqual([{ path: RECORD, data: withNewline(body), flag: "a" }]);
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "info",
+          text: "linear webhook recorded; Automation Needed",
+          sessionId: undefined,
+          agentId: "OLI-1063",
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+    }),
+  );
+
   it.effect(
     "appends a UTF-8 BOM body as the exact bytes Linear signed, plus a trailing newline",
     () =>

--- a/test/automation/webhook.unit.test.ts
+++ b/test/automation/webhook.unit.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { Option } from "effect";
+import * as Webhook from "../../src/automation/webhook.ts";
+
+const bytes = (json: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(json));
+
+const issue = {
+  action: "update",
+  type: "Issue",
+  data: {
+    identifier: "OLI-1063",
+    title: "drive the guest",
+    state: {
+      id: "a9fe2d89-3cb3-47dd-8645-5d224f997134",
+      color: "#bec2c8",
+      name: "Automation Needed",
+      type: "unstarted",
+    },
+  },
+  updatedFrom: { title: "old title" },
+} as const;
+
+describe("Webhook.issue", () => {
+  it("reads the ticket and the state Linear put on an Issue", () => {
+    const parsed = Webhook.issue(bytes(issue));
+    expect(Option.isSome(parsed)).toBe(true);
+    if (Option.isNone(parsed)) {
+      return;
+    }
+    expect(Webhook.work(parsed.value)).toEqual({
+      ticket: "OLI-1063",
+      state: "Automation Needed",
+      stateId: "a9fe2d89-3cb3-47dd-8645-5d224f997134",
+      stateType: "unstarted",
+      action: "update",
+      stateChanged: false,
+    });
+  });
+
+  it("marks a create, or an update whose updatedFrom names state, as a state change", () => {
+    const created = Webhook.issue(bytes({ ...issue, action: "create", updatedFrom: undefined }));
+    expect(Option.isSome(created)).toBe(true);
+    if (Option.isSome(created)) {
+      expect(Webhook.work(created.value).stateChanged).toBe(true);
+    }
+    const moved = Webhook.issue(
+      bytes({
+        ...issue,
+        updatedFrom: { state: { id: "old", name: "Todo", type: "unstarted" } },
+      }),
+    );
+    expect(Option.isSome(moved)).toBe(true);
+    if (Option.isSome(moved)) {
+      expect(Webhook.work(moved.value).stateChanged).toBe(true);
+    }
+  });
+
+  it("returns none for invalid JSON, a Comment, a missing ticket or state, or a remove without those fields", () => {
+    expect(Webhook.issue(new TextEncoder().encode("{bad"))).toEqual(Option.none());
+    expect(Webhook.issue(bytes({ action: "update", type: "Comment", data: {} }))).toEqual(
+      Option.none(),
+    );
+    expect(
+      Webhook.issue(bytes({ action: "update", type: "Issue", data: { identifier: "OLI-1" } })),
+    ).toEqual(Option.none());
+    expect(
+      Webhook.issue(
+        bytes({
+          action: "update",
+          type: "Issue",
+          data: { state: { id: "x", name: "Todo", type: "unstarted" } },
+        }),
+      ),
+    ).toEqual(Option.none());
+  });
+});

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -230,7 +230,8 @@ describe("automation serving", () => {
       expect(await automate.json()).toEqual({ error: "not found" });
       expect(existsSync(record)).toBe(false);
 
-      const webhookBody = '{"action":"update","type":"Issue","data":{"identifier":"OLI-9"}}';
+      const webhookBody =
+        '{"action":"update","type":"Issue","data":{"identifier":"OLI-9","state":{"id":"st-1","name":"Automation Needed","type":"unstarted"}},"updatedFrom":{"state":{"name":"Todo"}}}';
       const unsigned = await request(
         port,
         "POST",
@@ -276,7 +277,7 @@ describe("automation serving", () => {
     expect(code, process.stdout()).toBe(0);
     const output = lines(process.stdout());
     expect(output).toContain("[global] error: POST /linear failed: unauthorized");
-    expect(output).toContain("[global] linear webhook recorded");
+    expect(output).toContain("[OLI-9] linear webhook recorded; Automation Needed");
     expect(output.some((line) => line.includes("/automate"))).toBe(false);
     expect(output.some((line) => line.includes("/start"))).toBe(false);
     expect(process.stderr()).toBe("");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After HMAC, `POST /linear` decodes `data.identifier` and `data.state` from an Issue payload.

The raw body still goes to `./automation-logs`. When the body is an Issue with a ticket and a status, the process logs `[OLI-…] linear webhook recorded; <state name>` and keeps a `Work` value (`ticket`, `state`, `stateId`, `stateType`, `action`, `stateChanged` from `updatedFrom.state`) ready for the queue rows.

Two deliveries with the same current `data.state` is Linear sending two Issue events (or a retry). Compare `updatedFrom` and `Linear-Delivery`; this change does not drop the second write.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-482b95b5-900c-4031-a17d-9eece132b692?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-482b95b5-900c-4031-a17d-9eece132b692&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

