### PR TITLE
Enqueue drive/diagnose from Linear Automation Needed and Needs Review

### DIFF
--- a/development.md
+++ b/development.md
@@ -741,8 +741,8 @@ statement inside with `Client.attempt("endSession", () => tx.update(...))`.
   sits above `Database` so the flush completes before the pool closes. `Log.layer` reads
   `ErrorReporter.CurrentErrorReporters` once at build, so `SentryLive` is provided beneath it,
   never only to callers. `Log.layerStdout` persists nothing: it is for tests and for a process
-  that keeps no rows (the automation service), whose record is stdout and Sentry. A fatal path
-  flushes the log, then Sentry, then exits.
+  that does not persist log rows (the automation service writes queue jobs, not log lines), whose
+  console copy is stdout and Sentry. A fatal path flushes the log, then Sentry, then exits.
 - `Log` installs no Effect `Logger`; `emit` formats, writes and offers synchronously. `console.*`
   appears only in `src/dashboard/**` and `vitest.global-setup.ts`. Test log output through the
   fake `Log` layer (`test/support/log.ts`) or `Log.layerStdout` with `TestConsole.logLines`.

--- a/src/automation/command.ts
+++ b/src/automation/command.ts
@@ -1,8 +1,11 @@
 import { Deferred, Effect, Layer } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import type { HttpServerError } from "effect/unstable/http";
+import * as Client from "../db/client.ts";
+import * as ExternalFailure from "../external-failure.ts";
 import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
+import * as Errors from "../shared/errors.ts";
 
 // The port the operator's tunnel points at; nothing else of ours is near it.
 const DEFAULT_PORT = 54321;
@@ -14,7 +17,12 @@ export type AutomationServer<RServe> = {
   readonly serverFailed: Deferred.Deferred<never, HttpServerError.ServeError>;
 };
 
-// No database to ping and no host to check: the flags parsed, the service listens.
+type StartupError = Errors.DatabaseError | HttpServerError.ServeError;
+
+// A ServeError says nothing itself; the bind or accept error it wraps does.
+const detail = (error: StartupError): string =>
+  error._tag === "ServeError" ? Render.errorDetail(error.cause) : Render.errorDetail(error);
+
 export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) =>
   Command.make(
     "automation",
@@ -27,18 +35,29 @@ export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) 
     ({ port }) =>
       Effect.gen(function* () {
         const log = yield* Log.Log;
-        return yield* Effect.raceFirst(
-          Layer.launch(server.serve(port)),
-          Deferred.await(server.serverFailed),
-        ).pipe(
-          // A ServeError says nothing itself; the bind or accept error it wraps does.
-          Effect.tapError((error) =>
-            log.fatal(`automation: ${Render.errorDetail(error.cause)}`, { cause: error }),
-          ),
+        const database = yield* Client.Database;
+        const startup = Effect.gen(function* () {
+          // Queue rows live in Postgres: fail at startup, not on the first webhook.
+          yield* database.ping.pipe(
+            Effect.mapError((error) =>
+              Errors.DatabaseError.make({
+                operation: "ping",
+                message: `database unreachable: ${Render.errorDetail(ExternalFailure.causeOf(error))}`,
+                cause: error,
+              }),
+            ),
+          );
+          return yield* Effect.raceFirst(
+            Layer.launch(server.serve(port)),
+            Deferred.await(server.serverFailed),
+          );
+        });
+        return yield* startup.pipe(
+          Effect.tapError((error) => log.fatal(`automation: ${detail(error)}`, { cause: error })),
         );
       }),
   ).pipe(
     Command.withDescription(
-      "The oligarchy automation service: POST /linear records a signed Linear webhook as the exact body plus a trailing newline in ./automation-logs",
+      "The oligarchy automation service: POST /linear verifies a signed Linear webhook and enqueues drive or diagnose jobs from status changes",
     ),
   );

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -1,7 +1,9 @@
-import { Context, Effect, FileSystem, Layer, Redacted } from "effect";
+import { Context, Effect, Layer, Option, Redacted } from "effect";
 import { HttpServerRequest } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import * as Config from "../config.ts";
+import * as Automation from "../db/automation.ts";
+import * as Tests from "../db/tests.ts";
 import * as Log from "../observability/log.ts";
 import * as ProxyHandlers from "../proxy/handlers.ts";
 import * as Middleware from "../proxy/middleware.ts";
@@ -9,6 +11,7 @@ import * as Api from "../shared/api.ts";
 import * as Contract from "../shared/contract.ts";
 import * as Errors from "../shared/errors.ts";
 import * as Signature from "./signature.ts";
+import * as Webhook from "./webhook.ts";
 
 const ok = Contract.Ok.make({});
 
@@ -19,44 +22,78 @@ export class LinearWebhookSecret extends Context.Service<LinearWebhookSecret>()(
   static readonly layer = Layer.effect(this)(this.make);
 }
 
-// No payload schema: Linear's HMAC is over the raw bytes, and the record is those same bytes
-// plus a trailing newline. A JSON payload would parse and lose the exact body.
-export const LinearLive = (record: string) =>
-  HttpApiBuilder.group(Api.AutomationApi, "Linear", (handlers) =>
-    handlers.handle("linear", () =>
-      Effect.gen(function* () {
-        const secret = yield* LinearWebhookSecret;
-        const request = yield* HttpServerRequest.HttpServerRequest;
-        const fs = yield* FileSystem.FileSystem;
-        const log = yield* Log.Log;
-        const bytes = new Uint8Array(
-          yield* request.arrayBuffer.pipe(
-            Effect.mapError((cause) => Errors.Internal.make({ cause })),
-          ),
-        );
-        if (
-          !Signature.matches(Redacted.value(secret), request.headers["linear-signature"], bytes)
-        ) {
-          return yield* Errors.Unauthorized.make({});
-        }
-        const recorded = new Uint8Array(bytes.length + 1);
-        recorded.set(bytes);
-        recorded[bytes.length] = 0x0a;
-        yield* fs
-          .writeFile(record, recorded, { flag: "a" })
-          .pipe(Effect.mapError((cause) => Errors.Internal.make({ cause })));
+const isDuplicateJob = (error: Errors.DatabaseError): boolean =>
+  String(error.cause).includes("duplicate key");
+
+// HMAC is over the raw bytes. After verifying, parse identifier + state and enqueue drive or
+// diagnose when the Oligarchy board moves into Automation Needed or Needs Review.
+export const LinearLive = HttpApiBuilder.group(Api.AutomationApi, "Linear", (handlers) =>
+  handlers.handle("linear", () =>
+    Effect.gen(function* () {
+      const secret = yield* LinearWebhookSecret;
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const log = yield* Log.Log;
+      const tests = yield* Tests.TestStore;
+      const automation = yield* Automation.AutomationStore;
+      const bytes = new Uint8Array(
+        yield* request.arrayBuffer.pipe(
+          Effect.mapError((cause) => Errors.Internal.make({ cause })),
+        ),
+      );
+      if (!Signature.matches(Redacted.value(secret), request.headers["linear-signature"], bytes)) {
+        return yield* Errors.Unauthorized.make({});
+      }
+      const parsed = Option.map(Webhook.issue(bytes), Webhook.work);
+      if (Option.isNone(parsed)) {
         yield* log.info("linear webhook recorded");
         return ok;
-      }),
-    ),
-  );
+      }
+      const event = parsed.value;
+      const job = Webhook.queuedAction(event);
+      if (Option.isNone(job)) {
+        yield* log.info(`linear webhook recorded; ${event.state}`, { agentId: event.ticket });
+        return ok;
+      }
+      const result = yield* tests
+        .findResultByLinearId(event.ticket)
+        .pipe(
+          Effect.mapError((error) => Errors.Internal.make({ cause: error, agentId: event.ticket })),
+        );
+      if (Option.isNone(result)) {
+        yield* log.info(`linear webhook ignored; no result for ${event.state}`, {
+          agentId: event.ticket,
+        });
+        return ok;
+      }
+      const outcome = yield* automation
+        .enqueue({ resultId: result.value.id, action: job.value })
+        .pipe(
+          Effect.as("queued" as const),
+          Effect.catchTag("DatabaseError", (error) =>
+            isDuplicateJob(error)
+              ? Effect.succeed("duplicate" as const)
+              : Effect.fail(Errors.Internal.make({ cause: error, agentId: event.ticket })),
+          ),
+        );
+      if (outcome === "duplicate") {
+        yield* log.info(`linear webhook ignored; ${job.value} already queued`, {
+          agentId: event.ticket,
+        });
+        return ok;
+      }
+      yield* log.info(`linear webhook queued ${job.value}; ${event.state}`, {
+        agentId: event.ticket,
+      });
+      return ok;
+    }),
+  ),
+);
 
 // The bearer is left off: Linear signs /linear.
-export const routes = (record: string) =>
-  Layer.mergeAll(
-    HttpApiBuilder.layer(Api.AutomationApi).pipe(
-      Layer.provide(LinearLive(record)),
-      Layer.provide(Middleware.ApiBoundaryLive),
-    ),
-    ProxyHandlers.NotFoundRoute,
-  );
+export const routes = Layer.mergeAll(
+  HttpApiBuilder.layer(Api.AutomationApi).pipe(
+    Layer.provide(LinearLive),
+    Layer.provide(Middleware.ApiBoundaryLive),
+  ),
+  ProxyHandlers.NotFoundRoute,
+);

--- a/src/automation/main.ts
+++ b/src/automation/main.ts
@@ -4,6 +4,9 @@ import { Cause, Deferred, Effect, Exit, Layer, type Runtime } from "effect";
 import { Command } from "effect/unstable/cli";
 import { HttpMiddleware, HttpRouter, HttpServerError } from "effect/unstable/http";
 import * as Config from "../config.ts";
+import * as Automation from "../db/automation.ts";
+import * as Client from "../db/client.ts";
+import * as Tests from "../db/tests.ts";
 import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
 import * as Sentry from "../observability/sentry.ts";
@@ -13,11 +16,9 @@ import * as Handlers from "./handlers.ts";
 
 const HOST = "127.0.0.1";
 
-// Where every request lands, appended in the working directory as they asked.
-const RECORD = "./automation-logs";
-
-// stdout is the convenience copy of the log; Sentry is the record. A write refused by a full
-// filesystem is dropped, never an uncaught exception per line (see the proxy's main).
+// stdout is the convenience copy of the log; the automation_jobs rows and Sentry are the record.
+// A write refused by a full filesystem is dropped, never an uncaught exception per line
+// (see the proxy's main).
 process.stdout.on("error", () => {});
 process.stderr.on("error", () => {});
 
@@ -33,13 +34,11 @@ const ServerLive = (port: number) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const log = yield* Log.Log;
-      yield* log.info(
-        `oligarchy automation listening on ${HOST}:${String(port)}; recording to ${RECORD}`,
-      );
+      yield* log.info(`oligarchy automation listening on ${HOST}:${String(port)}`);
     }),
   ).pipe(
     Layer.provide(
-      HttpRouter.serve(Handlers.routes(RECORD), {
+      HttpRouter.serve(Handlers.routes, {
         disableLogger: true,
         disableListenLog: true,
       }).pipe(Layer.provide(NodeHttpServer.layer(() => server, { host: HOST, port }))),
@@ -48,10 +47,17 @@ const ServerLive = (port: number) =>
     Layer.provide(Layer.succeed(HttpMiddleware.TracerDisabledWhen)(() => true)),
   );
 
-// LINEAR_WEBHOOK_SECRET is the one variable this process reads: Linear signs POST /linear with it.
-// No database: this service keeps no rows, so its log is stdout and Sentry. Sentry sits beneath
-// Log so Log captures the reporter.
-const MainLive = Layer.mergeAll(Log.Log.layerStdout, Handlers.LinearWebhookSecret.layer).pipe(
+const DatabaseLive = Layer.unwrap(Effect.map(Config.databaseUrl, Client.Database.layer));
+
+// LINEAR_WEBHOOK_SECRET signs POST /linear; DATABASE_URL holds the queue. Sentry sits beneath
+// Log so Log captures the reporter. Log is stdout: durable work is automation_jobs, not log rows.
+const MainLive = Layer.mergeAll(
+  Log.Log.layerStdout,
+  Handlers.LinearWebhookSecret.layer,
+  Tests.TestStore.layer,
+  Automation.AutomationStore.layer,
+).pipe(
+  Layer.provideMerge(DatabaseLive),
   Layer.provideMerge(Sentry.SentryLive),
   Layer.provideMerge(Config.providerLayer),
   Layer.provideMerge(NodeServices.layer),
@@ -59,9 +65,9 @@ const MainLive = Layer.mergeAll(Log.Log.layerStdout, Handlers.LinearWebhookSecre
 
 const command = AutomationCommand.makeAutomationCommand({ serve: ServerLive, serverFailed });
 
-// The graph is built before the command runs: a missing LINEAR_WEBHOOK_SECRET is the one failure
-// no Log exists to record, so it is printed here. Every later failure logs its own fatal line; a
-// defect has nothing else to say for it.
+// The graph is built before the command runs: a missing LINEAR_WEBHOOK_SECRET or DATABASE_URL is
+// the one failure no Log exists to record, so it is printed here. Every later failure logs its
+// own fatal line; a defect has nothing else to say for it.
 const program = Effect.gen(function* () {
   const services = yield* Layer.build(MainLive).pipe(Effect.tapCause(Render.reportFailure));
   yield* Command.run(command, { version: Api.VERSION }).pipe(

--- a/src/automation/webhook.ts
+++ b/src/automation/webhook.ts
@@ -1,0 +1,63 @@
+import { Option, Schema } from "effect";
+import type * as Automation from "../db/automation.ts";
+
+export const IssueState = Schema.Struct({
+  id: Schema.String,
+  name: Schema.NonEmptyString,
+  type: Schema.NonEmptyString,
+}).annotate({ identifier: "@oligarchy/automation/webhook/IssueState" });
+export type IssueState = typeof IssueState.Type;
+
+export const IssueWebhook = Schema.Struct({
+  action: Schema.Literals(["create", "update", "remove"]),
+  type: Schema.Literal("Issue"),
+  data: Schema.Struct({
+    identifier: Schema.NonEmptyString,
+    state: IssueState,
+  }),
+  updatedFrom: Schema.optionalKey(
+    Schema.Struct({
+      state: Schema.optionalKey(Schema.Unknown),
+    }),
+  ),
+}).annotate({ identifier: "@oligarchy/automation/webhook/IssueWebhook" });
+export type IssueWebhook = typeof IssueWebhook.Type;
+
+export type Work = {
+  readonly ticket: string;
+  readonly state: string;
+  readonly stateId: string;
+  readonly stateType: string;
+  readonly action: IssueWebhook["action"];
+  readonly stateChanged: boolean;
+};
+
+const decodeIssue = Schema.decodeUnknownOption(Schema.fromJsonString(IssueWebhook));
+
+// Linear's body has many keys we do not store yet; the decoder keeps identifier and state
+// and whether updatedFrom named state, which is the queue key once rows exist.
+export const issue = (body: Uint8Array): Option.Option<IssueWebhook> =>
+  decodeIssue(new TextDecoder().decode(body));
+
+export const work = (event: IssueWebhook): Work => ({
+  ticket: event.data.identifier,
+  state: event.data.state.name,
+  stateId: event.data.state.id,
+  stateType: event.data.state.type,
+  action: event.action,
+  stateChanged: event.action === "create" || event.updatedFrom?.state !== undefined,
+});
+
+// Status names on the Oligarchy board: Automation Needed starts a drive, Needs Review a diagnose.
+export const queuedAction = (event: Work): Option.Option<Automation.AutomationAction> => {
+  if (!event.stateChanged) {
+    return Option.none();
+  }
+  if (event.state === "Automation Needed") {
+    return Option.some("drive");
+  }
+  if (event.state === "Needs Review") {
+    return Option.some("diagnose");
+  }
+  return Option.none();
+};

--- a/test/automation/command.unit.test.ts
+++ b/test/automation/command.unit.test.ts
@@ -17,7 +17,9 @@ import { Command } from "effect/unstable/cli";
 import { HttpServerError } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as AutomationCommand from "../../src/automation/command.ts";
+import * as Client from "../../src/db/client.ts";
 import * as Api from "../../src/shared/api.ts";
+import * as Errors from "../../src/shared/errors.ts";
 import * as FakeLog from "../support/log.ts";
 
 const CliTestLayer = Layer.mergeAll(
@@ -56,15 +58,24 @@ const fakeServer = () => {
   return { served, listening, serverFailed, server };
 };
 
-// No Database in the layer: the command has none to ping, and one it asked for would not compile.
+const DatabaseLive = (ping: Effect.Effect<void, Errors.DatabaseError> = Effect.void) =>
+  Layer.succeed(Client.Database)(
+    Client.Database.of({
+      run: () => Effect.die("unused"),
+      transaction: () => Effect.die("unused"),
+      ping,
+    }),
+  );
+
 const run = (
   server: AutomationCommand.AutomationServer<never>,
   args: ReadonlyArray<string>,
   log: FakeLog.FakeLog,
+  database: Layer.Layer<Client.Database> = DatabaseLive(),
 ) =>
   Command.runWith(AutomationCommand.makeAutomationCommand(server), { version: Api.VERSION })(
     args,
-  ).pipe(Effect.provide(Layer.mergeAll(CliTestLayer, log.layer)));
+  ).pipe(Effect.provide(Layer.mergeAll(CliTestLayer, log.layer, database)));
 
 describe("automation command flags", () => {
   it.effect("--port must be an integer", () =>
@@ -93,7 +104,7 @@ describe("automation command flags", () => {
     }),
   );
 
-  it.effect("defaults to port 54321 and listens with nothing to ping first", () =>
+  it.effect("defaults to port 54321, pings the database, and listens", () =>
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
@@ -120,6 +131,30 @@ describe("automation command flags", () => {
 });
 
 describe("automation command startup failures", () => {
+  it.effect("an unreachable database is fatal and never listens (unhappy)", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const unreachable = Errors.DatabaseError.make({
+        operation: "ping",
+        message: "database request failed",
+        cause: new Error("connect ECONNREFUSED"),
+      });
+      const error = yield* Effect.flip(
+        run(fake.server, [], log, DatabaseLive(Effect.fail(unreachable))),
+      );
+      expect(error).toMatchObject({
+        _tag: "DatabaseError",
+        operation: "ping",
+        message: "database unreachable: connect ECONNREFUSED",
+      });
+      expect(fake.served).toEqual([]);
+      expect(log.lines.map((line) => [line.level, line.text])).toEqual([
+        ["fatal", "automation: database unreachable: connect ECONNREFUSED"],
+      ]);
+    }),
+  );
+
   it.effect("a server error after listen fails the handler with the error's detail", () =>
     Effect.gen(function* () {
       const fake = fakeServer();

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -1,71 +1,35 @@
 import { createHmac } from "node:crypto";
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
-import { Effect, FileSystem, Layer, Redacted } from "effect";
+import { Effect, Layer, Redacted } from "effect";
 import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
 import { NodeHttpServer } from "@effect/platform-node";
 import * as Handlers from "../../src/automation/handlers.ts";
-import * as FakeFs from "../support/fake-fs.ts";
 import * as FakeLog from "../support/log.ts";
 import * as Reporter from "../support/reporter.ts";
+import * as Stores from "../support/stores.ts";
 
 const WEBHOOK_SECRET = "whsec_test";
-const RECORD = "./automation-logs";
 
 const SecretLive = Layer.succeed(Handlers.LinearWebhookSecret)(
   Handlers.LinearWebhookSecret.of(Redacted.make(WEBHOOK_SECRET)),
 );
 
-type Write = {
-  readonly path: string;
-  readonly data: Uint8Array;
-  readonly flag: FileSystem.OpenFlag | undefined;
-};
-
-type RecordFile = {
-  readonly writes: Array<Write>;
-  readonly layer: Layer.Layer<FileSystem.FileSystem>;
-};
-
-const denied = (path: string) => Effect.fail(FakeFs.permissionDenied("open", path));
-
-// A FileSystem that records every write, or refuses each one as a file it may not open.
-const recordFile = (refuse = false): RecordFile => {
-  const writes: Array<Write> = [];
-  const layer = FileSystem.layerNoop({
-    writeFile: (path, data, options) =>
-      refuse
-        ? denied(path)
-        : Effect.sync(() => {
-            writes.push({ path, data, flag: options?.flag });
-          }),
-  });
-  return { writes, layer };
-};
-
-const withNewline = (payload: string | Uint8Array): Uint8Array => {
-  const bytes = typeof payload === "string" ? new TextEncoder().encode(payload) : payload;
-  const out = new Uint8Array(bytes.length + 1);
-  out.set(bytes);
-  out[bytes.length] = 0x0a;
-  return out;
-};
-
 type Fixture = {
-  readonly file: RecordFile;
+  readonly stores: ReturnType<typeof Stores.fakeStores>;
   readonly log: FakeLog.FakeLog;
   readonly reporter: Reporter.Collector;
 };
 
-const fixture = (file: RecordFile = recordFile()): Fixture => ({
-  file,
+const fixture = (): Fixture => ({
+  stores: Stores.fakeStores(),
   log: FakeLog.fakeLog(),
   reporter: Reporter.collect(),
 });
 
 const serve = (fixed: Fixture) =>
-  HttpRouter.serve(Handlers.routes(RECORD), { disableLogger: true, disableListenLog: true }).pipe(
-    Layer.provide(Layer.mergeAll(fixed.file.layer, fixed.log.layer, SecretLive)),
+  HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
+    Layer.provide(Layer.mergeAll(fixed.stores.layer, fixed.log.layer, SecretLive)),
     Layer.provideMerge(NodeHttpServer.layerTest),
     Layer.provideMerge(fixed.reporter.layer),
   );
@@ -85,10 +49,46 @@ const webhook = (http: HttpClient.HttpClient, payload: string | Uint8Array, sign
         : HttpBody.uint8Array(payload, "application/json"),
   });
 
+const seedResult = (
+  fixed: Fixture,
+  linearId: string,
+  resultId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+) => {
+  fixed.stores.tests.results.push({
+    id: resultId,
+    runId: "11111111-1111-4111-8111-111111111111",
+    definitionId: 1,
+    sessionId: null,
+    model: null,
+    linearId,
+    status: "pending",
+    reason: null,
+    createdAt: new Date(),
+    finishedAt: null,
+  });
+  return resultId;
+};
+
+const issueBody = (state: string, extras: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    action: "update",
+    type: "Issue",
+    data: {
+      identifier: "OLI-1063",
+      state: {
+        id: "a9fe2d89-3cb3-47dd-8645-5d224f997134",
+        name: state,
+        type: state === "Needs Review" ? "started" : "unstarted",
+      },
+    },
+    updatedFrom: { state: { name: "Todo" } },
+    ...extras,
+  });
+
 describe("POST /linear", () => {
   const payload = '{"action":"update","type":"Issue","data":{"identifier":"OLI-1"}}';
 
-  it.effect("appends the exact body Linear sent, answers ok and logs it", () =>
+  it.effect("answers ok and logs a signed body that is not a queueable Issue state", () =>
     Effect.gen(function* () {
       const fixed = fixture();
       yield* Effect.gen(function* () {
@@ -97,7 +97,7 @@ describe("POST /linear", () => {
         expect(response.status).toBe(200);
         expect(yield* response.json).toEqual({ ok: "true" });
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes).toEqual([{ path: RECORD, data: withNewline(payload), flag: "a" }]);
+      expect(fixed.stores.automation.jobs).toEqual([]);
       expect(fixed.log.lines).toEqual([
         {
           level: "info",
@@ -112,45 +112,93 @@ describe("POST /linear", () => {
     }),
   );
 
-  it.effect("every signed delivery appends its own exact body, in order", () =>
+  it.effect("queues drive when Automation Needed arrives for a known ticket", () =>
     Effect.gen(function* () {
-      const first = '{"action":"create","type":"Issue"}';
-      const second = '{\n  "action": "update",\n  "type": "Comment"\n}';
+      const body = issueBody("Automation Needed");
       const fixed = fixture();
+      const resultId = seedResult(fixed, "OLI-1063");
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
-        expect((yield* webhook(http, first, sign(first))).status).toBe(200);
-        expect((yield* webhook(http, second, sign(second))).status).toBe(200);
+        expect((yield* webhook(http, body, sign(body))).status).toBe(200);
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes.map((write) => write.data)).toEqual([
-        withNewline(first),
-        withNewline(second),
+      expect(fixed.stores.automation.jobs).toEqual([
+        expect.objectContaining({ resultId, action: "drive", status: "pending" }),
       ]);
-      expect(FakeLog.texts(fixed.log)).toEqual([
-        "linear webhook recorded",
-        "linear webhook recorded",
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "info",
+          text: "linear webhook queued drive; Automation Needed",
+          sessionId: undefined,
+          agentId: "OLI-1063",
+          skipSentry: false,
+          cause: undefined,
+        },
       ]);
     }),
   );
 
-  it.effect(
-    "appends a UTF-8 BOM body as the exact bytes Linear signed, plus a trailing newline",
-    () =>
-      Effect.gen(function* () {
-        const bom = new Uint8Array([
-          0xef,
-          0xbb,
-          0xbf,
-          ...new TextEncoder().encode('{"action":"update"}'),
-        ]);
-        const fixed = fixture();
-        yield* Effect.gen(function* () {
-          const http = yield* HttpClient.HttpClient;
-          const response = yield* webhook(http, bom, sign(bom));
-          expect(response.status).toBe(200);
-        }).pipe(Effect.provide(serve(fixed)));
-        expect(fixed.file.writes).toEqual([{ path: RECORD, data: withNewline(bom), flag: "a" }]);
-      }),
+  it.effect("queues diagnose when Needs Review arrives for a known ticket", () =>
+    Effect.gen(function* () {
+      const body = issueBody("Needs Review");
+      const fixed = fixture();
+      const resultId = seedResult(fixed, "OLI-1063");
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        expect((yield* webhook(http, body, sign(body))).status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.stores.automation.jobs).toEqual([
+        expect.objectContaining({ resultId, action: "diagnose", status: "pending" }),
+      ]);
+      expect(FakeLog.texts(fixed.log)).toEqual(["linear webhook queued diagnose; Needs Review"]);
+    }),
+  );
+
+  it.effect("ignores a queueable state when no result has that Linear id (unhappy)", () =>
+    Effect.gen(function* () {
+      const body = issueBody("Automation Needed");
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        expect((yield* webhook(http, body, sign(body))).status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.stores.automation.jobs).toEqual([]);
+      expect(FakeLog.texts(fixed.log)).toEqual([
+        "linear webhook ignored; no result for Automation Needed",
+      ]);
+      expect(fixed.log.lines[0]?.agentId).toBe("OLI-1063");
+    }),
+  );
+
+  it.effect("ignores a second drive for the same result (unhappy duplicate)", () =>
+    Effect.gen(function* () {
+      const body = issueBody("Automation Needed");
+      const fixed = fixture();
+      seedResult(fixed, "OLI-1063");
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        expect((yield* webhook(http, body, sign(body))).status).toBe(200);
+        expect((yield* webhook(http, body, sign(body))).status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.stores.automation.jobs).toHaveLength(1);
+      expect(FakeLog.texts(fixed.log)).toEqual([
+        "linear webhook queued drive; Automation Needed",
+        "linear webhook ignored; drive already queued",
+      ]);
+    }),
+  );
+
+  it.effect("records In Progress without enqueueing", () =>
+    Effect.gen(function* () {
+      const body = issueBody("In Progress");
+      const fixed = fixture();
+      seedResult(fixed, "OLI-1063");
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        expect((yield* webhook(http, body, sign(body))).status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.stores.automation.jobs).toEqual([]);
+      expect(FakeLog.texts(fixed.log)).toEqual(["linear webhook recorded; In Progress"]);
+    }),
   );
 });
 
@@ -158,7 +206,7 @@ describe("POST /linear refusals", () => {
   const payload = '{"action":"update"}';
 
   it.effect(
-    "a missing or wrong signature is 401 unauthorized, records nothing and logs one line each",
+    "a missing or wrong signature is 401 unauthorized, queues nothing and logs one line each",
     () =>
       Effect.gen(function* () {
         const fixed = fixture();
@@ -171,7 +219,7 @@ describe("POST /linear refusals", () => {
           expect(wrong.status).toBe(401);
           expect(yield* wrong.json).toEqual({ error: "unauthorized" });
         }).pipe(Effect.provide(serve(fixed)));
-        expect(fixed.file.writes).toEqual([]);
+        expect(fixed.stores.automation.jobs).toEqual([]);
         expect(fixed.log.lines).toEqual([
           {
             level: "error",
@@ -194,7 +242,7 @@ describe("POST /linear refusals", () => {
       }),
   );
 
-  it.effect("a valid signature of a different body is 401 and records nothing", () =>
+  it.effect("a valid signature of a different body is 401 and queues nothing", () =>
     Effect.gen(function* () {
       const fixed = fixture();
       yield* Effect.gen(function* () {
@@ -203,33 +251,8 @@ describe("POST /linear refusals", () => {
         expect(response.status).toBe(401);
         expect(yield* response.json).toEqual({ error: "unauthorized" });
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.file.writes).toEqual([]);
+      expect(fixed.stores.automation.jobs).toEqual([]);
     }),
-  );
-
-  it.effect(
-    "a record file that cannot be written is 500 internal error, logged with Node's reason",
-    () =>
-      Effect.gen(function* () {
-        const fixed = fixture(recordFile(true));
-        yield* Effect.gen(function* () {
-          const http = yield* HttpClient.HttpClient;
-          const raw = yield* webhook(http, payload, sign(payload));
-          expect(raw.status).toBe(500);
-          expect(yield* raw.json).toEqual({ error: "internal error" });
-        }).pipe(Effect.provide(serve(fixed)));
-        expect(fixed.file.writes).toEqual([]);
-        expect(fixed.log.lines).toHaveLength(1);
-        expect(fixed.log.lines[0]).toMatchObject({
-          level: "error",
-          text: `POST /linear failed: EACCES: permission denied, open '${RECORD}'`,
-          sessionId: undefined,
-          agentId: undefined,
-          skipSentry: false,
-        });
-        expect(fixed.log.lines[0]?.cause).toMatchObject({ _tag: "PlatformError" });
-        expect(fixed.reporter.reported).toEqual([]);
-      }),
   );
 
   it.effect(
@@ -254,7 +277,7 @@ describe("POST /linear refusals", () => {
           });
           expect(start.status).toBe(404);
         }).pipe(Effect.provide(serve(fixed)));
-        expect(fixed.file.writes).toEqual([]);
+        expect(fixed.stores.automation.jobs).toEqual([]);
         expect(fixed.log.lines).toEqual([]);
       }),
   );

--- a/test/automation/webhook.unit.test.ts
+++ b/test/automation/webhook.unit.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { Option } from "effect";
+import * as Webhook from "../../src/automation/webhook.ts";
+
+const bytes = (json: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(json));
+
+const issue = {
+  action: "update",
+  type: "Issue",
+  data: {
+    identifier: "OLI-1063",
+    title: "drive the guest",
+    state: {
+      id: "a9fe2d89-3cb3-47dd-8645-5d224f997134",
+      color: "#bec2c8",
+      name: "Automation Needed",
+      type: "unstarted",
+    },
+  },
+  updatedFrom: { title: "old title" },
+} as const;
+
+describe("Webhook.issue", () => {
+  it("reads the ticket and the state Linear put on an Issue", () => {
+    const parsed = Webhook.issue(bytes(issue));
+    expect(Option.isSome(parsed)).toBe(true);
+    if (Option.isNone(parsed)) {
+      return;
+    }
+    expect(Webhook.work(parsed.value)).toEqual({
+      ticket: "OLI-1063",
+      state: "Automation Needed",
+      stateId: "a9fe2d89-3cb3-47dd-8645-5d224f997134",
+      stateType: "unstarted",
+      action: "update",
+      stateChanged: false,
+    });
+  });
+
+  it("marks a create, or an update whose updatedFrom names state, as a state change", () => {
+    const created = Webhook.issue(bytes({ ...issue, action: "create", updatedFrom: undefined }));
+    expect(Option.isSome(created)).toBe(true);
+    if (Option.isSome(created)) {
+      expect(Webhook.work(created.value).stateChanged).toBe(true);
+    }
+    const moved = Webhook.issue(
+      bytes({
+        ...issue,
+        updatedFrom: { state: { id: "old", name: "Todo", type: "unstarted" } },
+      }),
+    );
+    expect(Option.isSome(moved)).toBe(true);
+    if (Option.isSome(moved)) {
+      expect(Webhook.work(moved.value).stateChanged).toBe(true);
+    }
+  });
+
+  it("returns none for invalid JSON, a Comment, a missing ticket or state, or a remove without those fields", () => {
+    expect(Webhook.issue(new TextEncoder().encode("{bad"))).toEqual(Option.none());
+    expect(Webhook.issue(bytes({ action: "update", type: "Comment", data: {} }))).toEqual(
+      Option.none(),
+    );
+    expect(
+      Webhook.issue(bytes({ action: "update", type: "Issue", data: { identifier: "OLI-1" } })),
+    ).toEqual(Option.none());
+    expect(
+      Webhook.issue(
+        bytes({
+          action: "update",
+          type: "Issue",
+          data: { state: { id: "x", name: "Todo", type: "unstarted" } },
+        }),
+      ),
+    ).toEqual(Option.none());
+  });
+});
+
+describe("Webhook.queuedAction", () => {
+  const base = {
+    ticket: "OLI-1063",
+    stateId: "a9fe2d89-3cb3-47dd-8645-5d224f997134",
+    stateType: "unstarted",
+    action: "update" as const,
+    stateChanged: true,
+  };
+
+  it("queues drive when the state moves to Automation Needed", () => {
+    expect(Webhook.queuedAction({ ...base, state: "Automation Needed" })).toEqual(
+      Option.some("drive"),
+    );
+  });
+
+  it("queues diagnose when the state moves to Needs Review", () => {
+    expect(
+      Webhook.queuedAction({
+        ...base,
+        state: "Needs Review",
+        stateType: "started",
+      }),
+    ).toEqual(Option.some("diagnose"));
+  });
+
+  it("queues nothing when the state did not change, or is not a queue trigger (unhappy)", () => {
+    expect(
+      Webhook.queuedAction({ ...base, state: "Automation Needed", stateChanged: false }),
+    ).toEqual(Option.none());
+    expect(Webhook.queuedAction({ ...base, state: "In Progress", stateType: "started" })).toEqual(
+      Option.none(),
+    );
+    expect(Webhook.queuedAction({ ...base, state: "Done", stateType: "completed" })).toEqual(
+      Option.none(),
+    );
+  });
+});

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -1,24 +1,31 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { createHmac } from "node:crypto";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createHmac, randomUUID } from "node:crypto";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect } from "vitest";
+import { describe, expect, inject } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect } from "effect";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import * as DbSchema from "../../src/db/schema.ts";
+import * as Postgres from "../support/postgres.ts";
 
 const AUTOMATION = fileURLToPath(new URL("../../automation", import.meta.url));
 const WEBHOOK_SECRET = "whsec_test";
+const UNREACHABLE = "postgres://user:sentinel-pw@127.0.0.1:1/oligarchy";
 const EXIT_WITHIN_MS = 60_000;
+
+const dbUrl = inject("dbUrl");
 
 const sign = (payload: string): string =>
   createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
 
 type Process = {
   readonly child: ChildProcess;
-  // Distinct from cwd: a write to $HOME/automation-logs must not satisfy the record-file checks.
   readonly home: string;
   readonly cwd: string;
   readonly stdout: () => string;
@@ -28,14 +35,13 @@ type Process = {
 };
 
 // Sentry is initialised by the wrapper's --import; a proxy nobody listens on keeps the test
-// run's fatal lines out of the real project without touching the code under test. The service
-// has no database, so a DATABASE_URL in the developer's environment is removed: it must not be
-// what makes these pass.
+// run's fatal lines out of the real project without touching the code under test.
 const environment = (home: string, overrides: Record<string, string>): NodeJS.ProcessEnv => {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     HOME: home,
     LINEAR_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    DATABASE_URL: dbUrl === "" ? UNREACHABLE : dbUrl,
     NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --disable-warning=ExperimentalWarning`.trim(),
     https_proxy: "http://127.0.0.1:1",
     http_proxy: "http://127.0.0.1:1",
@@ -43,13 +49,12 @@ const environment = (home: string, overrides: Record<string, string>): NodeJS.Pr
     ...overrides,
   };
   delete env.FORCE_COLOR;
-  delete env.DATABASE_URL;
   delete env.OLIGARCHY_TOKEN;
   return env;
 };
 
-// Each process gets an empty cwd (no `.env`) and a different empty HOME, so a write under
-// $HOME cannot pass as ./automation-logs. Both directories are removed once it has exited.
+// Each process gets an empty cwd (no `.env`) and a different empty HOME. Both directories are
+// removed once it has exited.
 const spawnAutomation = (
   args: ReadonlyArray<string>,
   overrides: Record<string, string> = {},
@@ -152,6 +157,51 @@ const request = (
     body === undefined ? { method, headers } : { method, headers, body },
   );
 
+const seedResult = async (linearId: string): Promise<string> => {
+  const client = new Client({ connectionString: Postgres.getDbUrl() });
+  await client.connect();
+  try {
+    const db = drizzle({ client, schema: DbSchema });
+    const [definition] = await db.select().from(DbSchema.testDefinitions).limit(1);
+    if (definition === undefined) {
+      throw new Error("no seeded test definition");
+    }
+    const runId = randomUUID();
+    const resultId = randomUUID();
+    await db.insert(DbSchema.testRuns).values({
+      id: runId,
+      name: `automation-${linearId}`,
+      iso: "https://example.com/omarchy.iso",
+      serverUrl: "http://127.0.0.1:42069",
+      status: "pending",
+    });
+    await db.insert(DbSchema.testResults).values({
+      id: resultId,
+      runId,
+      definitionId: definition.id,
+      linearId,
+      status: "pending",
+    });
+    return resultId;
+  } finally {
+    await client.end();
+  }
+};
+
+const jobsFor = async (resultId: string) => {
+  const client = new Client({ connectionString: Postgres.getDbUrl() });
+  await client.connect();
+  try {
+    const db = drizzle({ client, schema: DbSchema });
+    return await db
+      .select()
+      .from(DbSchema.automationJobs)
+      .where(eq(DbSchema.automationJobs.resultId, resultId));
+  } finally {
+    await client.end();
+  }
+};
+
 describe("automation startup refusals", () => {
   it.live("--help exits 0 and lists --port alone", () =>
     Effect.promise(async () => {
@@ -184,6 +234,34 @@ describe("automation startup refusals", () => {
     }),
   );
 
+  it.live("a missing DATABASE_URL exits 1 with DATABASE_URL is not set", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomation([], { DATABASE_URL: "" });
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("DATABASE_URL is not set");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live("an unreachable database exits 1 and never listens", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomation([], { DATABASE_URL: UNREACHABLE });
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      const fatal = lines(process.stdout()).find((line) =>
+        line.startsWith("[global] fatal: automation: "),
+      );
+      expect(fatal, process.stdout()).toBeDefined();
+      expect(fatal).toContain("database unreachable");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+});
+
+const describeWithDatabase = dbUrl === "" ? describe.skip : describe;
+
+describeWithDatabase("automation startup refusals with a database", () => {
   it.live("an occupied port exits 1 with EADDRINUSE", () =>
     Effect.promise(async () => {
       const { port, release } = await occupy();
@@ -205,19 +283,19 @@ describe("automation startup refusals", () => {
   );
 });
 
-describe("automation serving", () => {
+const describeServing = dbUrl === "" ? describe.skip : describe;
+
+describeServing("automation serving", () => {
   const served = async (signal: "SIGINT" | "SIGTERM") => {
     const port = await freePort();
     const process = spawnAutomation(["--port", String(port)]);
     const record = join(process.cwd, "automation-logs");
-    const homeRecord = join(process.home, "automation-logs");
     try {
       await process.waitFor(/oligarchy automation listening/);
       expect(lines(process.stdout())).toContain(
-        `[global] oligarchy automation listening on 127.0.0.1:${String(port)}; recording to ./automation-logs`,
+        `[global] oligarchy automation listening on 127.0.0.1:${String(port)}`,
       );
       expect(existsSync(record)).toBe(false);
-      expect(existsSync(homeRecord)).toBe(false);
 
       const automate = await request(
         port,
@@ -228,7 +306,6 @@ describe("automation serving", () => {
       );
       expect(automate.status).toBe(404);
       expect(await automate.json()).toEqual({ error: "not found" });
-      expect(existsSync(record)).toBe(false);
 
       const webhookBody = '{"action":"update","type":"Issue","data":{"identifier":"OLI-9"}}';
       const unsigned = await request(
@@ -252,8 +329,60 @@ describe("automation serving", () => {
       expect(signed.status).toBe(200);
       expect(signed.headers.get("content-type")).toContain("application/json");
       expect(await signed.json()).toEqual({ ok: "true" });
-      expect(readFileSync(record, "utf8")).toBe(`${webhookBody}\n`);
-      expect(existsSync(homeRecord)).toBe(false);
+      expect(existsSync(record)).toBe(false);
+
+      const linearId = `OLI-${randomUUID().slice(0, 8)}`;
+      const resultId = await seedResult(linearId);
+      const driveBody = JSON.stringify({
+        action: "update",
+        type: "Issue",
+        data: {
+          identifier: linearId,
+          state: {
+            id: "a9fe2d89-3cb3-47dd-8645-5d224f997134",
+            name: "Automation Needed",
+            type: "unstarted",
+          },
+        },
+        updatedFrom: { state: { name: "Backlog" } },
+      });
+      const drive = await request(
+        port,
+        "POST",
+        "/linear",
+        { "content-type": "application/json", "linear-signature": sign(driveBody) },
+        driveBody,
+      );
+      expect(drive.status).toBe(200);
+      expect(await drive.json()).toEqual({ ok: "true" });
+      expect(await jobsFor(resultId)).toEqual([
+        expect.objectContaining({ resultId, action: "drive", status: "pending" }),
+      ]);
+
+      const diagnoseBody = JSON.stringify({
+        action: "update",
+        type: "Issue",
+        data: {
+          identifier: linearId,
+          state: {
+            id: "cdf3eb61-bc4b-4b61-8e47-cc2c145a6b6a",
+            name: "Needs Review",
+            type: "started",
+          },
+        },
+        updatedFrom: { state: { name: "In Progress" } },
+      });
+      const diagnose = await request(
+        port,
+        "POST",
+        "/linear",
+        { "content-type": "application/json", "linear-signature": sign(diagnoseBody) },
+        diagnoseBody,
+      );
+      expect(diagnose.status).toBe(200);
+      const jobs = await jobsFor(resultId);
+      expect(jobs).toHaveLength(2);
+      expect(jobs.map((job) => job.action).sort()).toEqual(["diagnose", "drive"]);
 
       const start = await request(
         port,
@@ -277,6 +406,8 @@ describe("automation serving", () => {
     const output = lines(process.stdout());
     expect(output).toContain("[global] error: POST /linear failed: unauthorized");
     expect(output).toContain("[global] linear webhook recorded");
+    expect(output).toContain("[global] linear webhook queued drive; Automation Needed");
+    expect(output).toContain("[global] linear webhook queued diagnose; Needs Review");
     expect(output.some((line) => line.includes("/automate"))).toBe(false);
     expect(output.some((line) => line.includes("/start"))).toBe(false);
     expect(process.stderr()).toBe("");
@@ -285,7 +416,7 @@ describe("automation serving", () => {
   };
 
   it.live(
-    "listens without a database, records a signed /linear, answers 401 and 404, and exits 0 on SIGINT",
+    "listens with a database, queues drive and diagnose from signed /linear, answers 401 and 404, and exits 0 on SIGINT",
     () => Effect.promise(() => served("SIGINT")),
     120_000,
   );

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -1,5 +1,6 @@
 import { Effect, Layer, Option } from "effect";
 import * as Actions from "../../src/db/actions.ts";
+import * as Automation from "../../src/db/automation.ts";
 import * as DebugLogs from "../../src/db/debug-logs.ts";
 import * as Diagnosis from "../../src/db/diagnosis.ts";
 import * as Logs from "../../src/db/logs.ts";
@@ -18,6 +19,7 @@ type TestDefinitionRow = typeof DbSchema.testDefinitions.$inferSelect;
 type TestBasePromptRow = typeof DbSchema.testBasePrompts.$inferSelect;
 type TestRunRow = typeof DbSchema.testRuns.$inferSelect;
 type TestResultRow = typeof DbSchema.testResults.$inferSelect;
+type AutomationJobRow = typeof DbSchema.automationJobs.$inferSelect;
 
 const sameId = (left: string, right: string): boolean => left.toLowerCase() === right.toLowerCase();
 
@@ -508,6 +510,49 @@ export const fakeTestStore = (
 };
 
 // ---------------------------------------------------------------------------
+// AutomationStore
+// ---------------------------------------------------------------------------
+
+export type FakeAutomationStore = {
+  readonly jobs: Array<AutomationJobRow>;
+  readonly layer: Layer.Layer<Automation.AutomationStore>;
+};
+
+// One pending job per (result, action), as the unique index: a second insert is DatabaseError.
+export const fakeAutomationStore = (
+  overrides: Partial<typeof Automation.AutomationStore.Service> = {},
+): FakeAutomationStore => {
+  const jobs: Array<AutomationJobRow> = [];
+  let nextId = 1;
+  const service = Automation.AutomationStore.of({
+    enqueue: (input) =>
+      Effect.gen(function* () {
+        if (
+          jobs.some((job) => sameId(job.resultId, input.resultId) && job.action === input.action)
+        ) {
+          return yield* Effect.fail(
+            conflict("enqueueAutomationJob", 'insert into "automation_jobs"'),
+          );
+        }
+        const row: AutomationJobRow = {
+          id: `00000000-0000-4000-8000-${String(nextId++).padStart(12, "0")}`,
+          resultId: input.resultId,
+          action: input.action,
+          status: "pending",
+          reason: null,
+          createdAt: new Date(),
+          startedAt: null,
+          finishedAt: null,
+        };
+        jobs.push(row);
+        return row;
+      }),
+    ...overrides,
+  });
+  return { jobs, layer: Layer.succeed(Automation.AutomationStore)(service) };
+};
+
+// ---------------------------------------------------------------------------
 // ServerStore
 // ---------------------------------------------------------------------------
 
@@ -575,6 +620,7 @@ export const fakeStores = () => {
   const actions = fakeActionStore();
   const logs = fakeLogStore();
   const tests = fakeTestStore();
+  const automation = fakeAutomationStore();
   const debugLogs = fakeDebugLogStore();
   const diagnosis = fakeDiagnosisStore();
   return {
@@ -582,6 +628,7 @@ export const fakeStores = () => {
     actions,
     logs,
     tests,
+    automation,
     debugLogs,
     diagnosis,
     layer: Layer.mergeAll(
@@ -589,6 +636,7 @@ export const fakeStores = () => {
       actions.layer,
       logs.layer,
       tests.layer,
+      automation.layer,
       debugLogs.layer,
       diagnosis.layer,
     ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Signed `POST /linear` webhooks now enqueue automation jobs from Oligarchy status changes:

- **Automation Needed** → pending `drive` job
- **Needs Review** → pending `diagnose` job

Lookup is by `test_results.linear_id`. Unknown tickets, non-trigger states, and duplicate `(result_id, action)` rows are ignored with a log line (still HTTP 200). Other DB failures become 500.

Also:
- Stopped appending `./automation-logs`; durable record is `automation_jobs` (+ stdout/Sentry)
- `./automation` requires `DATABASE_URL` and pings Postgres before listen
- Parses Issue identifier + state (same shape as the open parse-only PR)

## Tests

- Unit: webhook parse + `queuedAction` mapping; HTTP enqueue happy/unhappy paths; command DB ping refusal
- Integration: missing `DATABASE_URL` / unreachable DB; serving + enqueue when Docker is available
- `npm run check:fast` green (862 unit tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0887e-8dee-7c6d-9179-c4e15ff5433c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0887e-8dee-7c6d-9179-c4e15ff5433c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

