### PR TITLE
servers: add a type column; the reverse proxy fronts qemu servers alone

### DIFF
--- a/SERVER_VS_REVERSE_PROXY.md
+++ b/SERVER_VS_REVERSE_PROXY.md
@@ -39,10 +39,10 @@ running here". A client may still talk to a server directly; nothing in this cha
 reverse proxy.
 
 Started with `--url <url>`, the server also announces itself: once its listener is up and every
-thirty seconds after, it rewrites its own row in `servers` (keyed by that url) with what `/stats`
-would answer, cut to what the fleet page shows — its qemu count, memory in use and the cpu's one,
-two and three minute means — stamps `heartbeat_at` with the database's clock and counts
-`generation` up by one. A shutdown deletes that row, so a process that left is gone from the
+thirty seconds after, it rewrites its own row in `servers` (keyed by that url) as a `qemu` server
+with what `/stats` would answer, cut to what the fleet page shows — its qemu count, memory in use
+and the cpu's one, two and three minute means — stamps `heartbeat_at` with the database's clock
+and counts `generation` up by one. A shutdown deletes that row, so a process that left is gone from the
 fleet and from placement. Every write is a ping: a generation that stops moving is a server that
 stopped without deleting — killed, or it cannot reach the database (its own log then has the
 `heartbeat failed` lines, and a delete that fails is `unannounce failed: <reason>`) — and the
@@ -92,13 +92,15 @@ The reverse proxy holds no session state. It knows three things, all of them row
 
 - Which servers exist, because a server announced itself (`./server --url`) or an operator
   registered it — on the dashboard, or over `POST /servers { url }`, where the reverse proxy
-  checks the server answers `GET /stats` before remembering it. Registering the same url twice is
-  two probes and one row; `DELETE /servers` forgets a server without touching the sessions still
-  running on it; `GET /servers` probes every server at once and reports each one's stats, or
-  `null` for one that did not answer.
-- Where to put a new session: `POST /start` probes every registered server at once, skips the ones
-  that fail (a `server skipped; …` warning each), and places the start on the one with the fewest
-  `qemus`, ties to the earliest registered. With no server registered the answer is 503
+  checks the server answers `GET /stats` before remembering it as a `qemu` server. Every row has
+  a `type`, and this reverse proxy fronts the `qemu` ones: it registers a server as one, and
+  lists and places on those alone. Registering the same url twice is two probes and one row;
+  `DELETE /servers` forgets a server without touching the sessions still running on it;
+  `GET /servers` probes every `qemu` server at once and reports each one's stats, or `null` for
+  one that did not answer.
+- Where to put a new session: `POST /start` probes every registered `qemu` server at once, skips
+  the ones that fail (a `server skipped; …` warning each), and places the start on the one with
+  the fewest `qemus`, ties to the earliest registered. With no server registered the answer is 503
   `no server registered`; with every probe failing it is 503 `no server available`.
 - Which server started each session: the server's 200 to `/start` carries the id it minted, and the
   reverse proxy writes `session_servers (session_id, server_url)` before answering the client. Every
@@ -156,8 +158,8 @@ session and the agent.
 `./client start --server-url http://reverse:42070 --agent-id OLI-7 --iso …`
 
 1. The reverse proxy checks the bearer and decodes `StartBody` (it needs `agent` for its log
-   lines). It reads `servers`, probes each `GET /stats`, picks the fewest `qemus`, and POSTs the
-   client's body text to that server's `/start`.
+   lines). It reads the `qemu` rows of `servers`, probes each `GET /stats`, picks the fewest
+   `qemus`, and POSTs the client's body text to that server's `/start`.
 2. The server does everything it always did: inserts the `sessions` row, fetches the ISO,
    prepares the directory, registers the agent, boots QEMU, and answers `{"id":"<uuid>"}`.
 3. The reverse proxy decodes the id, inserts `session_servers (id, url)`, logs
@@ -244,14 +246,19 @@ errors; the switch ends in `satisfies never`, so a tag without an arm does not c
 
 ### `src/db/schema.ts`, `drizzle/0004_reverse_proxy.sql`, `src/db/servers.ts`
 
-- `servers (url text primary key, stats jsonb, generation bigint not null default 0,
-  heartbeat_at timestamptz, created_at)`: the fleet. The primary key makes registration
-  idempotent (`insert … on conflict do nothing`) and gives the heartbeat its upsert. The three
-  columns after the key came with the heartbeat (`drizzle/0006_server_heartbeat.sql`): `stats` is
-  what the server last said of itself (`ServerStats` in `schema.ts`: qemus, memory total and
-  used, the cpu's three means), `generation` counts its heartbeats, `heartbeat_at` is the
-  database's clock at the last one. `stats` and `heartbeat_at` are null together, for a row an
-  operator added that no server has claimed — the one absence the page must show as such.
+- `servers (url text primary key, type server_type not null default 'qemu', stats jsonb,
+  generation bigint not null default 0, heartbeat_at timestamptz, created_at)`: the fleet. The
+  primary key makes registration idempotent (`insert … on conflict do nothing`) and gives the
+  heartbeat its upsert. `type` (`drizzle/0008_server_type.sql`) says what kind of server the row
+  is, an enum with one value so far, `qemu`, so a reverse proxy can list its own kind and leave
+  the rest; every writer names it — the reverse proxy's `POST /servers`, the dashboard's add box
+  and the server's heartbeat all say `qemu` — and the default is what the migration filled the
+  rows that predate the column with. The three columns after it came with the heartbeat
+  (`drizzle/0006_server_heartbeat.sql`): `stats` is what the server last said of itself
+  (`ServerStats` in `schema.ts`: qemus, memory total and used, the cpu's three means),
+  `generation` counts its heartbeats, `heartbeat_at` is the database's clock at the last one.
+  `stats` and `heartbeat_at` are null together, for a row an operator added that no server has
+  claimed — the one absence the page must show as such.
 - `session_servers (session_id uuid primary key references sessions.id, server_url text not
   null, created_at)`: which server started a session. The primary key gives a session one route;
   the foreign key guarantees a route names a real session (the server has inserted the row by
@@ -270,17 +277,24 @@ errors; the switch ends in `satisfies never`, so a tag without an arm does not c
 - The migration was generated by `drizzle-kit generate --name reverse_proxy`; existing
   migrations are untouched and `drizzle-kit check` is clean.
 - `ServerStore` follows the repository pattern: a `Context.Service` whose methods are
-  `Effect.fn("db.<name>")` over `Database.run` — `addServer`, `heartbeat` (one upsert: the row
-  comes into being at generation 1 or is rewritten at `generation + 1`, `heartbeat_at = now()`
-  either way), `removeServer` (answers whether a row went, which `DELETE /servers` turns into its
-  404), `listServers` (registration order), `routeSession`, `serverForSession` (an `Option`).
-  The server's `main.ts` provides the store to its graph for the heartbeat alone.
+  `Effect.fn("db.<name>")` over `Database.run` — `addServer` (a url and its type), `heartbeat`
+  (a url, its type and its stats in one upsert: the row comes into being at generation 1 or is
+  rewritten at `generation + 1`, its type the server's word, `heartbeat_at = now()` either way),
+  `removeServer` (answers whether a row went, which `DELETE /servers` turns into its 404),
+  `listServers` (the servers of one type, registration order), `routeSession`,
+  `serverForSession` (an `Option`). The server's `main.ts` provides the store to its graph for
+  the heartbeat alone.
 
 ### `src/reverse-proxy/router.ts`: the one service
 
 `Router` is a `Context.Service` over `ServerStore`, `Log`, `HttpClient` and `ProxyConfig`, with
 `register`, `unregister`, `servers`, `start` and `forward`. Decisions inside it:
 
+- It fronts one kind of server, `qemu`: the probe is that server's `/stats` and the placement
+  its `qemus`. `register` stores a url as a `qemu` server, and `servers` and `start` read the
+  `qemu` rows alone, so a row of another kind is neither reported nor placed on. The kind is one
+  constant in `router.ts`, so a second reverse proxy for a second kind is that constant and its
+  own probe.
 - Urls are stored exactly as given, like `--server-url`, and joined to paths with
   `HttpClientRequest.prependUrl`, which inserts or trims one slash, as the generated client's
   `baseUrl` does. `https://host/` and `https://host` both reach `/stats`; they are two rows if
@@ -394,7 +408,9 @@ Every surface has a happy and an unhappy test:
 - `test/integration/db.integration.test.ts`: `ServerStore` against the migrated database,
   including the primary key and foreign key refusals, and the heartbeat: a first write at
   generation 1 with its stats and stamp, a second counting up and rewriting, and one filling the
-  row an operator added, still one row.
+  row an operator added, still one row. The `type` column: every write lands as `qemu` and is
+  listed as such, a row written without a type is a `qemu` server (the migration's default), and
+  a value outside the enum is the database's refusal.
 - `test/integration/reverse-proxy.integration.test.ts`: the black-box process — `--help`, a
   bad `--port`, a missing token, an unreachable database (this one needs neither QEMU nor Docker,
   so it always runs), an occupied port, and serving (`GET /servers` empty, a dead server refused

--- a/drizzle/0008_server_type.sql
+++ b/drizzle/0008_server_type.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."server_type" AS ENUM('qemu');--> statement-breakpoint
+ALTER TABLE "servers" ADD COLUMN "type" "server_type" DEFAULT 'qemu' NOT NULL;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1262 @@
+{
+  "id": "d6a89b8c-47d8-447b-b8df-0e26be85a450",
+  "prevId": "05385a35-ebbd-4f78-a8ae-e18d21642f34",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "actions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "action_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "actions_session_id_idx": {
+          "name": "actions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_session_id_sessions_id_fk": {
+          "name": "actions_session_id_sessions_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actions_agent_id_agent_runs_agent_id_fk": {
+          "name": "actions_agent_id_agent_runs_agent_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_runs_session_id_idx": {
+          "name": "agent_runs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_session_id_sessions_id_fk": {
+          "name": "agent_runs_session_id_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_jobs": {
+      "name": "automation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "automation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_jobs_result_action_idx": {
+          "name": "automation_jobs_result_action_idx",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_jobs_status_created_at_idx": {
+          "name": "automation_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_jobs_result_id_test_results_result_id_fk": {
+          "name": "automation_jobs_result_id_test_results_result_id_fk",
+          "tableFrom": "automation_jobs",
+          "tableTo": "test_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debug_logs_session_id_sessions_id_fk": {
+          "name": "debug_logs_session_id_sessions_id_fk",
+          "tableFrom": "debug_logs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "images_id_idx": {
+          "name": "images_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_action_id_actions_id_fk": {
+          "name": "images_action_id_actions_id_fk",
+          "tableFrom": "images",
+          "tableTo": "actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_session_id_idx": {
+          "name": "logs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_run_diagnosis": {
+      "name": "post_run_diagnosis",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "diagnosis_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_run_diagnosis_error_type_idx": {
+          "name": "post_run_diagnosis_error_type_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_run_diagnosis_session_id_sessions_id_fk": {
+          "name": "post_run_diagnosis_session_id_sessions_id_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_run_diagnosis_error_type_post_run_error_types_key_fk": {
+          "name": "post_run_diagnosis_error_type_post_run_error_types_key_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "post_run_error_types",
+          "columnsFrom": [
+            "error_type"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_run_diagnosis_verdict_error_type_check": {
+          "name": "post_run_diagnosis_verdict_error_type_check",
+          "value": "(\"post_run_diagnosis\".\"verdict\" = 'passed') = (\"post_run_diagnosis\".\"error_type\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_run_error_types": {
+      "name": "post_run_error_types",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servers": {
+      "name": "servers",
+      "schema": "",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "server_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'qemu'"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_servers": {
+      "name": "session_servers",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_servers_session_id_sessions_id_fk": {
+          "name": "session_servers_session_id_sessions_id_fk",
+          "tableFrom": "session_servers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_base_prompts": {
+      "name": "test_base_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_base_prompts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_base_prompts_name_idx": {
+          "name": "test_base_prompts_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_definitions": {
+      "name": "test_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_definitions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_definitions_name_idx": {
+          "name": "test_definitions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_results": {
+      "name": "test_results",
+      "schema": "",
+      "columns": {
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_id": {
+          "name": "linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "test_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_results_run_definition_idx": {
+          "name": "test_results_run_definition_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_session_id_idx": {
+          "name": "test_results_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_linear_id_idx": {
+          "name": "test_results_linear_id_idx",
+          "columns": [
+            {
+              "expression": "linear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_results_run_id_test_runs_id_fk": {
+          "name": "test_results_run_id_test_runs_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_definition_id_test_definitions_id_fk": {
+          "name": "test_results_definition_id_test_definitions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_session_id_sessions_id_fk": {
+          "name": "test_results_session_id_sessions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso": {
+          "name": "iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "test_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.action_state": {
+      "name": "action_state",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed"
+      ]
+    },
+    "public.automation_action": {
+      "name": "automation_action",
+      "schema": "public",
+      "values": [
+        "drive",
+        "diagnose"
+      ]
+    },
+    "public.automation_job_status": {
+      "name": "automation_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.diagnosis_verdict": {
+      "name": "diagnosis_verdict",
+      "schema": "public",
+      "values": [
+        "passed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.server_type": {
+      "name": "server_type",
+      "schema": "public",
+      "values": [
+        "qemu"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_result_status": {
+      "name": "test_result_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_run_status": {
+      "name": "test_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1788991797438,
       "tag": "0007_woozy_may_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1788999629271,
+      "tag": "0008_server_type",
+      "breakpoints": true
     }
   ]
 }

--- a/src/dashboard/query.ts
+++ b/src/dashboard/query.ts
@@ -351,10 +351,12 @@ export function listServers(connectionString: string): Promise<Server[]> {
   );
 }
 
-// Registering a url twice is one row; the server fills the rest in when it announces itself.
+// Registering a url twice is one row; the server fills the rest in when it announces itself. The
+// add box names a qemu server, the one kind an operator can add; the server's heartbeat is the
+// word on what it is.
 export function addServer(connectionString: string, url: string): Promise<void> {
   return withDatabase(connectionString, async (db) => {
-    await db.insert(servers).values({ url }).onConflictDoNothing();
+    await db.insert(servers).values({ url, type: "qemu" }).onConflictDoNothing();
   });
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -47,6 +47,9 @@ export const actionState = pgEnum("action_state", ["completed", "failed"]);
 // The reviewer's own answer to "did the proof land": the test's vocabulary, not the session's.
 export const diagnosisVerdict = pgEnum("diagnosis_verdict", ["passed", "failed"]);
 
+// What kind of machine a server boots, and so which reverse proxy fronts it. One kind so far.
+export const serverType = pgEnum("server_type", ["qemu"]);
+
 export const automationAction = pgEnum("automation_action", ["drive", "diagnose"]);
 export const automationJobStatus = pgEnum("automation_job_status", [
   "pending",
@@ -197,9 +200,12 @@ export type ServerStats = {
 // and counts generation up, and a shutdown deletes the row. A generation that stops moving is
 // a server that stopped without a chance to leave — killed, or cut off from the database.
 // stats and heartbeat_at are null together, for a row an operator added that no server has
-// claimed.
+// claimed. type says what kind of server the row is, so a reverse proxy lists its own kind;
+// every writer names it, and the default is what the migration filled the rows that predate
+// the column with — qemu servers were the only kind there was.
 export const servers = pgTable("servers", {
   url: text("url").primaryKey(),
+  type: serverType("type").notNull().default("qemu"),
   stats: jsonb("stats").$type<ServerStats>(),
   generation: bigint("generation", { mode: "number" }).notNull().default(0),
   heartbeatAt: timestamp("heartbeat_at", { withTimezone: true }),

--- a/src/db/servers.ts
+++ b/src/db/servers.ts
@@ -3,31 +3,41 @@ import { Array as Arr, Context, Effect, Layer, Option } from "effect";
 import * as Client from "./client.ts";
 import * as DbSchema from "./schema.ts";
 
+type ServerRow = typeof DbSchema.servers.$inferSelect;
+export type ServerType = ServerRow["type"];
+
 export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/ServerStore", {
   make: Effect.gen(function* () {
     const database = yield* Client.Database;
 
     // Registering a url twice is one row: the probe already said the server is there.
-    const addServer = Effect.fn("db.addServer")(function* (url: string) {
+    const addServer = Effect.fn("db.addServer")(function* (url: string, type: ServerType) {
       yield* database.run("addServer", (db) =>
-        db.insert(DbSchema.servers).values({ url }).onConflictDoNothing(),
+        db.insert(DbSchema.servers).values({ url, type }).onConflictDoNothing(),
       );
     });
 
-    // A server's own word on itself: its row comes into being on the first heartbeat or is
-    // rewritten, the generation counting every write, stamped by the database's clock.
+    // A server's own word on itself, its kind included: its row comes into being on the first
+    // heartbeat or is rewritten, the generation counting every write, stamped by the database's
+    // clock.
     const heartbeat = Effect.fn("db.heartbeat")(function* (
       url: string,
+      type: ServerType,
       stats: DbSchema.ServerStats,
     ) {
       const now = sql`now()`;
       yield* database.run("heartbeat", (db) =>
         db
           .insert(DbSchema.servers)
-          .values({ url, stats, generation: 1, heartbeatAt: now })
+          .values({ url, type, stats, generation: 1, heartbeatAt: now })
           .onConflictDoUpdate({
             target: DbSchema.servers.url,
-            set: { stats, generation: sql`${DbSchema.servers.generation} + 1`, heartbeatAt: now },
+            set: {
+              type,
+              stats,
+              generation: sql`${DbSchema.servers.generation} + 1`,
+              heartbeatAt: now,
+            },
           }),
       );
     });
@@ -43,12 +53,14 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       return rows.length > 0;
     });
 
-    // Registration order, so a placement tie goes to the server that was there first.
-    const listServers = Effect.fn("db.listServers")(function* () {
+    // The servers of one kind, in registration order, so a placement tie goes to the server that
+    // was there first.
+    const listServers = Effect.fn("db.listServers")(function* (type: ServerType) {
       const rows = yield* database.run("listServers", (db) =>
         db
           .select({ url: DbSchema.servers.url })
           .from(DbSchema.servers)
+          .where(eq(DbSchema.servers.type, type))
           .orderBy(DbSchema.servers.createdAt, DbSchema.servers.url),
       );
       return rows.map((row) => row.url);

--- a/src/proxy/heartbeat.ts
+++ b/src/proxy/heartbeat.ts
@@ -19,12 +19,12 @@ const detail = (error: unknown): string =>
     : Render.errorDetail(error);
 
 // Announces this server under `url`: its `servers` row is written now and every thirty seconds
-// with what it knows of itself, and the row's generation counts the writes, so a number that
-// stops moving is a server that stopped without a chance to leave. A tick that fails is one
-// error line; the next tick runs. The row is this process's word on itself, so a shutdown
-// deletes it: registered before the loop so the fiber is interrupted first, a write in flight
-// finishes (the write is uninterruptible), then the row goes. A delete that fails is one
-// `unannounce failed` line; the process still exits.
+// with what it knows of itself — a qemu server, this process boots nothing else — and the row's
+// generation counts the writes, so a number that stops moving is a server that stopped without a
+// chance to leave. A tick that fails is one error line; the next tick runs. The row is this
+// process's word on itself, so a shutdown deletes it: registered before the loop so the fiber is
+// interrupted first, a write in flight finishes (the write is uninterruptible), then the row
+// goes. A delete that fails is one `unannounce failed` line; the process still exits.
 export const announce = (
   url: string,
 ): Effect.Effect<void, never, Scope.Scope | Sessions.Sessions | Servers.ServerStore | Log.Log> =>
@@ -35,7 +35,7 @@ export const announce = (
     const tick = sessions.stats.pipe(
       Effect.flatMap((stats) =>
         Effect.uninterruptible(
-          store.heartbeat(url, {
+          store.heartbeat(url, "qemu", {
             qemus: stats.qemus,
             memory: { totalBytes: stats.memory.totalBytes, usedBytes: stats.memory.usedBytes },
             cpu: { mean1m: stats.cpu.mean1m, mean2m: stats.cpu.mean2m, mean3m: stats.cpu.mean3m },

--- a/src/reverse-proxy/router.ts
+++ b/src/reverse-proxy/router.ts
@@ -23,6 +23,11 @@ import * as Errors from "../shared/errors.ts";
 // is null in GET /servers; the request that probed it does not wait longer.
 export const PROBE_TIMEOUT = "10 seconds";
 
+// This reverse proxy fronts the servers that boot QEMU: the probe is their /stats, the placement
+// their qemus. It registers a server as one and reads only those rows, whatever else is in the
+// table.
+const SERVER_TYPE: Servers.ServerType = "qemu";
+
 // What a server's /start answers with a 200: the id it minted, a uuid as servers mint them and
 // as the session_servers column stores them.
 const StartAnswer = Schema.fromJsonString(
@@ -195,7 +200,7 @@ const make = Effect.gen(function* () {
 
   const register = Effect.fn("Router.register")(function* (url: string) {
     yield* probe(url, {});
-    yield* store.addServer(url).pipe(Effect.mapError((cause) => internal(cause)));
+    yield* store.addServer(url, SERVER_TYPE).pipe(Effect.mapError((cause) => internal(cause)));
     yield* log.info(`server registered; ${url}`);
   });
 
@@ -210,7 +215,9 @@ const make = Effect.gen(function* () {
   });
 
   const servers: Effect.Effect<Contract.Servers, Errors.Internal> = Effect.gen(function* () {
-    const urls = yield* store.listServers().pipe(Effect.mapError((cause) => internal(cause)));
+    const urls = yield* store
+      .listServers(SERVER_TYPE)
+      .pipe(Effect.mapError((cause) => internal(cause)));
     const probed = yield* Effect.forEach(
       urls,
       (url) =>
@@ -226,7 +233,7 @@ const make = Effect.gen(function* () {
   const place = (agent: string): Effect.Effect<string, Errors.NoServer | Errors.Internal> =>
     Effect.gen(function* () {
       const urls = yield* store
-        .listServers()
+        .listServers(SERVER_TYPE)
         .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
       if (urls.length === 0) {
         return yield* Errors.NoServer.make({ message: "no server registered", agentId: agent });

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -720,16 +720,20 @@ describe("dashboard/query unhappy path: unreachable database", () => {
   });
 });
 
-const registeredUrls = async (databaseUrl: string): Promise<ReadonlyArray<string>> => {
+const registered = async (
+  databaseUrl: string,
+): Promise<ReadonlyArray<{ readonly url: string; readonly type: string }>> => {
   const client = new Client({ connectionString: databaseUrl });
   await client.connect();
   try {
-    const rows = await drizzle(client).select({ url: servers.url }).from(servers);
-    return rows.map((row) => row.url);
+    return await drizzle(client).select({ url: servers.url, type: servers.type }).from(servers);
   } finally {
     await client.end();
   }
 };
+
+const registeredUrls = async (databaseUrl: string): Promise<ReadonlyArray<string>> =>
+  (await registered(databaseUrl)).map((row) => row.url);
 
 describe.skipIf(dbUrl === "")("dashboard/servers page happy path", () => {
   it("lists the fleet from its rows: one heard from just now, one silent, one never heard from", async () => {
@@ -786,14 +790,16 @@ describe.skipIf(dbUrl === "")("dashboard/servers page happy path", () => {
     expect(html).not.toContain("add a server");
   });
 
-  it("adds a server once, however often it is posted, and sends the browser back to the page", async () => {
+  it("adds a qemu server once, however often it is posted, and sends the browser back to the page", async () => {
     const first = await postForm({ url: "http://10.1.0.9:42069" }, dbUrl, "/servers");
     expect(first.status).toBe(303);
     expect(first.location).toBe("/servers");
     const again = await postForm({ url: "http://10.1.0.9:42069" }, dbUrl, "/servers");
     expect(again.status).toBe(303);
-    const urls = await registeredUrls(dbUrl);
-    expect(urls.filter((url) => url === "http://10.1.0.9:42069")).toHaveLength(1);
+    const rows = await registered(dbUrl);
+    expect(rows.filter((row) => row.url === "http://10.1.0.9:42069")).toEqual([
+      { url: "http://10.1.0.9:42069", type: "qemu" },
+    ]);
     const { html } = await getPage("/servers", dbUrl);
     expect(html).toContain(
       '<tr><td>http://10.1.0.9:42069</td><td colspan="3">never heard from</td><td>0</td><td>never</td>',

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -1078,27 +1078,71 @@ Postgres.describeWithDatabase("database", () => {
         }),
     );
 
-    scoped.effect("ServerStore registers a url once, lists in registration order, forgets it", () =>
+    scoped.effect(
+      "ServerStore registers a url once as a qemu server, lists the qemu servers in registration order, forgets it",
+      () =>
+        Effect.gen(function* () {
+          const store = yield* Servers.ServerStore;
+          const database = yield* Client.Database;
+          const first = `http://10.0.0.5:${uuid().slice(0, 8)}`;
+          const second = `http://10.0.0.6:${uuid().slice(0, 8)}`;
+          yield* store.addServer(first, "qemu");
+          yield* store.addServer(second, "qemu");
+          yield* store.addServer(first, "qemu");
+          const [row] = yield* database.run("select", (db) =>
+            db.select().from(DbSchema.servers).where(eq(DbSchema.servers.url, first)),
+          );
+          expect(row).toMatchObject({ url: first, type: "qemu", stats: null, generation: 0 });
+          const listed = yield* store.listServers("qemu");
+          expect(listed.filter((url) => url === first || url === second)).toEqual([first, second]);
+          expect(yield* store.removeServer(first)).toBe(true);
+          expect(yield* store.removeServer(first)).toBe(false);
+          expect(yield* store.listServers("qemu")).not.toContain(first);
+          expect(yield* store.listServers("qemu")).toContain(second);
+          expect(yield* store.removeServer(second)).toBe(true);
+          expect(yield* store.listServers("qemu")).not.toContain(second);
+        }),
+    );
+
+    // The column's default is what the migration filled the rows that predate it with: a row
+    // written without a type is a qemu server, the only kind there was.
+    scoped.effect("a servers row written without a type is a qemu server", () =>
       Effect.gen(function* () {
         const store = yield* Servers.ServerStore;
-        const first = `http://10.0.0.5:${uuid().slice(0, 8)}`;
-        const second = `http://10.0.0.6:${uuid().slice(0, 8)}`;
-        yield* store.addServer(first);
-        yield* store.addServer(second);
-        yield* store.addServer(first);
-        const listed = yield* store.listServers();
-        expect(listed.filter((url) => url === first || url === second)).toEqual([first, second]);
-        expect(yield* store.removeServer(first)).toBe(true);
-        expect(yield* store.removeServer(first)).toBe(false);
-        expect(yield* store.listServers()).not.toContain(first);
-        expect(yield* store.listServers()).toContain(second);
-        expect(yield* store.removeServer(second)).toBe(true);
-        expect(yield* store.listServers()).not.toContain(second);
+        const database = yield* Client.Database;
+        const url = `http://10.0.0.9:${uuid().slice(0, 8)}`;
+        yield* database.run("insert", (db) => db.insert(DbSchema.servers).values({ url }));
+        const [row] = yield* database.run("select", (db) =>
+          db.select().from(DbSchema.servers).where(eq(DbSchema.servers.url, url)),
+        );
+        expect(row).toMatchObject({ url, type: "qemu" });
+        expect(yield* store.listServers("qemu")).toContain(url);
+        expect(yield* store.removeServer(url)).toBe(true);
+      }),
+    );
+
+    scoped.effect("the table refuses a server type outside the enum (unhappy)", () =>
+      Effect.gen(function* () {
+        const store = yield* Servers.ServerStore;
+        const database = yield* Client.Database;
+        const url = `http://10.0.0.10:${uuid().slice(0, 8)}`;
+        const error = yield* Effect.flip(
+          database.run("insert", (db) =>
+            db.insert(DbSchema.servers).values({ url, type: sql`'docker'` }),
+          ),
+        );
+        expect(error).toMatchObject({
+          _tag: "DatabaseError",
+          operation: "insert",
+          message: expect.stringContaining("Failed query"),
+        });
+        expect(String(error.cause)).toMatch(/invalid input value for enum server_type/);
+        expect(yield* store.listServers("qemu")).not.toContain(url);
       }),
     );
 
     scoped.effect(
-      "ServerStore heartbeat announces a server: generation 1 on the first write, then counting up with the stats rewritten",
+      "ServerStore heartbeat announces a qemu server: generation 1 on the first write, then counting up with the stats rewritten",
       () =>
         Effect.gen(function* () {
           const store = yield* Servers.ServerStore;
@@ -1112,16 +1156,16 @@ Postgres.describeWithDatabase("database", () => {
           const rowOf = database.run("select", (db) =>
             db.select().from(DbSchema.servers).where(eq(DbSchema.servers.url, url)),
           );
-          yield* store.heartbeat(url, first);
-          expect(yield* store.listServers()).toContain(url);
+          yield* store.heartbeat(url, "qemu", first);
+          expect(yield* store.listServers("qemu")).toContain(url);
           const [row] = yield* rowOf;
-          expect(row).toMatchObject({ url, stats: first, generation: 1 });
+          expect(row).toMatchObject({ url, type: "qemu", stats: first, generation: 1 });
           expect(row?.heartbeatAt).toBeInstanceOf(Date);
           const second: DbSchema.ServerStats = { ...first, qemus: 2 };
-          yield* store.heartbeat(url, second);
+          yield* store.heartbeat(url, "qemu", second);
           const rows = yield* rowOf;
           expect(rows).toHaveLength(1);
-          expect(rows[0]).toMatchObject({ url, stats: second, generation: 2 });
+          expect(rows[0]).toMatchObject({ url, type: "qemu", stats: second, generation: 2 });
           expect(rows[0]?.heartbeatAt?.getTime()).toBeGreaterThanOrEqual(
             row?.heartbeatAt?.getTime() ?? Number.POSITIVE_INFINITY,
           );
@@ -1139,18 +1183,24 @@ Postgres.describeWithDatabase("database", () => {
           const rowOf = database.run("select", (db) =>
             db.select().from(DbSchema.servers).where(eq(DbSchema.servers.url, url)),
           );
-          yield* store.addServer(url);
+          yield* store.addServer(url, "qemu");
           const [added] = yield* rowOf;
-          expect(added).toMatchObject({ url, stats: null, generation: 0, heartbeatAt: null });
+          expect(added).toMatchObject({
+            url,
+            type: "qemu",
+            stats: null,
+            generation: 0,
+            heartbeatAt: null,
+          });
           const stats: DbSchema.ServerStats = {
             qemus: 0,
             memory: { totalBytes: 66_900_000_000, usedBytes: 31_500_000_000 },
             cpu: { mean1m: 12.3, mean2m: 11, mean3m: 9.8 },
           };
-          yield* store.heartbeat(url, stats);
+          yield* store.heartbeat(url, "qemu", stats);
           const rows = yield* rowOf;
           expect(rows).toHaveLength(1);
-          expect(rows[0]).toMatchObject({ url, stats, generation: 1 });
+          expect(rows[0]).toMatchObject({ url, type: "qemu", stats, generation: 1 });
           expect(rows[0]?.heartbeatAt).toBeInstanceOf(Date);
           expect(yield* store.removeServer(url)).toBe(true);
         }),

--- a/test/integration/proxy.integration.test.ts
+++ b/test/integration/proxy.integration.test.ts
@@ -476,7 +476,7 @@ describe("proxy serving", () => {
             }),
           ),
         );
-        expect(row).toMatchObject({ url, generation: 1, stats: { qemus: 0 } });
+        expect(row).toMatchObject({ url, type: "qemu", generation: 1, stats: { qemus: 0 } });
         expect(row?.heartbeatAt).toBeInstanceOf(Date);
         const { code } = yield* Effect.promise(() => proxy.exited);
         expect(code, proxy.stdout()).toBe(0);

--- a/test/proxy/heartbeat.unit.test.ts
+++ b/test/proxy/heartbeat.unit.test.ts
@@ -17,6 +17,10 @@ const ROW_STATS = {
   cpu: { mean1m: 22.3, mean2m: 21.4, mean3m: 20.9 },
 };
 
+// One heartbeat as the store records it: this server announces itself as a qemu server.
+const ANNOUNCED = { url: URL, type: "qemu", stats: ROW_STATS };
+const REGISTERED = { url: URL, type: "qemu" };
+
 const refused = Errors.DatabaseError.make({
   operation: "heartbeat",
   message: "Failed query: insert into servers",
@@ -39,20 +43,25 @@ const start = (
   });
 
 describe("heartbeat happy path", () => {
-  it.effect("writes the row at once and then every thirty seconds with the server's stats", () =>
-    Effect.gen(function* () {
-      const store = Stores.fakeServerStore();
-      const { log } = yield* start(store);
-      expect(store.heartbeats).toEqual([{ url: URL, stats: ROW_STATS }]);
-      yield* TestClock.adjust("29 seconds");
-      expect(store.heartbeats).toHaveLength(1);
-      yield* TestClock.adjust("1 second");
-      expect(store.heartbeats).toHaveLength(2);
-      yield* TestClock.adjust("60 seconds");
-      expect(store.heartbeats).toHaveLength(4);
-      expect(store.heartbeats.every((beat) => beat.url === URL)).toBe(true);
-      expect(log.lines).toEqual([]);
-    }),
+  it.effect(
+    "writes the row at once and then every thirty seconds, a qemu server with the server's stats",
+    () =>
+      Effect.gen(function* () {
+        const store = Stores.fakeServerStore();
+        const { log } = yield* start(store);
+        expect(store.heartbeats).toEqual([ANNOUNCED]);
+        expect(store.servers).toEqual([REGISTERED]);
+        yield* TestClock.adjust("29 seconds");
+        expect(store.heartbeats).toHaveLength(1);
+        yield* TestClock.adjust("1 second");
+        expect(store.heartbeats).toHaveLength(2);
+        yield* TestClock.adjust("60 seconds");
+        expect(store.heartbeats).toHaveLength(4);
+        expect(store.heartbeats.every((beat) => beat.url === URL && beat.type === "qemu")).toBe(
+          true,
+        );
+        expect(log.lines).toEqual([]);
+      }),
   );
 
   it.effect("stops when the scope it was started in closes", () =>
@@ -70,10 +79,10 @@ describe("heartbeat happy path", () => {
   it.effect("deletes its own row when the scope closes, and leaves every other server", () =>
     Effect.gen(function* () {
       const store = Stores.fakeServerStore();
-      const other = "http://127.0.0.1:1";
+      const other = { url: "http://127.0.0.1:1", type: "qemu" as const };
       store.servers.push(other);
       const { scope, log } = yield* start(store);
-      expect(store.servers).toEqual([other, URL]);
+      expect(store.servers).toEqual([other, REGISTERED]);
       yield* Scope.close(scope, Exit.void);
       expect(store.servers).toEqual([other]);
       expect(log.lines).toEqual([]);
@@ -117,15 +126,15 @@ describe("heartbeat unhappy path", () => {
     () =>
       Effect.gen(function* () {
         let attempts = 0;
-        const written: Array<{ readonly url: string; readonly stats: typeof ROW_STATS }> = [];
+        const written: Array<typeof ANNOUNCED> = [];
         const store = Stores.fakeServerStore({
-          heartbeat: (url, stats) =>
+          heartbeat: (url, type, stats) =>
             Effect.suspend(() => {
               attempts += 1;
               if (attempts === 1) {
                 return Effect.fail(refused);
               }
-              written.push({ url, stats });
+              written.push({ url, type, stats });
               return Effect.void;
             }),
         });
@@ -142,7 +151,7 @@ describe("heartbeat unhappy path", () => {
           },
         ]);
         yield* TestClock.adjust("30 seconds");
-        expect(written).toEqual([{ url: URL, stats: ROW_STATS }]);
+        expect(written).toEqual([ANNOUNCED]);
         expect(log.lines).toHaveLength(1);
       }),
   );
@@ -166,7 +175,7 @@ describe("heartbeat unhappy path", () => {
           { level: "error", text: "heartbeat failed: stats exploded", cause: boom },
         ]);
         yield* TestClock.adjust("30 seconds");
-        expect(store.heartbeats).toEqual([{ url: URL, stats: ROW_STATS }]);
+        expect(store.heartbeats).toEqual([ANNOUNCED]);
         expect(log.lines).toHaveLength(1);
       }),
   );
@@ -184,9 +193,9 @@ describe("heartbeat unhappy path", () => {
           removeServer: () => Effect.fail(refusedDelete),
         });
         const { scope, log } = yield* start(store);
-        expect(store.servers).toEqual([URL]);
+        expect(store.servers).toEqual([REGISTERED]);
         yield* Scope.close(scope, Exit.void);
-        expect(store.servers).toEqual([URL]);
+        expect(store.servers).toEqual([REGISTERED]);
         expect(log.lines).toEqual([
           {
             level: "error",

--- a/test/reverse-proxy/http.unit.test.ts
+++ b/test/reverse-proxy/http.unit.test.ts
@@ -117,38 +117,43 @@ const decoder = new TextDecoder();
 
 const serverBody = (url: string) => Contract.ServerBody.make({ url });
 
+// A registered qemu server, as the fake store's rows carry it: what this reverse proxy fronts.
+const qemu = (url: string) => ({ url, type: "qemu" as const });
+
 const upstreamCalls = (fixed: Fixture) =>
   fixed.upstream.requests.map((request) => `${request.method} ${request.url}`);
 
 describe("server registration", () => {
-  it.effect("POST /servers probes GET /stats with the bearer, stores the url and logs it", () =>
-    Effect.gen(function* () {
-      const fixed = fixture();
-      yield* Effect.gen(function* () {
-        const api = yield* reverseClient;
-        const ok = yield* api.Servers.register({ payload: serverBody(SERVER_A) });
-        expect(ok).toEqual(Contract.Ok.make({}));
-      }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.upstream.requests).toEqual([
-        {
-          method: "GET",
-          url: `${SERVER_A}/stats`,
-          headers: expect.objectContaining({ authorization: AUTHORIZATION }),
-          body: "",
-        },
-      ]);
-      expect(fixed.store.servers).toEqual([SERVER_A]);
-      expect(fixed.log.lines).toEqual([
-        {
-          level: "info",
-          text: `server registered; ${SERVER_A}`,
-          sessionId: undefined,
-          agentId: undefined,
-          skipSentry: false,
-          cause: undefined,
-        },
-      ]);
-    }),
+  it.effect(
+    "POST /servers probes GET /stats with the bearer, stores the url as a qemu server and logs it",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture();
+        yield* Effect.gen(function* () {
+          const api = yield* reverseClient;
+          const ok = yield* api.Servers.register({ payload: serverBody(SERVER_A) });
+          expect(ok).toEqual(Contract.Ok.make({}));
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.upstream.requests).toEqual([
+          {
+            method: "GET",
+            url: `${SERVER_A}/stats`,
+            headers: expect.objectContaining({ authorization: AUTHORIZATION }),
+            body: "",
+          },
+        ]);
+        expect(fixed.store.servers).toEqual([{ url: SERVER_A, type: "qemu" }]);
+        expect(fixed.log.lines).toEqual([
+          {
+            level: "info",
+            text: `server registered; ${SERVER_A}`,
+            sessionId: undefined,
+            agentId: undefined,
+            skipSentry: false,
+            cause: undefined,
+          },
+        ]);
+      }),
   );
 
   it.effect("a url with a trailing slash probes /stats with one slash and is stored as given", () =>
@@ -159,7 +164,7 @@ describe("server registration", () => {
         yield* api.Servers.register({ payload: serverBody(`${SERVER_A}/`) });
       }).pipe(Effect.provide(serve(fixed)));
       expect(upstreamCalls(fixed)).toEqual([`GET ${SERVER_A}/stats`]);
-      expect(fixed.store.servers).toEqual([`${SERVER_A}/`]);
+      expect(fixed.store.servers).toEqual([qemu(`${SERVER_A}/`)]);
     }),
   );
 
@@ -172,7 +177,7 @@ describe("server registration", () => {
         yield* api.Servers.register({ payload: serverBody(SERVER_A) });
       }).pipe(Effect.provide(serve(fixed)));
       expect(upstreamCalls(fixed)).toEqual([`GET ${SERVER_A}/stats`, `GET ${SERVER_A}/stats`]);
-      expect(fixed.store.servers).toEqual([SERVER_A]);
+      expect(fixed.store.servers).toEqual([qemu(SERVER_A)]);
       expect(FakeLog.texts(fixed.log)).toEqual([
         `server registered; ${SERVER_A}`,
         `server registered; ${SERVER_A}`,
@@ -183,13 +188,13 @@ describe("server registration", () => {
   it.effect("DELETE /servers removes the server, logs it, and never probes", () =>
     Effect.gen(function* () {
       const fixed = fixture();
-      fixed.store.servers.push(SERVER_A, SERVER_B);
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
       yield* Effect.gen(function* () {
         const api = yield* reverseClient;
         const ok = yield* api.Servers.unregister({ payload: serverBody(SERVER_A) });
         expect(ok.ok).toBe("true");
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.store.servers).toEqual([SERVER_B]);
+      expect(fixed.store.servers).toEqual([qemu(SERVER_B)]);
       expect(fixed.upstream.requests).toEqual([]);
       expect(fixed.log.lines).toEqual([
         {
@@ -242,13 +247,13 @@ describe("server registration", () => {
   );
 
   it.effect(
-    "GET /servers answers every server with its stats in registration order, null for one that does not answer, and logs nothing",
+    "GET /servers answers every qemu server with its stats in registration order, null for one that does not answer, and logs nothing",
     () =>
       Effect.gen(function* () {
         const fixed = fixture((request, url) =>
           url.origin === SERVER_B ? refused(request, url) : FakeHttp.json(stats(2)),
         );
-        fixed.store.servers.push(SERVER_A, SERVER_B);
+        fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
         yield* Effect.gen(function* () {
           const api = yield* reverseClient;
           const [servers, response] = yield* api.Servers.servers({
@@ -485,11 +490,11 @@ describe("placement", () => {
         : fleet(request, url);
 
   it.effect(
-    "POST /start probes every server, picks the fewest qemus, forwards the body with the bearer, records the route and logs it",
+    "POST /start probes every qemu server, picks the fewest qemus, forwards the body with the bearer, records the route and logs it",
     () =>
       Effect.gen(function* () {
         const fixed = fixture(placing());
-        fixed.store.servers.push(SERVER_A, SERVER_B);
+        fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
         yield* Effect.gen(function* () {
           const api = yield* proxyClient;
           const [started, response] = yield* api.Sessions.start({
@@ -532,7 +537,7 @@ describe("placement", () => {
       const fixed = fixture((request, url) =>
         url.pathname === "/stats" ? FakeHttp.json(stats(1)) : placing()(request, url),
       );
-      fixed.store.servers.push(SERVER_B, SERVER_A);
+      fixed.store.servers.push(qemu(SERVER_B), qemu(SERVER_A));
       yield* Effect.gen(function* () {
         const api = yield* proxyClient;
         yield* api.Sessions.start({ payload: startBody });
@@ -548,7 +553,7 @@ describe("placement", () => {
           ? refused(request, url)
           : placing()(request, url),
       );
-      fixed.store.servers.push(SERVER_A, SERVER_B);
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
       yield* Effect.gen(function* () {
         const api = yield* proxyClient;
         yield* api.Sessions.start({ payload: startBody });
@@ -616,7 +621,7 @@ describe("placement", () => {
   it.effect("every server failing its probe is 503 no server available after the warnings", () =>
     Effect.gen(function* () {
       const fixed = fixture(refused);
-      fixed.store.servers.push(SERVER_A, SERVER_B);
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
       yield* Effect.gen(function* () {
         const api = yield* reverseClient;
         const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
@@ -646,7 +651,7 @@ describe("placement", () => {
           ? FakeHttp.json({ error: "qemu: disk not found: /tmp/nope.qcow2" }, 502)
           : fleet(request, url),
       );
-      fixed.store.servers.push(SERVER_A);
+      fixed.store.servers.push(qemu(SERVER_A));
       yield* Effect.gen(function* () {
         const api = yield* proxyClient;
         const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
@@ -671,7 +676,7 @@ describe("placement", () => {
   it.effect("a 200 without an id is 502 server <url> answered 200 without an id", () =>
     Effect.gen(function* () {
       const fixed = fixture(placing(null));
-      fixed.store.servers.push(SERVER_A);
+      fixed.store.servers.push(qemu(SERVER_A));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
         const raw = yield* http.post("/start", {
@@ -700,7 +705,7 @@ describe("placement", () => {
       const fixed = fixture((request, url) =>
         url.pathname === "/start" ? refused(request, url) : fleet(request, url),
       );
-      fixed.store.servers.push(SERVER_A);
+      fixed.store.servers.push(qemu(SERVER_A));
       yield* Effect.gen(function* () {
         // The proxy's client reads a 502 on /start as the proxy's StartFailed: same status, same
         // message, which is all ./client ever shows.
@@ -734,7 +739,7 @@ describe("placement", () => {
         const fixed = fixture(placing(), {
           store: Stores.fakeServerStore({ routeSession: () => Effect.fail(failure) }),
         });
-        fixed.store.servers.push(SERVER_A);
+        fixed.store.servers.push(qemu(SERVER_A));
         yield* Effect.gen(function* () {
           const api = yield* proxyClient;
           const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
@@ -775,7 +780,7 @@ describe("placement", () => {
           }),
         },
       );
-      fixed.store.servers.push(SERVER_A);
+      fixed.store.servers.push(qemu(SERVER_A));
       yield* Effect.gen(function* () {
         const api = yield* proxyClient;
         const request = yield* Effect.forkChild(api.Sessions.start({ payload: startBody }));
@@ -940,7 +945,7 @@ describe("forwarding", () => {
       const fixed = fixture(
         () => new Response("serial\n", { status: 200, headers: { "content-type": "text/plain" } }),
       );
-      fixed.store.servers.push(SERVER_A);
+      fixed.store.servers.push(qemu(SERVER_A));
       fixed.store.routes.set(SESSION_ID, SERVER_A);
       yield* Effect.gen(function* () {
         const operator = yield* reverseClient;
@@ -1320,7 +1325,7 @@ describe("forwarding refusals", () => {
   it.effect("every route refuses a missing or wrong bearer with 401 and one error line", () =>
     Effect.gen(function* () {
       const fixed = fixture();
-      fixed.store.servers.push(SERVER_A);
+      fixed.store.servers.push(qemu(SERVER_A));
       fixed.store.routes.set(SESSION_ID, SERVER_A);
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
@@ -1353,7 +1358,7 @@ describe("forwarding refusals", () => {
     () =>
       Effect.gen(function* () {
         const fixed = fixture();
-        fixed.store.servers.push(SERVER_A);
+        fixed.store.servers.push(qemu(SERVER_A));
         yield* Effect.gen(function* () {
           const http = yield* HttpClient.HttpClient;
           const headers = { authorization: AUTHORIZATION };

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -556,11 +556,16 @@ export const fakeAutomationStore = (
 // ServerStore
 // ---------------------------------------------------------------------------
 
-type Heartbeat = { readonly url: string; readonly stats: DbSchema.ServerStats };
+type RegisteredServer = { readonly url: string; readonly type: Servers.ServerType };
+type Heartbeat = {
+  readonly url: string;
+  readonly type: Servers.ServerType;
+  readonly stats: DbSchema.ServerStats;
+};
 
 export type FakeServerStore = {
-  // Registered urls, in registration order.
-  readonly servers: Array<string>;
+  // Registered servers, in registration order.
+  readonly servers: Array<RegisteredServer>;
   // Session id to the url of the server that started it.
   readonly routes: Map<string, string>;
   // Every heartbeat written, in order.
@@ -570,37 +575,44 @@ export type FakeServerStore = {
 
 // A url registers once and a session is routed once, as the real keys promise: a second
 // registration is a no-op and a second route is the primary key's DatabaseError. A heartbeat
-// registers the url too, as the real upsert does.
+// registers the url too, as the real upsert does, and its type is the server's word.
 export const fakeServerStore = (
   overrides: Partial<typeof Servers.ServerStore.Service> = {},
 ): FakeServerStore => {
-  const servers: Array<string> = [];
+  const servers: Array<RegisteredServer> = [];
   const routes = new Map<string, string>();
   const heartbeats: Array<Heartbeat> = [];
+  const indexOf = (url: string) => servers.findIndex((server) => server.url === url);
   const service = Servers.ServerStore.of({
-    addServer: (url) =>
+    addServer: (url, type) =>
       Effect.sync(() => {
-        if (!servers.includes(url)) {
-          servers.push(url);
+        if (indexOf(url) === -1) {
+          servers.push({ url, type });
         }
       }),
-    heartbeat: (url, stats) =>
+    heartbeat: (url, type, stats) =>
       Effect.sync(() => {
-        if (!servers.includes(url)) {
-          servers.push(url);
+        const index = indexOf(url);
+        if (index === -1) {
+          servers.push({ url, type });
+        } else {
+          servers[index] = { url, type };
         }
-        heartbeats.push({ url, stats });
+        heartbeats.push({ url, type, stats });
       }),
     removeServer: (url) =>
       Effect.sync(() => {
-        const index = servers.indexOf(url);
+        const index = indexOf(url);
         if (index === -1) {
           return false;
         }
         servers.splice(index, 1);
         return true;
       }),
-    listServers: () => Effect.sync(() => [...servers]),
+    listServers: (type) =>
+      Effect.sync(() =>
+        servers.filter((server) => server.type === type).map((server) => server.url),
+      ),
     routeSession: (sessionId, url) =>
       routes.has(sessionId)
         ? Effect.fail(conflict("routeSession", "insert into session_servers"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

- `servers` gains a `type` column: a new `server_type` Postgres enum with one value so far, `qemu`, `not null default 'qemu'`. The default is what the migration fills the rows that predate the column with — qemu servers were the only kind there was.
- Every writer names the type: the reverse proxy's `POST /servers`, the dashboard's add box and the server's heartbeat all say `qemu`. The heartbeat's upsert rewrites `type` too, so the row's kind is the server's own word.
- `ServerStore.listServers(type)` filters on the type. The reverse proxy's `Router` holds one constant, `SERVER_TYPE = "qemu"`: `register` stores a url as a qemu server, and `GET /servers` and `POST /start` read the `qemu` rows alone, so a row of another kind is neither reported nor placed on.
- Migration `drizzle/0008_server_type.sql`, generated with `npm run db:generate -- --name server_type`; `drizzle-kit check` is clean and a second generate produces no drift.
- `SERVER_VS_REVERSE_PROXY.md` describes the column, the store and the router's kind.

## Tests (written first)

- `test/integration/db.integration.test.ts`: `addServer`/`heartbeat` land as `qemu` and are listed by `listServers("qemu")`; the heartbeat upsert keeps the type; a row written without a type is a `qemu` server (the migration's default); a value outside the enum is the database's refusal (unhappy).
- `test/reverse-proxy/http.unit.test.ts`: registration stores `{ url, type: "qemu" }`; the fake store's rows carry a type and `listServers(type)` filters as the real query does.
- `test/proxy/heartbeat.unit.test.ts`: the heartbeat announces a qemu server.
- `test/integration/proxy.integration.test.ts` and `test/integration/dashboard.integration.test.ts`: the `--url` heartbeat row and the add box's row have `type: "qemu"`.

## Verification

- `npm run check:fast` green (lint, format, types, 862 unit tests).
- Docker is unavailable in this environment, so the DB-backed integration suites (`db`, `dashboard`, `reverse-proxy`) were run against a local Postgres 16 through a temporary vitest config outside the repo: 84/85 pass. The one failure, `TestStore refuses a second result for the same session`, is pre-existing on `master` and unrelated (`test_results`).
- Production's upgrade path was simulated: migrations 0001–0007 applied, a heartbeating row and an operator-added row inserted, then 0008 applied — both rows read `type = 'qemu'`, `listServers('qemu')` returns them, and `insert … type 'docker'` is refused with `invalid input value for enum server_type`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a088a0-e916-71d4-b203-0629e9e6e826?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a088a0-e916-71d4-b203-0629e9e6e826&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

