### PR TITLE
Attribute logs by location text (`server` / `automation` / session id)

### DIFF
--- a/development.md
+++ b/development.md
@@ -707,8 +707,12 @@ statement inside with `Client.attempt("endSession", () => tx.update(...))`.
 
 - Application code logs through the `Log` service (`src/observability/log.ts`): `info`, `warning`,
   `error`, `fatal`, `acquireColor`, `releaseColor`, `flush`. Messages are fixed sentences; every
-  variable is in the attribution (`sessionId`, `agentId`) or in the text after the `;`, as in
-  `log.info(\`running; started in ${String(ms)}ms\`, { sessionId, agentId })`.
+  variable is in the attribution (`location`, `agentId`) or in the text after the `;`, as in
+  `log.info(\`running; started in ${String(ms)}ms\`, { location: sessionId, agentId })`.
+  `location` is a text bucket: a session UUID, `Locations.server` (proxy-wide lines with no
+  session), or `Locations.automation` (the automation process; its `agentId` is also
+  `Locations.automation`). `ProcessAttribution` is the fallback the HTTP boundary uses when an
+  error carries no session; the proxy leaves the default (`server`), automation overrides it.
 - Each line is written twice: to stdout through `Console.log` when the method runs, and as a
   `logs` row `Queue.offerUnsafe`d to a `Queue.unbounded` drained by one `forkScoped` fiber that
   inserts in call order. The queue is unbounded by policy: a log call never blocks or drops a row
@@ -740,9 +744,10 @@ statement inside with `Client.attempt("endSession", () => tx.update(...))`.
   finalizer runs `flush` before the drain fiber is interrupted, and `Log.layer` (over `LogStore`)
   sits above `Database` so the flush completes before the pool closes. `Log.layer` reads
   `ErrorReporter.CurrentErrorReporters` once at build, so `SentryLive` is provided beneath it,
-  never only to callers. `Log.layerStdout` persists nothing: it is for tests and for a process
-  that does not persist log rows (the automation service writes queue jobs, not log lines), whose
-  console copy is stdout and Sentry. A fatal path flushes the log, then Sentry, then exits.
+  never only to callers. `Log.layerStdout` persists nothing: it is for tests. The automation
+  service persists through `Log.layer` once it has a database; its lines use
+  `location = 'automation'` (and process-wide lines also use `agentId = 'automation'`), while
+  durable work remains `automation_jobs`. A fatal path flushes the log, then Sentry, then exits.
 - `Log` installs no Effect `Logger`; `emit` formats, writes and offers synchronously. `console.*`
   appears only in `src/dashboard/**` and `vitest.global-setup.ts`. Test log output through the
   fake `Log` layer (`test/support/log.ts`) or `Log.layerStdout` with `TestConsole.logLines`.
@@ -759,7 +764,7 @@ statement inside with `Client.attempt("endSession", () => tx.update(...))`.
   `@sentry/cloudflare` only in `src/dashboard/`. All three are pinned to one version so
   `@sentry/core` is not duplicated (`SentryEffectTracer` relies on one `getActiveSpan()`).
 - Route exceptions through one `ErrorReporter.make` installed with `ErrorReporter.layer([reporter])`
-  (below); never call `captureException` elsewhere in Effect code. Tags are `session_id`/`agent_id`
+  (below); never call `captureException` elsewhere in Effect code. Tags are `location`/`agent_id`
   read from `fiber.getRef(References.CurrentLogAnnotations)` (the `Log` methods annotate them,
   with the text as `log`) merged with the reporter's `attributes`, which no error of ours sets;
   Effect's `Warn` maps to `warning`, `Fatal` to `fatal`, every other severity to `error`.
@@ -799,7 +804,7 @@ export const reporter: ErrorReporter.ErrorReporter = ErrorReporter.make(
       error.name === Errors.LogLine.identifier && error.cause !== undefined ? error.cause : error;
     Sentry.captureException(exception, {
       level: toSentryLevel(severity),
-      tags: Object.assign({}, tag(context, "session_id"), tag(context, "agent_id")),
+      tags: Object.assign({}, tag(context, "location"), tag(context, "agent_id")),
       extra: context,
     });
   },

--- a/drizzle/0009_logs_location.sql
+++ b/drizzle/0009_logs_location.sql
@@ -1,0 +1,11 @@
+-- logs.session_id (uuid) becomes logs.location (text): a session UUID, 'server', or 'automation'.
+-- Existing nulls were process-wide proxy lines; they become 'server'.
+ALTER TABLE "logs" RENAME COLUMN "session_id" TO "location";--> statement-breakpoint
+ALTER TABLE "logs" ALTER COLUMN "location" SET DATA TYPE text USING (
+  CASE
+    WHEN "location" IS NULL THEN 'server'
+    ELSE "location"::text
+  END
+);--> statement-breakpoint
+DROP INDEX IF EXISTS "logs_session_id_idx";--> statement-breakpoint
+CREATE INDEX "logs_location_idx" ON "logs" USING btree ("location");

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1262 @@
+{
+  "id": "c1fd6a0a-b3e1-4862-bcb4-c09d59bd4d9d",
+  "prevId": "d6a89b8c-47d8-447b-b8df-0e26be85a450",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "actions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "action_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "actions_session_id_idx": {
+          "name": "actions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_session_id_sessions_id_fk": {
+          "name": "actions_session_id_sessions_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actions_agent_id_agent_runs_agent_id_fk": {
+          "name": "actions_agent_id_agent_runs_agent_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_runs_session_id_idx": {
+          "name": "agent_runs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_session_id_sessions_id_fk": {
+          "name": "agent_runs_session_id_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_jobs": {
+      "name": "automation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "automation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_jobs_result_action_idx": {
+          "name": "automation_jobs_result_action_idx",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_jobs_status_created_at_idx": {
+          "name": "automation_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_jobs_result_id_test_results_result_id_fk": {
+          "name": "automation_jobs_result_id_test_results_result_id_fk",
+          "tableFrom": "automation_jobs",
+          "tableTo": "test_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debug_logs_session_id_sessions_id_fk": {
+          "name": "debug_logs_session_id_sessions_id_fk",
+          "tableFrom": "debug_logs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "images_id_idx": {
+          "name": "images_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_action_id_actions_id_fk": {
+          "name": "images_action_id_actions_id_fk",
+          "tableFrom": "images",
+          "tableTo": "actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "logs_location_idx": {
+          "name": "logs_location_idx",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_run_diagnosis": {
+      "name": "post_run_diagnosis",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "diagnosis_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_run_diagnosis_error_type_idx": {
+          "name": "post_run_diagnosis_error_type_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_run_diagnosis_session_id_sessions_id_fk": {
+          "name": "post_run_diagnosis_session_id_sessions_id_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_run_diagnosis_error_type_post_run_error_types_key_fk": {
+          "name": "post_run_diagnosis_error_type_post_run_error_types_key_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "post_run_error_types",
+          "columnsFrom": [
+            "error_type"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_run_diagnosis_verdict_error_type_check": {
+          "name": "post_run_diagnosis_verdict_error_type_check",
+          "value": "(\"post_run_diagnosis\".\"verdict\" = 'passed') = (\"post_run_diagnosis\".\"error_type\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_run_error_types": {
+      "name": "post_run_error_types",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servers": {
+      "name": "servers",
+      "schema": "",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "server_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'qemu'"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_servers": {
+      "name": "session_servers",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_servers_session_id_sessions_id_fk": {
+          "name": "session_servers_session_id_sessions_id_fk",
+          "tableFrom": "session_servers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_base_prompts": {
+      "name": "test_base_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_base_prompts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_base_prompts_name_idx": {
+          "name": "test_base_prompts_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_definitions": {
+      "name": "test_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_definitions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_definitions_name_idx": {
+          "name": "test_definitions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_results": {
+      "name": "test_results",
+      "schema": "",
+      "columns": {
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_id": {
+          "name": "linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "test_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_results_run_definition_idx": {
+          "name": "test_results_run_definition_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_session_id_idx": {
+          "name": "test_results_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_linear_id_idx": {
+          "name": "test_results_linear_id_idx",
+          "columns": [
+            {
+              "expression": "linear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_results_run_id_test_runs_id_fk": {
+          "name": "test_results_run_id_test_runs_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_definition_id_test_definitions_id_fk": {
+          "name": "test_results_definition_id_test_definitions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_session_id_sessions_id_fk": {
+          "name": "test_results_session_id_sessions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso": {
+          "name": "iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "test_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.action_state": {
+      "name": "action_state",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed"
+      ]
+    },
+    "public.automation_action": {
+      "name": "automation_action",
+      "schema": "public",
+      "values": [
+        "drive",
+        "diagnose"
+      ]
+    },
+    "public.automation_job_status": {
+      "name": "automation_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.diagnosis_verdict": {
+      "name": "diagnosis_verdict",
+      "schema": "public",
+      "values": [
+        "passed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.server_type": {
+      "name": "server_type",
+      "schema": "public",
+      "values": [
+        "qemu"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_result_status": {
+      "name": "test_result_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_run_status": {
+      "name": "test_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1788999629271,
       "tag": "0008_server_type",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1789001000000,
+      "tag": "0009_logs_location",
+      "breakpoints": true
     }
   ]
 }

--- a/src/automation/command.ts
+++ b/src/automation/command.ts
@@ -53,7 +53,13 @@ export const makeAutomationCommand = <RServe>(server: AutomationServer<RServe>) 
           );
         });
         return yield* startup.pipe(
-          Effect.tapError((error) => log.fatal(`automation: ${detail(error)}`, { cause: error })),
+          Effect.tapError((error) =>
+            log.fatal(`automation: ${detail(error)}`, {
+              location: Log.Locations.automation,
+              agentId: Log.AutomationAgentId,
+              cause: error,
+            }),
+          ),
         );
       }),
   ).pipe(

--- a/src/automation/handlers.ts
+++ b/src/automation/handlers.ts
@@ -45,13 +45,19 @@ export const LinearLive = HttpApiBuilder.group(Api.AutomationApi, "Linear", (han
       }
       const parsed = Option.map(Webhook.issue(bytes), Webhook.work);
       if (Option.isNone(parsed)) {
-        yield* log.info("linear webhook recorded");
+        yield* log.info("linear webhook recorded", {
+          location: Log.Locations.automation,
+          agentId: Log.AutomationAgentId,
+        });
         return ok;
       }
       const event = parsed.value;
       const job = Webhook.queuedAction(event);
       if (Option.isNone(job)) {
-        yield* log.info(`linear webhook recorded; ${event.state}`, { agentId: event.ticket });
+        yield* log.info(`linear webhook recorded; ${event.state}`, {
+          location: Log.Locations.automation,
+          agentId: event.ticket,
+        });
         return ok;
       }
       const result = yield* tests
@@ -61,6 +67,7 @@ export const LinearLive = HttpApiBuilder.group(Api.AutomationApi, "Linear", (han
         );
       if (Option.isNone(result)) {
         yield* log.info(`linear webhook ignored; no result for ${event.state}`, {
+          location: Log.Locations.automation,
           agentId: event.ticket,
         });
         return ok;
@@ -77,11 +84,13 @@ export const LinearLive = HttpApiBuilder.group(Api.AutomationApi, "Linear", (han
         );
       if (outcome === "duplicate") {
         yield* log.info(`linear webhook ignored; ${job.value} already queued`, {
+          location: Log.Locations.automation,
           agentId: event.ticket,
         });
         return ok;
       }
       yield* log.info(`linear webhook queued ${job.value}; ${event.state}`, {
+        location: Log.Locations.automation,
         agentId: event.ticket,
       });
       return ok;

--- a/src/automation/main.ts
+++ b/src/automation/main.ts
@@ -6,6 +6,7 @@ import { HttpMiddleware, HttpRouter, HttpServerError } from "effect/unstable/htt
 import * as Config from "../config.ts";
 import * as Automation from "../db/automation.ts";
 import * as Client from "../db/client.ts";
+import * as Logs from "../db/logs.ts";
 import * as Tests from "../db/tests.ts";
 import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
@@ -16,9 +17,14 @@ import * as Handlers from "./handlers.ts";
 
 const HOST = "127.0.0.1";
 
-// stdout is the convenience copy of the log; the automation_jobs rows and Sentry are the record.
-// A write refused by a full filesystem is dropped, never an uncaught exception per line
-// (see the proxy's main).
+const automationAttr = {
+  location: Log.Locations.automation,
+  agentId: Log.AutomationAgentId,
+} as const;
+
+// stdout is the convenience copy of the log; the logs rows, automation_jobs rows and Sentry are
+// the record. A write refused by a full filesystem is dropped, never an uncaught exception per
+// line (see the proxy's main).
 process.stdout.on("error", () => {});
 process.stderr.on("error", () => {});
 
@@ -34,7 +40,8 @@ const ServerLive = (port: number) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const log = yield* Log.Log;
-      yield* log.info(`oligarchy automation listening on ${HOST}:${String(port)}`);
+      yield* log.acquireColor(Log.AutomationAgentId);
+      yield* log.info(`oligarchy automation listening on ${HOST}:${String(port)}`, automationAttr);
     }),
   ).pipe(
     Layer.provide(
@@ -49,16 +56,19 @@ const ServerLive = (port: number) =>
 
 const DatabaseLive = Layer.unwrap(Effect.map(Config.databaseUrl, Client.Database.layer));
 
-// LINEAR_WEBHOOK_SECRET signs POST /linear; DATABASE_URL holds the queue. Sentry sits beneath
-// Log so Log captures the reporter. Log is stdout: durable work is automation_jobs, not log rows.
+// LINEAR_WEBHOOK_SECRET signs POST /linear; DATABASE_URL holds the queue and the logs rows.
+// Sentry sits beneath Log so Log captures the reporter. Lines land in logs with
+// location/agentId "automation"; durable jobs remain automation_jobs.
 const MainLive = Layer.mergeAll(
-  Log.Log.layerStdout,
+  Log.Log.layer,
   Handlers.LinearWebhookSecret.layer,
   Tests.TestStore.layer,
   Automation.AutomationStore.layer,
 ).pipe(
+  Layer.provideMerge(Logs.LogStore.layer),
   Layer.provideMerge(DatabaseLive),
   Layer.provideMerge(Sentry.SentryLive),
+  Layer.provideMerge(Layer.succeed(Log.ProcessAttribution)(Log.AutomationProcessAttribution)),
   Layer.provideMerge(Config.providerLayer),
   Layer.provideMerge(NodeServices.layer),
 );

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,9 +58,12 @@ export class ProxyConfig extends Context.Service<ProxyConfig>()("@oligarchy/conf
   static readonly layer = Layer.effect(this)(this.make);
 }
 
-export class AutomationConfig extends Context.Service<AutomationConfig>()("@oligarchy/config/AutomationConfig", {
-  // Sequential on purpose: LINEAR_WEBHOOK_SECRET is reported before DATABASE_URL.
-  make: Effect.all({ linearWebhookSecret, databaseUrl }),
-}) {
+export class AutomationConfig extends Context.Service<AutomationConfig>()(
+  "@oligarchy/config/AutomationConfig",
+  {
+    // Sequential on purpose: LINEAR_WEBHOOK_SECRET is reported before DATABASE_URL.
+    make: Effect.all({ linearWebhookSecret, databaseUrl }),
+  },
+) {
   static readonly layer = Layer.effect(this)(this.make);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,3 +57,10 @@ export class ProxyConfig extends Context.Service<ProxyConfig>()("@oligarchy/conf
 }) {
   static readonly layer = Layer.effect(this)(this.make);
 }
+
+export class AutomationConfig extends Context.Service<AutomationConfig>()("@oligarchy/config/AutomationConfig", {
+  // Sequential on purpose: LINEAR_WEBHOOK_SECRET is reported before DATABASE_URL.
+  make: Effect.all({ linearWebhookSecret, databaseUrl }),
+}) {
+  static readonly layer = Layer.effect(this)(this.make);
+}

--- a/src/ctrl/command.ts
+++ b/src/ctrl/command.ts
@@ -434,7 +434,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
       ),
     );
     yield* log.info(`test result ${input.testResultId}: running`, {
-      sessionId: input.sessionId,
+      location: input.sessionId,
     });
   });
 
@@ -474,7 +474,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
         { agentId: input.agentId },
         Option.match(agentSession, {
           onNone: () => undefined,
-          onSome: (session) => ({ sessionId: session }),
+          onSome: (session) => ({ location: session }),
         }),
       ),
     );
@@ -558,7 +558,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
       onSome: (key) => `${key}; `,
     });
     return yield* log.info(`diagnosed; ${input.verdict}; ${cause}${input.model}`, {
-      sessionId: input.sessionId,
+      location: input.sessionId,
     });
   });
 

--- a/src/db/logs.ts
+++ b/src/db/logs.ts
@@ -7,7 +7,7 @@ import * as DbSchema from "./schema.ts";
 export type LogRow = {
   readonly text: string;
   readonly level: Domain.LogLevel;
-  readonly sessionId: string | null;
+  readonly location: string | null;
   readonly agentId: string | null;
 };
 
@@ -19,12 +19,13 @@ export class LogStore extends Context.Service<LogStore>()("@oligarchy/db/LogStor
       yield* database.run("insertLog", (db) => db.insert(DbSchema.logs).values(row));
     });
 
-    const listLogs = Effect.fn("db.listLogs")(function* (sessionId: string) {
+    // Rows for one location bucket: a session UUID, "server", or "automation".
+    const listLogs = Effect.fn("db.listLogs")(function* (location: string) {
       return yield* database.run("listLogs", (db) =>
         db
           .select()
           .from(DbSchema.logs)
-          .where(eq(DbSchema.logs.sessionId, sessionId))
+          .where(eq(DbSchema.logs.location, location))
           .orderBy(DbSchema.logs.createdAt, DbSchema.logs.id),
       );
     });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -119,19 +119,20 @@ export const images = pgTable(
   (table) => [uniqueIndex("images_id_idx").on(table.id)],
 );
 
-// session_id and agent_id are attribution, not relations: a log must never be refused
+// location and agent_id are attribution, not relations: a log must never be refused
 // because the row it names is missing or already gone, so neither is a foreign key.
+// location is a text bucket: a session UUID, "server" (proxy-wide), or "automation".
 export const logs = pgTable(
   "logs",
   {
     id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
-    sessionId: uuid("session_id"),
+    location: text("location"),
     agentId: text("agent_id"),
     level: logLevel("level").notNull().default("info"),
     text: text("text").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [index("logs_session_id_idx").on(table.sessionId)],
+  (table) => [index("logs_location_idx").on(table.location)],
 );
 
 // One snapshot per failed session, keyed by origin. journalctl / dmesg / compositor

--- a/src/observability/log.ts
+++ b/src/observability/log.ts
@@ -15,8 +15,34 @@ import * as Errors from "../shared/errors.ts";
 import type * as Domain from "../shared/domain.ts";
 import * as Render from "./render.ts";
 
-export type Attribution = { readonly sessionId?: string; readonly agentId?: string };
+// location is a text bucket: a session UUID, Locations.server, or Locations.automation.
+export type Attribution = { readonly location?: string; readonly agentId?: string };
 export type Report = Attribution & { readonly cause?: unknown; readonly skipSentry?: true };
+
+export const Locations = {
+  automation: "automation",
+  server: "server",
+} as const;
+
+// The automation process logs with agentId === Locations.automation as well.
+export const AutomationAgentId = Locations.automation;
+
+// Fallback attribution when a log line has no session: proxy-wide "server", or automation's
+// own bucket. Processes override this Reference at the top of their layer graph.
+export type ProcessAttribution = {
+  readonly location: string;
+  readonly agentId?: string;
+};
+
+export const ProcessAttribution = Context.Reference<ProcessAttribution>(
+  "@oligarchy/observability/log/ProcessAttribution",
+  { defaultValue: () => ({ location: Locations.server }) },
+);
+
+export const AutomationProcessAttribution: ProcessAttribution = {
+  location: Locations.automation,
+  agentId: AutomationAgentId,
+};
 
 export type LogService = {
   readonly info: (text: string, attribution?: Attribution) => Effect.Effect<void>;
@@ -48,7 +74,7 @@ type Sink = {
 const annotations = (text: string, attribution: Attribution): Record<string, unknown> =>
   Object.assign(
     {},
-    attribution.sessionId === undefined ? undefined : { session_id: attribution.sessionId },
+    attribution.location === undefined ? undefined : { location: attribution.location },
     attribution.agentId === undefined ? undefined : { agent_id: attribution.agentId },
     { log: text },
   );
@@ -153,7 +179,7 @@ const makeLog = (
         yield* write(
           Object.assign(
             { text, level },
-            attribution.sessionId === undefined ? undefined : { sessionId: attribution.sessionId },
+            attribution.location === undefined ? undefined : { location: attribution.location },
             attribution.agentId === undefined ? undefined : { agentId: attribution.agentId },
             color === undefined ? undefined : { color },
           ),
@@ -161,7 +187,7 @@ const makeLog = (
         offer({
           text,
           level,
-          sessionId: attribution.sessionId ?? null,
+          location: attribution.location ?? null,
           agentId: attribution.agentId ?? null,
         });
       });
@@ -206,7 +232,7 @@ export class Log extends Context.Service<Log>()("@oligarchy/observability/Log", 
   }),
 }) {
   static readonly layer: Layer.Layer<Log, never, Logs.LogStore> = Layer.effect(this)(this.make);
-  // stdout only, no rows: tests and the processes that have no database (the automation service).
+  // stdout only, no rows: tests. Automation persists through `layer` once it has a database.
   static readonly layerStdout: Layer.Layer<Log> = Layer.effect(this)(
     makeLog(() => Effect.succeed(stdoutOnly)),
   );

--- a/src/observability/render.ts
+++ b/src/observability/render.ts
@@ -74,7 +74,7 @@ const style = (format: "gray" | "white", text: string, colors: boolean): string 
 export type LogLine = {
   readonly text: string;
   readonly level: Domain.LogLevel;
-  readonly sessionId?: string;
+  readonly location?: string;
   readonly agentId?: string;
   readonly color?: string;
 };
@@ -85,9 +85,9 @@ export const renderLogLine = (entry: LogLine, colors: boolean): string => {
   const ticket =
     entry.color === undefined ? style("gray", tag, colors) : paint(entry.color, tag, colors);
   const rest =
-    entry.sessionId === undefined
+    entry.location === undefined
       ? style("white", `] ${text}`, colors)
-      : `${style("white", "] ", colors)}${style("gray", entry.sessionId, colors)}${style("white", `: ${text}`, colors)}`;
+      : `${style("white", "] ", colors)}${style("gray", entry.location, colors)}${style("white", `: ${text}`, colors)}`;
   return `${style("white", "[", colors)}${ticket}${rest}`;
 };
 

--- a/src/observability/sentry.ts
+++ b/src/observability/sentry.ts
@@ -53,7 +53,7 @@ export const reporter: ErrorReporter.ErrorReporter = ErrorReporter.make(
       error.name === Errors.LogLine.identifier && error.cause !== undefined ? error.cause : error;
     Sentry.captureException(exception, {
       level: toSentryLevel(severity),
-      tags: Object.assign({}, tag(context, "session_id"), tag(context, "agent_id")),
+      tags: Object.assign({}, tag(context, "location"), tag(context, "agent_id")),
       extra: context,
     });
   },

--- a/src/proxy/command.ts
+++ b/src/proxy/command.ts
@@ -97,7 +97,9 @@ export const makeProxyCommand = <RHost, RServe>(server: ProxyServer<RHost, RServ
           );
         });
         return yield* startup.pipe(
-          Effect.tapError((error) => log.fatal(`proxy: ${detail(error)}`, { location: Log.Locations.server, cause: error })),
+          Effect.tapError((error) =>
+            log.fatal(`proxy: ${detail(error)}`, { location: Log.Locations.server, cause: error }),
+          ),
         );
       }),
   ).pipe(

--- a/src/proxy/command.ts
+++ b/src/proxy/command.ts
@@ -97,7 +97,7 @@ export const makeProxyCommand = <RHost, RServe>(server: ProxyServer<RHost, RServ
           );
         });
         return yield* startup.pipe(
-          Effect.tapError((error) => log.fatal(`proxy: ${detail(error)}`, { cause: error })),
+          Effect.tapError((error) => log.fatal(`proxy: ${detail(error)}`, { location: Log.Locations.server, cause: error })),
         );
       }),
   ).pipe(

--- a/src/proxy/heartbeat.ts
+++ b/src/proxy/heartbeat.ts
@@ -44,7 +44,7 @@ export const announce = (
       ),
       Effect.catchCause((cause) => {
         const error = Cause.squash(cause);
-        return log.error(`heartbeat failed: ${detail(error)}`, { cause: error });
+        return log.error(`heartbeat failed: ${detail(error)}`, { location: Log.Locations.server, cause: error });
       }),
     );
     // Before the loop: close interrupts the fiber first, then this runs.
@@ -52,7 +52,7 @@ export const announce = (
       store.removeServer(url).pipe(
         Effect.catchCause((cause) => {
           const error = Cause.squash(cause);
-          return log.error(`unannounce failed: ${detail(error)}`, { cause: error });
+          return log.error(`unannounce failed: ${detail(error)}`, { location: Log.Locations.server, cause: error });
         }),
         Effect.asVoid,
       ),

--- a/src/proxy/heartbeat.ts
+++ b/src/proxy/heartbeat.ts
@@ -44,7 +44,10 @@ export const announce = (
       ),
       Effect.catchCause((cause) => {
         const error = Cause.squash(cause);
-        return log.error(`heartbeat failed: ${detail(error)}`, { location: Log.Locations.server, cause: error });
+        return log.error(`heartbeat failed: ${detail(error)}`, {
+          location: Log.Locations.server,
+          cause: error,
+        });
       }),
     );
     // Before the loop: close interrupts the fiber first, then this runs.
@@ -52,7 +55,10 @@ export const announce = (
       store.removeServer(url).pipe(
         Effect.catchCause((cause) => {
           const error = Cause.squash(cause);
-          return log.error(`unannounce failed: ${detail(error)}`, { location: Log.Locations.server, cause: error });
+          return log.error(`unannounce failed: ${detail(error)}`, {
+            location: Log.Locations.server,
+            cause: error,
+          });
         }),
         Effect.asVoid,
       ),

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -59,6 +59,7 @@ const ServerLive = (
       const log = yield* Log.Log;
       yield* log.info(
         `oligarchy proxy listening on ${HOST}:${String(port)}; display ${display}${automation ? "; automation" : ""}${Option.match(url, { onNone: () => "", onSome: (announced) => `; announcing ${announced}` })}`,
+        { location: Log.Locations.server },
       );
       yield* Option.match(url, { onNone: () => Effect.void, onSome: Heartbeat.announce });
     }),

--- a/src/proxy/middleware.ts
+++ b/src/proxy/middleware.ts
@@ -55,10 +55,7 @@ const translate = (
 
 // logs.location is text: an unknown id is attributed only when this server could have minted it
 // (a session UUID). Otherwise the process fallback applies (proxy: "server"; automation: its own).
-const attribution = (
-  error: Errors.ApiError,
-  fallback: Log.ProcessAttribution,
-): Log.Attribution => {
+const attribution = (error: Errors.ApiError, fallback: Log.ProcessAttribution): Log.Attribution => {
   switch (error._tag) {
     case "Unauthorized":
     case "NotFound":

--- a/src/proxy/middleware.ts
+++ b/src/proxy/middleware.ts
@@ -53,34 +53,50 @@ const translate = (
       ? Effect.fail(error)
       : Effect.die(error);
 
-// logs.session_id is a uuid column: an unknown id is attributed only when this server could have
-// minted it.
-const attribution = (error: Errors.ApiError): Log.Attribution => {
+// logs.location is text: an unknown id is attributed only when this server could have minted it
+// (a session UUID). Otherwise the process fallback applies (proxy: "server"; automation: its own).
+const attribution = (
+  error: Errors.ApiError,
+  fallback: Log.ProcessAttribution,
+): Log.Attribution => {
   switch (error._tag) {
     case "Unauthorized":
     case "NotFound":
-      return {};
+      return fallback;
     case "Forbidden":
-      return { sessionId: error.sessionId, agentId: error.agentId };
+      return { location: error.sessionId, agentId: error.agentId };
     case "Conflict":
-      return { sessionId: error.sessionId };
+      return { location: error.sessionId };
     case "UnknownSession":
       return Object.assign(
-        {},
-        Domain.isSessionId(error.id) ? { sessionId: error.id } : undefined,
-        error.agentId === undefined ? undefined : { agentId: error.agentId },
+        { location: Domain.isSessionId(error.id) ? error.id : fallback.location },
+        error.agentId === undefined
+          ? fallback.agentId === undefined
+            ? undefined
+            : { agentId: fallback.agentId }
+          : { agentId: error.agentId },
       );
     case "NoServer":
-      return error.agentId === undefined ? {} : { agentId: error.agentId };
+      return Object.assign(
+        { location: fallback.location },
+        error.agentId === undefined
+          ? fallback.agentId === undefined
+            ? undefined
+            : { agentId: fallback.agentId }
+          : { agentId: error.agentId },
+      );
     case "BadRequest":
     case "StartFailed":
     case "ExchangeFailed":
     case "Internal":
     case "ServerFailed":
       return Object.assign(
-        {},
-        error.sessionId === undefined ? undefined : { sessionId: error.sessionId },
-        error.agentId === undefined ? undefined : { agentId: error.agentId },
+        { location: error.sessionId ?? fallback.location },
+        error.agentId === undefined
+          ? fallback.agentId === undefined
+            ? undefined
+            : { agentId: fallback.agentId }
+          : { agentId: error.agentId },
       );
   }
   return error satisfies never;
@@ -94,16 +110,20 @@ const detail = (error: Errors.ApiError): string =>
     : error.message;
 
 // A refusal (< 500) is the caller's problem and skips Sentry; a failure carries its cause there.
-const report = (error: Errors.ApiError): Log.Report =>
+const report = (error: Errors.ApiError, fallback: Log.ProcessAttribution): Log.Report =>
   Errors.apiStatus(error) < 500
-    ? { ...attribution(error), skipSentry: true }
-    : { ...attribution(error), cause: "cause" in error ? error.cause : undefined };
+    ? { ...attribution(error, fallback), skipSentry: true }
+    : {
+        ...attribution(error, fallback),
+        cause: "cause" in error ? error.cause : undefined,
+      };
 
 // The one boundary: schema errors to 400, defects to 500, one log line per failed request. The
 // proxy and the reverse proxy wrap it in their own middleware tags, which differ only in the error
 // codecs they declare.
 const boundary = Effect.gen(function* () {
   const log = yield* Log.Log;
+  const fallback = yield* Log.ProcessAttribution;
   return (httpEffect: Effect.Effect<HttpServerResponse.HttpServerResponse, Types.unhandled>) =>
     Effect.gen(function* () {
       const request = yield* HttpServerRequest.HttpServerRequest;
@@ -111,9 +131,9 @@ const boundary = Effect.gen(function* () {
         log.error(`${request.method} ${request.originalUrl} failed: ${text}`, how);
       return yield* httpEffect.pipe(
         Effect.catch(translate),
-        Effect.tapError((error) => failed(detail(error), report(error))),
+        Effect.tapError((error) => failed(detail(error), report(error, fallback))),
         Effect.catchDefect((defect) =>
-          failed(Cause.pretty(Cause.die(defect)), { cause: defect }).pipe(
+          failed(Cause.pretty(Cause.die(defect)), { ...fallback, cause: defect }).pipe(
             Effect.andThen(
               Effect.fail(Errors.Internal.make({ message: "internal error", cause: defect })),
             ),

--- a/src/proxy/sessions.ts
+++ b/src/proxy/sessions.ts
@@ -871,7 +871,10 @@ const make = Effect.gen(function* () {
   const tick = sweep.pipe(
     Effect.catchCause((cause) => {
       const error = Cause.squash(cause);
-      return log.error(`session timeout cleanup failed: ${detail(error)}`, { location: Log.Locations.server, cause: error });
+      return log.error(`session timeout cleanup failed: ${detail(error)}`, {
+        location: Log.Locations.server,
+        cause: error,
+      });
     }),
     Effect.uninterruptible,
     guard.withPermitsIfAvailable(1),
@@ -912,7 +915,9 @@ const make = Effect.gen(function* () {
     yield* Fiber.interrupt(sweeper);
     const draining = [...(yield* Ref.getAndSet(sessions, new Map())).values()];
     const reason = MutableRef.get(shutdown.reason);
-    yield* log.info(`proxy: shutting down; stopping ${String(draining.length)} sessions`, { location: Log.Locations.server });
+    yield* log.info(`proxy: shutting down; stopping ${String(draining.length)} sessions`, {
+      location: Log.Locations.server,
+    });
     const exits = yield* Effect.forEach(draining, (live) => Effect.exit(drainOne(live, reason)), {
       concurrency: "unbounded",
     });

--- a/src/proxy/sessions.ts
+++ b/src/proxy/sessions.ts
@@ -165,8 +165,8 @@ const mapWithout = <V>(
   return next;
 };
 
-const attribution = (sessionId: string, agentId: string | undefined): Log.Attribution =>
-  agentId === undefined ? { sessionId } : { sessionId, agentId };
+const attribution = (location: string, agentId: string | undefined): Log.Attribution =>
+  agentId === undefined ? { location } : { location, agentId };
 
 const internal = (cause: unknown, sessionId: string, agentId?: string): Errors.Internal =>
   agentId === undefined
@@ -215,7 +215,7 @@ const make = Effect.gen(function* () {
         yield* Ref.update(live.followers, (set) => without(set, follower));
         Queue.endUnsafe(follower);
         yield* log.warning(`follower dropped; ${String(FOLLOW_BACKLOG)} events behind`, {
-          sessionId: live.id,
+          location: live.id,
           agentId: live.agent,
         });
       }
@@ -241,7 +241,7 @@ const make = Effect.gen(function* () {
         set.has(follower) ? [true, without(set, follower)] : [false, set],
       );
       if (removed) {
-        yield* log.info("follower detached", { sessionId: live.id, agentId: live.agent });
+        yield* log.info("follower detached", { location: live.id, agentId: live.agent });
       }
     });
 
@@ -302,7 +302,7 @@ const make = Effect.gen(function* () {
               yield* actionStore.finishAction(id, outcome).pipe(
                 Effect.tapError((error) =>
                   log.error(`db: closing action ${String(id)} failed: ${detail(error)}`, {
-                    sessionId: live.id,
+                    location: live.id,
                     agentId: live.agent,
                     cause: error,
                   }),
@@ -409,7 +409,7 @@ const make = Effect.gen(function* () {
           yield* sessionStore.endSession(live.id, "failed", detail(error)).pipe(
             Effect.catch((failure) =>
               log.error(`db: recording a failed start failed too: ${failure.message}`, {
-                sessionId: live.id,
+                location: live.id,
                 agentId: live.agent,
                 cause: failure,
               }),
@@ -456,7 +456,7 @@ const make = Effect.gen(function* () {
         ),
       );
     yield* log.info(`starting; iso ${body.iso}${disk === undefined ? "" : `, disk ${disk}`}`, {
-      sessionId: id,
+      location: id,
       agentId: agent,
     });
     const handle = yield* launch(live, body, display, automation).pipe(
@@ -480,7 +480,7 @@ const make = Effect.gen(function* () {
     yield* Ref.update(sessions, (map) => mapWith(map, id, running));
     yield* emit(running, { type: "session", status: "running" });
     yield* log.info(`running; started in ${yield* elapsed(started)}ms`, {
-      sessionId: id,
+      location: id,
       agentId: agent,
     });
     return id;
@@ -544,7 +544,7 @@ const make = Effect.gen(function* () {
       yield* actionStore.finishAction(id.value, result.value).pipe(
         Effect.catch((failure) =>
           log.error(`db: recording a failed screendump failed too: ${failure.message}`, {
-            sessionId: live.id,
+            location: live.id,
             agentId: live.agent,
             cause: failure,
           }),
@@ -573,7 +573,7 @@ const make = Effect.gen(function* () {
       yield* emit(live, { type: "image", id: stored.id, png: stored.png });
       yield* log.info(
         `image; ${String(png.length)} bytes in ${yield* elapsed(started)}ms; ${url}`,
-        { sessionId: live.id, agentId: live.agent },
+        { location: live.id, agentId: live.agent },
       );
       return { png, imageId };
     });
@@ -590,7 +590,7 @@ const make = Effect.gen(function* () {
         .pipe(Effect.mapError((cause) => internal(cause, live.id, live.agent))),
     );
     yield* log.info(`serial; ${String(data.length)} bytes in ${yield* elapsed(started)}ms`, {
-      sessionId: live.id,
+      location: live.id,
       agentId: live.agent,
     });
     return data;
@@ -618,7 +618,7 @@ const make = Effect.gen(function* () {
         .pipe(Effect.mapError((error) => exchangeFailed(error, live))),
     );
     return yield* log.info(`sent ${String(chords.length)} chords in ${yield* elapsed(started)}ms`, {
-      sessionId: live.id,
+      location: live.id,
       agentId: live.agent,
     });
   });
@@ -653,7 +653,7 @@ const make = Effect.gen(function* () {
     const pulses = clicks === undefined || clicks === 1 ? "" : ` ×${String(clicks)}`;
     return yield* log.info(
       `mouse ${String(x)} ${String(y)}${button === undefined ? "" : ` ${button}${pulses}`} in ${yield* elapsed(started)}ms`,
-      { sessionId: live.id, agentId: live.agent },
+      { location: live.id, agentId: live.agent },
     );
   });
 
@@ -672,7 +672,7 @@ const make = Effect.gen(function* () {
     yield* Ref.set(live.intent, Option.some({ span, message }));
     yield* emit(live, { type: "intent", state: "started", message });
     return yield* log.info(`intent start; ${message}`, {
-      sessionId: live.id,
+      location: live.id,
       agentId: live.agent,
     });
   });
@@ -682,7 +682,7 @@ const make = Effect.gen(function* () {
       return yield* badRequest("no active intent", live);
     }
     yield* finishOpenIntent(live, "completed");
-    return yield* log.info("intent end", { sessionId: live.id, agentId: live.agent });
+    return yield* log.info("intent end", { location: live.id, agentId: live.agent });
   });
 
   const readSerialText = (live: LiveSession): Effect.Effect<string> =>
@@ -693,7 +693,7 @@ const make = Effect.gen(function* () {
           ? Effect.succeed("")
           : log
               .error(`debug log: serial read failed: ${detail(error)}`, {
-                sessionId: live.id,
+                location: live.id,
                 agentId: live.agent,
                 cause: error,
               })
@@ -714,7 +714,7 @@ const make = Effect.gen(function* () {
       yield* debugLogs.saveDebugLog(live.id, captured).pipe(
         Effect.catch((error) =>
           log.error(`debug log save failed: ${detail(error)}`, {
-            sessionId: live.id,
+            location: live.id,
             agentId: live.agent,
             cause: error,
           }),
@@ -755,7 +755,7 @@ const make = Effect.gen(function* () {
       );
     // Colour is released in finishLiveSession; log first so the stopped line keeps it.
     yield* log.info(`stopped; ${finalStatus}${reason === undefined ? "" : `; ${reason}`}`, {
-      sessionId: live.id,
+      location: live.id,
       agentId: live.agent,
     });
     if (captured !== undefined) {
@@ -799,7 +799,7 @@ const make = Effect.gen(function* () {
     if (!(yield* Ref.get(openSessions)).has(live.id)) {
       Queue.endUnsafe(queue);
     }
-    yield* log.info("follower attached", { sessionId: id, agentId: live.agent });
+    yield* log.info("follower attached", { location: id, agentId: live.agent });
     Queue.offerUnsafe(queue, {
       type: "session",
       status: running === undefined ? "pending" : "running",
@@ -827,7 +827,7 @@ const make = Effect.gen(function* () {
       yield* sessionStore
         .endSession(live.id, "timed_out", SESSION_TIMEOUT_REASON)
         .pipe(
-          Effect.andThen(log.info(`timed out; ${SESSION_TIMEOUT_REASON}`, { sessionId: live.id })),
+          Effect.andThen(log.info(`timed out; ${SESSION_TIMEOUT_REASON}`, { location: live.id })),
           Effect.andThen(saveDebugLog(live, captured)),
           Effect.ensuring(finishLiveSession(live, "timed_out")),
         );
@@ -859,7 +859,7 @@ const make = Effect.gen(function* () {
       if (Exit.isFailure(exit)) {
         const error = Cause.squash(exit.cause);
         yield* log.error(`recording timeout failed: ${detail(error)}`, {
-          sessionId: live.id,
+          location: live.id,
           cause: error,
         });
       }
@@ -871,7 +871,7 @@ const make = Effect.gen(function* () {
   const tick = sweep.pipe(
     Effect.catchCause((cause) => {
       const error = Cause.squash(cause);
-      return log.error(`session timeout cleanup failed: ${detail(error)}`, { cause: error });
+      return log.error(`session timeout cleanup failed: ${detail(error)}`, { location: Log.Locations.server, cause: error });
     }),
     Effect.uninterruptible,
     guard.withPermitsIfAvailable(1),
@@ -894,13 +894,13 @@ const make = Effect.gen(function* () {
         yield* kill(live);
         yield* Ref.set(status, "aborted");
         yield* sessionStore.endSession(live.id, "aborted", reason);
-        yield* log.info(`stopped; aborted; ${reason}`, { sessionId: live.id });
+        yield* log.info(`stopped; aborted; ${reason}`, { location: live.id });
         yield* saveDebugLog(live, captured);
       }).pipe(
         Effect.catchCause((cause) => {
           const error = Cause.squash(cause);
           return log
-            .error(`shutdown: ${Render.errorDetail(error)}`, { sessionId: live.id, cause: error })
+            .error(`shutdown: ${Render.errorDetail(error)}`, { location: live.id, cause: error })
             .pipe(Effect.andThen(Effect.failCause(cause)));
         }),
         Effect.ensuring(Effect.flatMap(Ref.get(status), (ended) => finishLiveSession(live, ended))),
@@ -912,7 +912,7 @@ const make = Effect.gen(function* () {
     yield* Fiber.interrupt(sweeper);
     const draining = [...(yield* Ref.getAndSet(sessions, new Map())).values()];
     const reason = MutableRef.get(shutdown.reason);
-    yield* log.info(`proxy: shutting down; stopping ${String(draining.length)} sessions`);
+    yield* log.info(`proxy: shutting down; stopping ${String(draining.length)} sessions`, { location: Log.Locations.server });
     const exits = yield* Effect.forEach(draining, (live) => Effect.exit(drainOne(live, reason)), {
       concurrency: "unbounded",
     });

--- a/src/qemu/iso.ts
+++ b/src/qemu/iso.ts
@@ -23,6 +23,11 @@ import * as Qemu from "./qemu.ts";
 
 export type Who = { readonly sessionId: string; readonly agentId: string };
 
+const logWho = (who: Who): Log.Attribution => ({
+  location: who.sessionId,
+  agentId: who.agentId,
+});
+
 // The cache lives under this home and partial files carry this pid; tests point both elsewhere.
 export type HostFacts = { readonly homeDir: string; readonly pid: number };
 export const Host = Context.Reference<HostFacts>("@oligarchy/qemu/iso/Host", {
@@ -148,7 +153,7 @@ const make: Effect.Effect<
 
   const download = (url: string, file: string, target: string, who: Who) =>
     Effect.gen(function* () {
-      yield* log.info(`iso: downloading ${url} -> ${target}`, who);
+      yield* log.info(`iso: downloading ${url} -> ${target}`, logWho(who));
       // Renamed into place on success, so a file under the cached name is always a complete
       // download; the pid keeps two proxies on one machine out of each other's partials.
       const partial = `${target}.partial-${String(host.pid)}`;
@@ -171,7 +176,7 @@ const make: Effect.Effect<
         beatAt = now;
         // A failed beat only risks a duplicate download elsewhere, never this one.
         yield* updateManifest(file, "downloading").pipe(
-          Effect.catch((error) => log.warning(`iso: heartbeat failed: ${detail(error)}`, who)),
+          Effect.catch((error) => log.warning(`iso: heartbeat failed: ${detail(error)}`, logWho(who))),
         );
       });
       yield* Effect.gen(function* () {
@@ -188,7 +193,7 @@ const make: Effect.Effect<
         const published = yield* publishedSha256(url);
         yield* Option.match(published, {
           onNone: () =>
-            log.warning(`iso: no ${url}.sha256 published; skipping the checksum check`, who),
+            log.warning(`iso: no ${url}.sha256 published; skipping the checksum check`, logWho(who)),
           onSome: (expected) =>
             expected === digest
               ? Effect.void
@@ -197,7 +202,7 @@ const make: Effect.Effect<
                 }),
         });
         yield* fs.rename(partial, target);
-        yield* log.info(`iso: cached ${url} -> ${target}`, who);
+        yield* log.info(`iso: cached ${url} -> ${target}`, logWho(who));
       }).pipe(Effect.onError(() => Effect.ignore(fs.remove(partial, { force: true }))));
     });
 
@@ -217,7 +222,7 @@ const make: Effect.Effect<
           entry?.status === "downloading" && now - Date.parse(entry.heartbeatAt) < STALE_MS;
         if (live && !waitLogged) {
           waitLogged = true;
-          yield* log.info(`iso: another download of ${url} is running; waiting for it`, who);
+          yield* log.info(`iso: another download of ${url} is running; waiting for it`, logWho(who));
         }
         return live;
       });
@@ -225,7 +230,7 @@ const make: Effect.Effect<
       // The claim is checked before the file so a download that finishes between the two reads
       // is still seen here and not downloaded again.
       if (yield* fs.exists(target)) {
-        yield* log.info(`iso: cache hit ${url} -> ${target}`, who);
+        yield* log.info(`iso: cache hit ${url} -> ${target}`, logWho(who));
         yield* updateManifest(file, "cached");
         return target;
       }

--- a/src/qemu/iso.ts
+++ b/src/qemu/iso.ts
@@ -176,7 +176,9 @@ const make: Effect.Effect<
         beatAt = now;
         // A failed beat only risks a duplicate download elsewhere, never this one.
         yield* updateManifest(file, "downloading").pipe(
-          Effect.catch((error) => log.warning(`iso: heartbeat failed: ${detail(error)}`, logWho(who))),
+          Effect.catch((error) =>
+            log.warning(`iso: heartbeat failed: ${detail(error)}`, logWho(who)),
+          ),
         );
       });
       yield* Effect.gen(function* () {
@@ -193,7 +195,10 @@ const make: Effect.Effect<
         const published = yield* publishedSha256(url);
         yield* Option.match(published, {
           onNone: () =>
-            log.warning(`iso: no ${url}.sha256 published; skipping the checksum check`, logWho(who)),
+            log.warning(
+              `iso: no ${url}.sha256 published; skipping the checksum check`,
+              logWho(who),
+            ),
           onSome: (expected) =>
             expected === digest
               ? Effect.void
@@ -222,7 +227,10 @@ const make: Effect.Effect<
           entry?.status === "downloading" && now - Date.parse(entry.heartbeatAt) < STALE_MS;
         if (live && !waitLogged) {
           waitLogged = true;
-          yield* log.info(`iso: another download of ${url} is running; waiting for it`, logWho(who));
+          yield* log.info(
+            `iso: another download of ${url} is running; waiting for it`,
+            logWho(who),
+          );
         }
         return live;
       });

--- a/src/qemu/qemu.ts
+++ b/src/qemu/qemu.ts
@@ -110,7 +110,7 @@ const make: Effect.Effect<
       fs.remove(dir, { recursive: true, force: true }).pipe(
         Effect.catch((error) =>
           log.error(`qemu: removing ${dir} failed: ${Process.detail(error)}`, {
-            sessionId: id,
+            location: id,
             cause: error,
           }),
         ),

--- a/src/reverse-proxy/command.ts
+++ b/src/reverse-proxy/command.ts
@@ -54,7 +54,10 @@ export const makeReverseProxyCommand = <RServe>(server: ReverseProxyServer<RServ
         });
         return yield* startup.pipe(
           Effect.tapError((error) =>
-            log.fatal(`reverse proxy: ${detail(error)}`, { cause: error }),
+            log.fatal(`reverse proxy: ${detail(error)}`, {
+              location: Log.Locations.server,
+              cause: error,
+            }),
           ),
         );
       }),

--- a/src/reverse-proxy/main.ts
+++ b/src/reverse-proxy/main.ts
@@ -35,7 +35,9 @@ const ServerLive = (port: number) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const log = yield* Log.Log;
-      yield* log.info(`oligarchy reverse proxy listening on ${HOST}:${String(port)}`);
+      yield* log.info(`oligarchy reverse proxy listening on ${HOST}:${String(port)}`, {
+        location: Log.Locations.server,
+      });
     }),
   ).pipe(
     Layer.provide(

--- a/src/reverse-proxy/router.ts
+++ b/src/reverse-proxy/router.ts
@@ -82,7 +82,7 @@ const serverFailed = (
     Object.assign(
       { message, url },
       cause === undefined ? undefined : { cause },
-      who.sessionId === undefined ? undefined : { sessionId: who.sessionId },
+      who.location === undefined ? undefined : { sessionId: who.location },
       who.agentId === undefined ? undefined : { agentId: who.agentId },
     ),
   );
@@ -201,7 +201,7 @@ const make = Effect.gen(function* () {
   const register = Effect.fn("Router.register")(function* (url: string) {
     yield* probe(url, {});
     yield* store.addServer(url, SERVER_TYPE).pipe(Effect.mapError((cause) => internal(cause)));
-    yield* log.info(`server registered; ${url}`);
+    yield* log.info(`server registered; ${url}`, { location: Log.Locations.server });
   });
 
   const unregister = Effect.fn("Router.unregister")(function* (url: string) {
@@ -211,7 +211,7 @@ const make = Effect.gen(function* () {
     if (!removed) {
       return yield* Errors.NotFound.make({});
     }
-    return yield* log.info(`server removed; ${url}`);
+    return yield* log.info(`server removed; ${url}`, { location: Log.Locations.server });
   });
 
   const servers: Effect.Effect<Contract.Servers, Errors.Internal> = Effect.gen(function* () {
@@ -247,7 +247,7 @@ const make = Effect.gen(function* () {
       let chosen: { readonly url: string; readonly qemus: number } | undefined;
       for (const { url, result } of probed) {
         if (Result.isFailure(result)) {
-          yield* log.warning(`server skipped; ${result.failure.message}`, { agentId: agent });
+          yield* log.warning(`server skipped; ${result.failure.message}`, { location: Log.Locations.server, agentId: agent });
           continue;
         }
         if (chosen === undefined || result.success.qemus < chosen.qemus) {
@@ -283,7 +283,7 @@ const make = Effect.gen(function* () {
       ),
     );
     yield* store.routeSession(id, url).pipe(Effect.mapError((cause) => internal(cause, id, agent)));
-    yield* log.info(`routed; ${url}`, { sessionId: id, agentId: agent });
+    yield* log.info(`routed; ${url}`, { location: id, agentId: agent });
     return HttpServerResponse.text(text, { status: 200, headers });
   });
 
@@ -301,7 +301,7 @@ const make = Effect.gen(function* () {
     if (Option.isNone(route)) {
       return yield* Errors.unknownSession(id, agent);
     }
-    const who = agent === undefined ? { sessionId: id } : { sessionId: id, agentId: agent };
+    const who = agent === undefined ? { location: id } : { location: id, agentId: agent };
     const response = yield* send(route.value, request).pipe(
       Effect.mapError((error) => unreachable(route.value, error, who)),
     );

--- a/src/reverse-proxy/router.ts
+++ b/src/reverse-proxy/router.ts
@@ -247,7 +247,10 @@ const make = Effect.gen(function* () {
       let chosen: { readonly url: string; readonly qemus: number } | undefined;
       for (const { url, result } of probed) {
         if (Result.isFailure(result)) {
-          yield* log.warning(`server skipped; ${result.failure.message}`, { location: Log.Locations.server, agentId: agent });
+          yield* log.warning(`server skipped; ${result.failure.message}`, {
+            location: Log.Locations.server,
+            agentId: agent,
+          });
           continue;
         }
         if (chosen === undefined || result.success.qemus < chosen.qemus) {

--- a/test/automation/http.unit.test.ts
+++ b/test/automation/http.unit.test.ts
@@ -5,6 +5,7 @@ import { Effect, Layer, Redacted } from "effect";
 import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
 import { NodeHttpServer } from "@effect/platform-node";
 import * as Handlers from "../../src/automation/handlers.ts";
+import * as Log from "../../src/observability/log.ts";
 import * as FakeLog from "../support/log.ts";
 import * as Reporter from "../support/reporter.ts";
 import * as Stores from "../support/stores.ts";
@@ -30,6 +31,7 @@ const fixture = (): Fixture => ({
 const serve = (fixed: Fixture) =>
   HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
     Layer.provide(Layer.mergeAll(fixed.stores.layer, fixed.log.layer, SecretLive)),
+    Layer.provide(Layer.succeed(Log.ProcessAttribution)(Log.AutomationProcessAttribution)),
     Layer.provideMerge(NodeHttpServer.layerTest),
     Layer.provideMerge(fixed.reporter.layer),
   );
@@ -102,8 +104,8 @@ describe("POST /linear", () => {
         {
           level: "info",
           text: "linear webhook recorded",
-          sessionId: undefined,
-          agentId: undefined,
+          location: "automation",
+          agentId: "automation",
           skipSentry: false,
           cause: undefined,
         },
@@ -128,7 +130,7 @@ describe("POST /linear", () => {
         {
           level: "info",
           text: "linear webhook queued drive; Automation Needed",
-          sessionId: undefined,
+          location: "automation",
           agentId: "OLI-1063",
           skipSentry: false,
           cause: undefined,
@@ -224,16 +226,16 @@ describe("POST /linear refusals", () => {
           {
             level: "error",
             text: "POST /linear failed: unauthorized",
-            sessionId: undefined,
-            agentId: undefined,
+            location: "automation",
+            agentId: "automation",
             skipSentry: true,
             cause: undefined,
           },
           {
             level: "error",
             text: "POST /linear failed: unauthorized",
-            sessionId: undefined,
-            agentId: undefined,
+            location: "automation",
+            agentId: "automation",
             skipSentry: true,
             cause: undefined,
           },

--- a/test/ctrl/command.unit.test.ts
+++ b/test/ctrl/command.unit.test.ts
@@ -529,7 +529,7 @@ describe("test new", () => {
           {
             level: "info",
             text: `test ${run?.id} created; 2 tests; OLI-42, OLI-43`,
-            sessionId: undefined,
+            location: undefined,
             agentId: undefined,
             skipSentry: false,
             cause: undefined,
@@ -890,7 +890,7 @@ describe("test start", () => {
         {
           level: "info",
           text: `test result ${RESULT_ID}: running`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: undefined,
           skipSentry: false,
           cause: undefined,
@@ -1040,7 +1040,7 @@ describe("test-results", () => {
         {
           level: "info",
           text: `test result ${RESULT_ID}: passed`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: "agent-1",
           skipSentry: false,
           cause: undefined,
@@ -1100,7 +1100,7 @@ describe("test-results", () => {
           sessionId: SESSION_ID,
           reason: "installer hung",
         });
-        expect(h.log.lines.map((line) => [line.text, line.sessionId, line.agentId])).toEqual([
+        expect(h.log.lines.map((line) => [line.text, line.location, line.agentId])).toEqual([
           [`test result ${RESULT_ID}: failed; installer hung`, undefined, "agent-1"],
         ]);
         expect(h.log.acquired).toEqual(["agent-1"]);
@@ -1294,7 +1294,7 @@ describe("error-type new", () => {
         {
           level: "info",
           text: `error type created; ${bootHang.key}`,
-          sessionId: undefined,
+          location: undefined,
           agentId: undefined,
           skipSentry: false,
           cause: undefined,
@@ -1432,7 +1432,7 @@ const DIAGNOSE_PASSED = [
 const diagnoseLine = (text: string) => ({
   level: "info",
   text,
-  sessionId: SESSION_ID,
+  location: SESSION_ID,
   agentId: undefined,
   skipSentry: false,
   cause: undefined,
@@ -1788,8 +1788,8 @@ const seedInspect = (h: ReturnType<typeof harness>) => {
   h.stores.tests.definitions.push(install);
   h.stores.tests.runs.push(testRun);
   h.stores.logs.rows.push(
-    { text: "starting; iso omarchy.iso", level: "info", sessionId: SESSION_ID, agentId: "OLI-42" },
-    { text: "unrelated", level: "info", sessionId: OTHER_SESSION_ID, agentId: null },
+    { text: "starting; iso omarchy.iso", level: "info", location: SESSION_ID, agentId: "OLI-42" },
+    { text: "unrelated", level: "info", location: OTHER_SESSION_ID, agentId: null },
   );
   h.stores.actions.actions.push({
     id: 1,
@@ -1816,7 +1816,7 @@ describe("session inspect", () => {
       expect(printed).toHaveLength(1);
       expect(printed[0]).toMatchObject({
         text: "starting; iso omarchy.iso",
-        sessionId: SESSION_ID,
+        location: SESSION_ID,
       });
       expect(h.touched).toEqual(["database"]);
     }),
@@ -2557,7 +2557,7 @@ describe("SESSION_ID", () => {
         sessionId: SESSION_ID,
         model: MODEL,
       });
-      expect(h.log.lines.map((line) => [line.text, line.sessionId])).toEqual([
+      expect(h.log.lines.map((line) => [line.text, line.location])).toEqual([
         [`test result ${RESULT_ID}: running`, SESSION_ID],
       ]);
     }),
@@ -2584,7 +2584,7 @@ describe("SESSION_ID", () => {
       );
       expect(Exit.isSuccess(written)).toBe(true);
       expect(h.stores.diagnosis.diagnoses.map((row) => row.sessionId)).toEqual([SESSION_ID]);
-      expect(h.log.lines.map((line) => line.sessionId)).toEqual([SESSION_ID]);
+      expect(h.log.lines.map((line) => line.location)).toEqual([SESSION_ID]);
     }),
   );
 

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -250,7 +250,7 @@ describe("automation startup refusals", () => {
       const { code } = await process.exited;
       expect(code).toBe(1);
       const fatal = lines(process.stdout()).find((line) =>
-        line.startsWith("[global] fatal: automation: "),
+        line.startsWith("[automation] automation: fatal: automation: "),
       );
       expect(fatal, process.stdout()).toBeDefined();
       expect(fatal).toContain("database unreachable");
@@ -270,7 +270,7 @@ describeWithDatabase("automation startup refusals with a database", () => {
         const { code } = await process.exited;
         expect(code).toBe(1);
         const fatal = lines(process.stdout()).find((line) =>
-          line.startsWith("[global] fatal: automation: "),
+          line.startsWith("[automation] automation: fatal: automation: "),
         );
         expect(fatal, process.stdout()).toBeDefined();
         expect(fatal).toContain("EADDRINUSE");
@@ -293,7 +293,7 @@ describeServing("automation serving", () => {
     try {
       await process.waitFor(/oligarchy automation listening/);
       expect(lines(process.stdout())).toContain(
-        `[global] oligarchy automation listening on 127.0.0.1:${String(port)}`,
+        `[automation] automation: oligarchy automation listening on 127.0.0.1:${String(port)}`,
       );
       expect(existsSync(record)).toBe(false);
 
@@ -404,10 +404,10 @@ describeServing("automation serving", () => {
     const { code } = await process.exited;
     expect(code, process.stdout()).toBe(0);
     const output = lines(process.stdout());
-    expect(output).toContain("[global] error: POST /linear failed: unauthorized");
-    expect(output).toContain("[global] linear webhook recorded");
-    expect(output).toContain("[global] linear webhook queued drive; Automation Needed");
-    expect(output).toContain("[global] linear webhook queued diagnose; Needs Review");
+    expect(output).toContain("[automation] automation: error: POST /linear failed: unauthorized");
+    expect(output).toContain("[automation] automation: linear webhook recorded");
+    expect(output).toContain("[OLI-1063] automation: linear webhook queued drive; Automation Needed");
+    expect(output).toContain("[OLI-1063] automation: linear webhook queued diagnose; Needs Review");
     expect(output.some((line) => line.includes("/automate"))).toBe(false);
     expect(output.some((line) => line.includes("/start"))).toBe(false);
     expect(process.stderr()).toBe("");

--- a/test/integration/automation.integration.test.ts
+++ b/test/integration/automation.integration.test.ts
@@ -406,7 +406,9 @@ describeServing("automation serving", () => {
     const output = lines(process.stdout());
     expect(output).toContain("[automation] automation: error: POST /linear failed: unauthorized");
     expect(output).toContain("[automation] automation: linear webhook recorded");
-    expect(output).toContain("[OLI-1063] automation: linear webhook queued drive; Automation Needed");
+    expect(output).toContain(
+      "[OLI-1063] automation: linear webhook queued drive; Automation Needed",
+    );
     expect(output).toContain("[OLI-1063] automation: linear webhook queued diagnose; Needs Review");
     expect(output.some((line) => line.includes("/automate"))).toBe(false);
     expect(output.some((line) => line.includes("/start"))).toBe(false);

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -332,8 +332,18 @@ Postgres.describeWithDatabase("database", () => {
       Effect.gen(function* () {
         const logs = yield* Logs.LogStore;
         const sessionId = uuid();
-        yield* logs.insertLog({ text: "first", level: "info", location: sessionId, agentId: "OLI-1" });
-        yield* logs.insertLog({ text: "second", level: "error", location: sessionId, agentId: null });
+        yield* logs.insertLog({
+          text: "first",
+          level: "info",
+          location: sessionId,
+          agentId: "OLI-1",
+        });
+        yield* logs.insertLog({
+          text: "second",
+          level: "error",
+          location: sessionId,
+          agentId: null,
+        });
         yield* logs.insertLog({
           text: "global",
           level: "warning",

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -332,14 +332,29 @@ Postgres.describeWithDatabase("database", () => {
       Effect.gen(function* () {
         const logs = yield* Logs.LogStore;
         const sessionId = uuid();
-        yield* logs.insertLog({ text: "first", level: "info", sessionId, agentId: "OLI-1" });
-        yield* logs.insertLog({ text: "second", level: "error", sessionId, agentId: null });
-        yield* logs.insertLog({ text: "global", level: "warning", sessionId: null, agentId: null });
+        yield* logs.insertLog({ text: "first", level: "info", location: sessionId, agentId: "OLI-1" });
+        yield* logs.insertLog({ text: "second", level: "error", location: sessionId, agentId: null });
+        yield* logs.insertLog({
+          text: "global",
+          level: "warning",
+          location: "server",
+          agentId: null,
+        });
+        yield* logs.insertLog({
+          text: "queue claimed",
+          level: "info",
+          location: "automation",
+          agentId: "automation",
+        });
         const rows = yield* logs.listLogs(sessionId);
         expect(rows.map((row) => row.text)).toEqual(["first", "second"]);
-        expect(rows[0]).toMatchObject({ level: "info", sessionId, agentId: "OLI-1" });
+        expect(rows[0]).toMatchObject({ level: "info", location: sessionId, agentId: "OLI-1" });
         expect(rows[1]).toMatchObject({ level: "error", agentId: null });
         expect(yield* logs.listLogs(uuid())).toEqual([]);
+        expect((yield* logs.listLogs("server")).map((row) => row.text)).toEqual(["global"]);
+        expect((yield* logs.listLogs("automation")).map((row) => row.text)).toEqual([
+          "queue claimed",
+        ]);
       }),
     );
 
@@ -357,13 +372,13 @@ Postgres.describeWithDatabase("database", () => {
         yield* logs.insertLog({
           text: "running; started in 12ms",
           level: "info",
-          sessionId,
+          location: sessionId,
           agentId: "OLI-1",
         });
         yield* logs.insertLog({
           text: "GET /image failed: qemu: closed",
           level: "error",
-          sessionId,
+          location: sessionId,
           agentId: "OLI-1",
         });
         yield* actions.startAction({

--- a/test/integration/proxy.integration.test.ts
+++ b/test/integration/proxy.integration.test.ts
@@ -254,7 +254,7 @@ describe("proxy startup refusals", () => {
         expect(code).toBe(1);
         const output = lines(proxy.stdout());
         const fatal = output.findIndex(
-          (line) => line === "[global] fatal: proxy: missing host requirements:",
+          (line) => line === "[global] server: fatal: proxy: missing host requirements:",
         );
         expect(fatal, proxy.stdout()).toBeGreaterThanOrEqual(0);
         expect(output.slice(fatal + 1).length).toBeGreaterThan(0);
@@ -270,7 +270,7 @@ describe("proxy startup refusals", () => {
       const { code } = await proxy.exited;
       expect(code).toBe(1);
       const fatal = lines(proxy.stdout()).find((line) =>
-        line.startsWith("[global] fatal: proxy: database unreachable:"),
+        line.startsWith("[global] server: fatal: proxy: database unreachable:"),
       );
       expect(fatal, proxy.stdout()).toBeDefined();
       expect(fatal).toContain("ECONNREFUSED");
@@ -288,7 +288,7 @@ describe("proxy startup refusals", () => {
         const { code } = await proxy.exited;
         expect(code).toBe(1);
         const fatal = lines(proxy.stdout()).find((line) =>
-          line.startsWith("[global] fatal: proxy: "),
+          line.startsWith("[global] server: fatal: proxy: "),
         );
         expect(fatal, proxy.stdout()).toBeDefined();
         expect(fatal).toContain("EADDRINUSE");
@@ -355,9 +355,9 @@ describe("proxy serving", () => {
       const { code } = await proxy.exited;
       expect(code, proxy.stdout()).toBe(0);
       const output = lines(proxy.stdout());
-      expect(output).toContain("[global] proxy: shutting down; stopping 0 sessions");
-      expect(output).toContain("[global] error: POST /send-keys failed: unauthorized");
-      expect(output).toContain("[global] error: GET /stats failed: unauthorized");
+      expect(output).toContain("[global] server: proxy: shutting down; stopping 0 sessions");
+      expect(output).toContain("[global] server: error: POST /send-keys failed: unauthorized");
+      expect(output).toContain("[global] server: error: GET /stats failed: unauthorized");
       expect(output.some((line) => line.includes("GET /nope"))).toBe(false);
       expect(proxy.stderr()).toBe("");
 
@@ -419,7 +419,7 @@ describe("proxy serving", () => {
     () =>
       serving(
         [],
-        (port) => `[global] oligarchy proxy listening on 127.0.0.1:${String(port)}; display none`,
+        (port) => `[global] server: oligarchy proxy listening on 127.0.0.1:${String(port)}; display none`,
         "SIGINT",
       ),
     120_000,
@@ -431,7 +431,7 @@ describe("proxy serving", () => {
       serving(
         ["--automation"],
         (port) =>
-          `[global] oligarchy proxy listening on 127.0.0.1:${String(port)}; display none; automation`,
+          `[global] server: oligarchy proxy listening on 127.0.0.1:${String(port)}; display none; automation`,
         "SIGTERM",
       ),
     120_000,
@@ -458,7 +458,7 @@ describe("proxy serving", () => {
         const row = yield* Effect.gen(function* () {
           yield* Effect.promise(() => proxy.waitFor(/oligarchy proxy listening/));
           expect(lines(proxy.stdout())).toContain(
-            `[global] oligarchy proxy listening on 127.0.0.1:${String(port)}; display none; automation; announcing ${url}`,
+            `[global] server: oligarchy proxy listening on 127.0.0.1:${String(port)}; display none; automation; announcing ${url}`,
           );
           // The first heartbeat is written right after the listen line; the insert takes a moment.
           return yield* announced(url).pipe(

--- a/test/integration/proxy.integration.test.ts
+++ b/test/integration/proxy.integration.test.ts
@@ -419,7 +419,8 @@ describe("proxy serving", () => {
     () =>
       serving(
         [],
-        (port) => `[global] server: oligarchy proxy listening on 127.0.0.1:${String(port)}; display none`,
+        (port) =>
+          `[global] server: oligarchy proxy listening on 127.0.0.1:${String(port)}; display none`,
         "SIGINT",
       ),
     120_000,

--- a/test/integration/reverse-proxy.integration.test.ts
+++ b/test/integration/reverse-proxy.integration.test.ts
@@ -182,7 +182,7 @@ describe("reverse proxy startup refusals", () => {
       const { code } = await process.exited;
       expect(code).toBe(1);
       const fatal = lines(process.stdout()).find((line) =>
-        line.startsWith("[global] fatal: reverse proxy: database unreachable:"),
+        line.startsWith("[global] server: fatal: reverse proxy: database unreachable:"),
       );
       expect(fatal, process.stdout()).toBeDefined();
       expect(fatal).toContain("ECONNREFUSED");
@@ -200,7 +200,7 @@ describe("reverse proxy startup refusals", () => {
         const { code } = await process.exited;
         expect(code).toBe(1);
         const fatal = lines(process.stdout()).find((line) =>
-          line.startsWith("[global] fatal: reverse proxy: "),
+          line.startsWith("[global] server: fatal: reverse proxy: "),
         );
         expect(fatal, process.stdout()).toBeDefined();
         expect(fatal).toContain("EADDRINUSE");
@@ -230,7 +230,7 @@ describe("reverse proxy serving", () => {
     try {
       await process.waitFor(/oligarchy reverse proxy listening/);
       expect(lines(process.stdout())).toContain(
-        `[global] oligarchy reverse proxy listening on 127.0.0.1:${String(port)}`,
+        `[global] server: oligarchy reverse proxy listening on 127.0.0.1:${String(port)}`,
       );
 
       const servers = await request(port, "GET", "/servers", {
@@ -281,12 +281,12 @@ describe("reverse proxy serving", () => {
     const { code } = await process.exited;
     expect(code, process.stdout()).toBe(0);
     const output = lines(process.stdout());
-    expect(output).toContain("[global] error: POST /send-keys failed: unauthorized");
-    expect(output).toContain("[OLI-1] error: POST /start failed: no server registered");
+    expect(output).toContain("[global] server: error: POST /send-keys failed: unauthorized");
+    expect(output).toContain("[OLI-1] server: error: POST /start failed: no server registered");
     expect(
       output.some((line) =>
         line.startsWith(
-          "[global] error: POST /servers failed: server http://127.0.0.1:1 unreachable:",
+          "[global] server: error: POST /servers failed: server http://127.0.0.1:1 unreachable:",
         ),
       ),
     ).toBe(true);

--- a/test/observability/log.unit.test.ts
+++ b/test/observability/log.unit.test.ts
@@ -28,7 +28,7 @@ describe("Log rows", () => {
         const worker = (agentId: string) =>
           Effect.gen(function* () {
             for (const n of [1, 2, 3]) {
-              yield* log.info(`${agentId} line ${n}`, { agentId, sessionId: SESSION_ID });
+              yield* log.info(`${agentId} line ${n}`, { agentId, location: SESSION_ID });
               yield* Effect.yieldNow;
             }
           });
@@ -45,7 +45,7 @@ describe("Log rows", () => {
       expect(store.rows[0]).toEqual({
         text: "A line 1",
         level: "info",
-        sessionId: SESSION_ID,
+        location: SESSION_ID,
         agentId: "A",
       });
       expect(reporter.reported).toHaveLength(0);
@@ -64,7 +64,7 @@ describe("Log rows", () => {
         {
           text: "follower dropped; 64 events behind",
           level: "warning",
-          sessionId: null,
+          location: null,
           agentId: null,
         },
       ]);
@@ -176,7 +176,7 @@ describe("Log Sentry policy", () => {
       yield* Effect.gen(function* () {
         const log = yield* Log.Log;
         yield* log.error("stop cleanup failed: connect ECONNREFUSED", {
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           cause,
         });
@@ -188,7 +188,7 @@ describe("Log Sentry policy", () => {
       expect(report?.error.cause).toMatchObject({ message: "connect ECONNREFUSED" });
       expect(report?.severity).toBe("Error");
       expect(report?.annotations).toEqual({
-        session_id: SESSION_ID,
+        location: SESSION_ID,
         agent_id: AGENT_ID,
         log: "stop cleanup failed: connect ECONNREFUSED",
       });
@@ -278,11 +278,11 @@ describe("Log Sentry policy", () => {
       const reporter = Reporter.collect();
       yield* Effect.gen(function* () {
         const log = yield* Log.Log;
-        yield* log.error("timeout cleanup failed: boom", { sessionId: SESSION_ID });
+        yield* log.error("timeout cleanup failed: boom", { location: SESSION_ID });
       }).pipe(Effect.provide(Log.Log.layerStdout.pipe(Layer.provide(reporter.layer))));
       expect(reporter.reported[0]?.severity).toBe("Error");
       expect(reporter.reported[0]?.annotations).toEqual({
-        session_id: SESSION_ID,
+        location: SESSION_ID,
         log: "timeout cleanup failed: boom",
       });
     }),

--- a/test/observability/render.unit.test.ts
+++ b/test/observability/render.unit.test.ts
@@ -76,13 +76,13 @@ describe("renderFailure", () => {
 });
 
 describe("renderLogLine", () => {
-  it("colors only the ticket and renders the bare session id in gray", () => {
+  it("colors only the ticket and renders the bare location in gray", () => {
     expect(
       Render.renderLogLine(
         {
           text: "sent 9 chords in 1546ms",
           level: "info",
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           color: LOVE,
         },
@@ -121,7 +121,7 @@ describe("renderLogLine", () => {
         {
           text: "sent 9 chords in 1546ms",
           level: "info",
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           color: LOVE,
         },

--- a/test/observability/sentry.unit.test.ts
+++ b/test/observability/sentry.unit.test.ts
@@ -319,12 +319,12 @@ describe("reporter", () => {
       const captured = capture();
       yield* ErrorReporter.report(
         Cause.fail(Errors.QemuStartError.make({ message: "qemu: handshake timeout" })),
-      ).pipe(Effect.annotateLogs({ session_id: SESSION_ID, agent_id: AGENT_ID, log: "starting" }));
+      ).pipe(Effect.annotateLogs({ location: SESSION_ID, agent_id: AGENT_ID, log: "starting" }));
       const events = yield* captured.events;
       expect(events).toHaveLength(1);
-      expect(events[0]?.tags).toEqual({ session_id: SESSION_ID, agent_id: AGENT_ID });
+      expect(events[0]?.tags).toEqual({ location: SESSION_ID, agent_id: AGENT_ID });
       expect(events[0]?.extra).toEqual({
-        session_id: SESSION_ID,
+        location: SESSION_ID,
         agent_id: AGENT_ID,
         log: "starting",
       });

--- a/test/proxy/command.unit.test.ts
+++ b/test/proxy/command.unit.test.ts
@@ -251,7 +251,7 @@ describe("proxy command startup failures", () => {
         {
           level: "fatal",
           text: `proxy: missing host requirements:\n${missing.join("\n")}`,
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: false,
           cause: error,
@@ -276,7 +276,7 @@ describe("proxy command startup failures", () => {
         {
           level: "fatal",
           text: "proxy: database unreachable: connect ECONNREFUSED 127.0.0.1:1",
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: false,
           cause: error,

--- a/test/proxy/heartbeat.unit.test.ts
+++ b/test/proxy/heartbeat.unit.test.ts
@@ -144,7 +144,7 @@ describe("heartbeat unhappy path", () => {
           {
             level: "error",
             text: "heartbeat failed: connect ECONNREFUSED 127.0.0.1:5432",
-            sessionId: undefined,
+            location: "server",
             agentId: undefined,
             skipSentry: false,
             cause: refused,
@@ -200,7 +200,7 @@ describe("heartbeat unhappy path", () => {
           {
             level: "error",
             text: "unannounce failed: connect ECONNREFUSED 127.0.0.1:5432",
-            sessionId: undefined,
+            location: "server",
             agentId: undefined,
             skipSentry: false,
             cause: refusedDelete,

--- a/test/proxy/http.unit.test.ts
+++ b/test/proxy/http.unit.test.ts
@@ -352,7 +352,7 @@ describe("authentication", () => {
         sessionsRoutes.map(([method, path]) => ({
           level: "error",
           text: `${method} ${path} failed: unauthorized`,
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: true,
           cause: undefined,
@@ -452,7 +452,7 @@ describe("request decoding", () => {
         {
           level: "error",
           text: "POST /start failed: Expected a valid JSON body",
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: true,
           cause: undefined,
@@ -527,7 +527,7 @@ describe("request decoding", () => {
         {
           level: "error",
           text: `GET /serial?id=&agent=${AGENT_ID} failed: session id is required`,
-          sessionId: undefined,
+          location: "server",
           agentId: AGENT_ID,
           skipSentry: true,
           cause: undefined,
@@ -571,7 +571,7 @@ describe("Sessions failures", () => {
         {
           level: "error",
           text: `GET /serial?id=${unknown}&agent=${AGENT_ID} failed: unknown session "${unknown}"`,
-          sessionId: unknown,
+          location: unknown,
           agentId: AGENT_ID,
           skipSentry: true,
           cause: undefined,
@@ -579,7 +579,7 @@ describe("Sessions failures", () => {
         {
           level: "error",
           text: 'POST /stop failed: unknown session "garbage"',
-          sessionId: undefined,
+          location: "server",
           agentId: AGENT_ID,
           skipSentry: true,
           cause: undefined,
@@ -587,7 +587,7 @@ describe("Sessions failures", () => {
         {
           level: "error",
           text: `GET /follow?id=${unknown} failed: unknown session "${unknown}"`,
-          sessionId: unknown,
+          location: unknown,
           agentId: undefined,
           skipSentry: true,
           cause: undefined,
@@ -620,7 +620,7 @@ describe("Sessions failures", () => {
         {
           level: "error",
           text: `POST /send-keys failed: agent "${OTHER_AGENT_ID}" does not own session "${SESSION_ID}"`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: OTHER_AGENT_ID,
           skipSentry: true,
           cause: undefined,
@@ -650,7 +650,7 @@ describe("Sessions failures", () => {
         expect(raw.status).toBe(409);
         expect(yield* raw.json).toEqual({ error: conflict.message });
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.log.lines.map((line) => [line.text, line.sessionId, line.skipSentry])).toEqual([
+      expect(fixed.log.lines.map((line) => [line.text, line.location, line.skipSentry])).toEqual([
         [`GET /follow?id=${SESSION_ID} failed: ${conflict.message}`, SESSION_ID, true],
         [`GET /follow?id=${SESSION_ID} failed: ${conflict.message}`, SESSION_ID, true],
       ]);
@@ -720,7 +720,7 @@ describe("Sessions failures", () => {
         {
           level: "error",
           text: "POST /send-mouse failed: mouse: x and y must be in 0..1",
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           skipSentry: true,
           cause: undefined,
@@ -728,7 +728,7 @@ describe("Sessions failures", () => {
         {
           level: "error",
           text: "POST /intent/end failed: no active intent",
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           skipSentry: true,
           cause: undefined,
@@ -774,7 +774,7 @@ describe("Sessions failures", () => {
         {
           level: "error",
           text: `GET /image?id=${SESSION_ID}&agent=${AGENT_ID} failed: qemu: screendump timed out`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           skipSentry: false,
           cause: timeout,
@@ -782,7 +782,7 @@ describe("Sessions failures", () => {
         {
           level: "error",
           text: `GET /image?id=${SESSION_ID}&agent=${AGENT_ID} failed: qemu: screendump timed out`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           skipSentry: false,
           cause: timeout,
@@ -828,7 +828,7 @@ describe("Sessions failures", () => {
         {
           level: "error",
           text: "POST /start failed: qemu: disk not found: /tmp/nope.qcow2",
-          sessionId: STARTED_ID,
+          location: STARTED_ID,
           agentId: AGENT_ID,
           skipSentry: false,
           cause: undefined,
@@ -875,7 +875,7 @@ describe("Sessions failures", () => {
         expect(fixed.log.lines[0]).toEqual({
           level: "error",
           text: "POST /stop failed: connect ECONNREFUSED 127.0.0.1:5432",
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           skipSentry: false,
           cause: failure,
@@ -963,7 +963,7 @@ describe("defects", () => {
       expect(fixed.log.lines[0]).toEqual({
         level: "error",
         text: `GET /stats failed: ${Cause.pretty(Cause.die(defect))}`,
-        sessionId: undefined,
+        location: "server",
         agentId: undefined,
         skipSentry: false,
         cause: defect,
@@ -1016,7 +1016,7 @@ describe("defects", () => {
       );
       expect(withSession?.severity).toBe("Error");
       expect(withSession?.annotations).toMatchObject({
-        session_id: SESSION_ID,
+        location: SESSION_ID,
         agent_id: AGENT_ID,
       });
     }),

--- a/test/proxy/sessions.unit.test.ts
+++ b/test/proxy/sessions.unit.test.ts
@@ -251,7 +251,7 @@ describe("start", () => {
               `starting; iso ${URL_ISO}, disk ${DISK}`,
               "running; started in 0ms",
             ]);
-            expect(h.log.lines[0]).toMatchObject({ level: "info", sessionId: id, agentId: AGENT });
+            expect(h.log.lines[0]).toMatchObject({ level: "info", location: id, agentId: AGENT });
             const span = spanNamed(h, AGENT);
             expect(span?.attributes.get("session_id")).toBe(id);
             expect(span?.attributes.get("agent_id")).toBe(AGENT);
@@ -557,7 +557,7 @@ describe("image", () => {
           expect(line(h, "image;")).toMatchObject({
             level: "info",
             text: `image; ${String(FakeQemu.PNG.length)} bytes in 0ms; ${url}`,
-            sessionId: id,
+            location: id,
             agentId: AGENT,
           });
         }),
@@ -701,7 +701,7 @@ describe("serial", () => {
           expect(yield* sessions.serial(live)).toBe(SERIAL);
           expect(line(h, "serial;")).toMatchObject({
             text: `serial; ${String(SERIAL.length)} bytes in 0ms`,
-            sessionId: id,
+            location: id,
             agentId: AGENT,
           });
           expect(yield* collect(events, 3)).toEqual([
@@ -990,7 +990,7 @@ describe("intents", () => {
           );
           expect(line(h, "intent start")).toMatchObject({
             text: "intent start; open a terminal",
-            sessionId: id,
+            location: id,
             agentId: AGENT,
           });
           // Actions started under an intent hang off its span.
@@ -1030,7 +1030,7 @@ describe("intents", () => {
           expect(yield* Ref.get(live.intent)).toEqual(Option.none());
           expect(line(h, "intent end")).toMatchObject({
             text: "intent end",
-            sessionId: id,
+            location: id,
             agentId: AGENT,
           });
         }),
@@ -1121,7 +1121,7 @@ describe("stop", () => {
           });
           expect(line(h, "stopped")).toMatchObject({
             text: "stopped; succeeded; installed",
-            sessionId: id,
+            location: id,
             agentId: AGENT,
           });
           expect(endedWith(spanNamed(h, AGENT))).toBe("ok");
@@ -1142,7 +1142,7 @@ describe("stop", () => {
           expect(logged).toMatchObject({
             level: "error",
             text: "stop cleanup failed: EACCES: rm failed",
-            sessionId: id,
+            location: id,
             agentId: AGENT,
             skipSentry: false,
           });
@@ -1413,7 +1413,7 @@ describe("stop", () => {
           expect(h.debugLogs.saves).toEqual([{ sessionId: id, serial: "", qemu: "" }]);
           expect(line(h, "debug log: serial read failed:")).toMatchObject({
             level: "error",
-            sessionId: id,
+            location: id,
             agentId: AGENT,
             skipSentry: false,
           });
@@ -1439,7 +1439,7 @@ describe("stop", () => {
           expect(line(h, "debug log save failed:")).toMatchObject({
             level: "error",
             text: "debug log save failed: connect ECONNREFUSED",
-            sessionId: id,
+            location: id,
             agentId: AGENT,
             skipSentry: false,
           });
@@ -1471,7 +1471,7 @@ describe("follow", () => {
             expect(Domain.isSessionId(id)).toBe(true);
             const early = yield* sessions.follow(id);
             expect(yield* collect(early, 1)).toEqual([{ type: "session", status: "pending" }]);
-            expect(line(h, "follower attached")).toMatchObject({ sessionId: id, agentId: AGENT });
+            expect(line(h, "follower attached")).toMatchObject({ location: id, agentId: AGENT });
             yield* Deferred.succeed(gate, undefined);
             expect(yield* Fiber.join(booting)).toBe(id);
             const live = yield* sessions.lookup(id, AGENT);
@@ -1616,7 +1616,7 @@ describe("follow", () => {
           expect(line(h, "follower dropped")).toMatchObject({
             level: "warning",
             text: "follower dropped; 64 events behind",
-            sessionId: id,
+            location: id,
             agentId: AGENT,
           });
           expect(
@@ -1693,7 +1693,7 @@ describe("timeouts", () => {
           expect(line(h, "timed out")).toMatchObject({
             level: "info",
             text: "timed out; no command received for 10 minutes",
-            sessionId: id,
+            location: id,
             agentId: undefined,
           });
           expect(endedWith(spanNamed(h, AGENT))).toBe("deadline_exceeded");
@@ -1737,7 +1737,7 @@ describe("timeouts", () => {
           expect(line(h, "timeout cleanup failed")).toMatchObject({
             level: "error",
             text: "timeout cleanup failed: rm failed",
-            sessionId: id,
+            location: id,
             agentId: undefined,
           });
           expect(h.sessions.sessions[0]?.status).toBe("timed_out");
@@ -1766,7 +1766,7 @@ describe("timeouts", () => {
           expect(logged).toMatchObject({
             level: "error",
             text: "recording timeout failed: connect ECONNREFUSED 127.0.0.1:5432",
-            sessionId: id,
+            location: id,
           });
           expect(logged?.cause).toMatchObject({ _tag: "DatabaseError" });
           expect(line(h, "timed out")).toBeUndefined();
@@ -1859,14 +1859,14 @@ describe("drain", () => {
       expect(drainLines[0]).toMatchObject({
         level: "info",
         text: "proxy: shutting down; stopping 2 sessions",
-        sessionId: undefined,
+        location: "server",
         agentId: undefined,
       });
       expect(drainLines.slice(1).map((entry) => entry.text)).toEqual([
         "stopped; aborted; proxy shutdown",
         "stopped; aborted; proxy shutdown",
       ]);
-      expect(new Set(drainLines.slice(1).map((entry) => entry.sessionId))).toEqual(
+      expect(new Set(drainLines.slice(1).map((entry) => entry.location))).toEqual(
         new Set(drained.ids),
       );
       expect(drainLines.slice(1).every((entry) => entry.agentId === undefined)).toBe(true);
@@ -1947,8 +1947,8 @@ describe("drain", () => {
       expect(MutableRef.get(shutdown.failed)).toBe(true);
       const logged = h.log.lines.filter((entry) => entry.text.startsWith("shutdown:"));
       expect(logged).toMatchObject([
-        { level: "error", text: "shutdown: Failed query: endSession", sessionId: ids[0] },
-        { level: "error", text: "shutdown: rm failed", sessionId: ids[1] },
+        { level: "error", text: "shutdown: Failed query: endSession", location: ids[0] },
+        { level: "error", text: "shutdown: rm failed", location: ids[1] },
       ]);
       expect(logged[0]?.cause).toMatchObject({ _tag: "DatabaseError" });
       expect(logged[1]?.cause).toBeInstanceOf(Error);

--- a/test/qemu/iso.unit.test.ts
+++ b/test/qemu/iso.unit.test.ts
@@ -239,7 +239,7 @@ describe("getIso with a url: cache", () => {
           {
             level: "info",
             text: `iso: cache hit ${URL_ISO} -> ${cached}`,
-            sessionId: WHO.sessionId,
+            location: WHO.sessionId,
             agentId: WHO.agentId,
             skipSentry: false,
             cause: undefined,

--- a/test/reverse-proxy/command.unit.test.ts
+++ b/test/reverse-proxy/command.unit.test.ts
@@ -167,7 +167,7 @@ describe("reverse proxy command startup failures", () => {
         {
           level: "fatal",
           text: "reverse proxy: database unreachable: connect ECONNREFUSED 127.0.0.1:1",
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: false,
           cause: error,

--- a/test/reverse-proxy/http.unit.test.ts
+++ b/test/reverse-proxy/http.unit.test.ts
@@ -147,7 +147,7 @@ describe("server registration", () => {
           {
             level: "info",
             text: `server registered; ${SERVER_A}`,
-            sessionId: undefined,
+            location: "server",
             agentId: undefined,
             skipSentry: false,
             cause: undefined,
@@ -200,7 +200,7 @@ describe("server registration", () => {
         {
           level: "info",
           text: `server removed; ${SERVER_A}`,
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: false,
           cause: undefined,
@@ -228,7 +228,7 @@ describe("server registration", () => {
         {
           level: "error",
           text: "DELETE /servers failed: not found",
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: true,
           cause: undefined,
@@ -236,7 +236,7 @@ describe("server registration", () => {
         {
           level: "error",
           text: "DELETE /servers failed: not found",
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: true,
           cause: undefined,
@@ -342,7 +342,7 @@ describe("registration refusals", () => {
         expect(fixed.log.lines[0]).toMatchObject({
           level: "error",
           text: `POST /servers failed: server ${SERVER_A} unreachable: connect ECONNREFUSED 10.0.0.5:42069`,
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: false,
         });
@@ -468,7 +468,7 @@ describe("registration refusals", () => {
         {
           level: "error",
           text: "POST /servers failed: connect ECONNREFUSED 127.0.0.1:5432",
-          sessionId: undefined,
+          location: "server",
           agentId: undefined,
           skipSentry: false,
           cause: failure,
@@ -523,7 +523,7 @@ describe("placement", () => {
           {
             level: "info",
             text: `routed; ${SERVER_B}`,
-            sessionId: STARTED_ID,
+            location: STARTED_ID,
             agentId: AGENT_ID,
             skipSentry: false,
             cause: undefined,
@@ -563,7 +563,7 @@ describe("placement", () => {
         {
           level: "warning",
           text: `server skipped; server ${SERVER_A} unreachable: connect ECONNREFUSED 10.0.0.5:42069`,
-          sessionId: undefined,
+          location: "server",
           agentId: AGENT_ID,
           skipSentry: false,
           cause: undefined,
@@ -571,7 +571,7 @@ describe("placement", () => {
         {
           level: "info",
           text: `routed; ${SERVER_B}`,
-          sessionId: STARTED_ID,
+          location: STARTED_ID,
           agentId: AGENT_ID,
           skipSentry: false,
           cause: undefined,
@@ -601,7 +601,7 @@ describe("placement", () => {
         {
           level: "error",
           text: "POST /start failed: no server registered",
-          sessionId: undefined,
+          location: "server",
           agentId: AGENT_ID,
           skipSentry: false,
           cause: undefined,
@@ -609,7 +609,7 @@ describe("placement", () => {
         {
           level: "error",
           text: "POST /start failed: no server registered",
-          sessionId: undefined,
+          location: "server",
           agentId: AGENT_ID,
           skipSentry: false,
           cause: undefined,
@@ -720,7 +720,7 @@ describe("placement", () => {
       expect(fixed.log.lines[0]).toMatchObject({
         level: "error",
         text: `POST /start failed: server ${SERVER_A} unreachable: connect ECONNREFUSED 10.0.0.5:42069`,
-        sessionId: undefined,
+        location: "server",
         agentId: AGENT_ID,
         skipSentry: false,
       });
@@ -751,7 +751,7 @@ describe("placement", () => {
           {
             level: "error",
             text: "POST /start failed: connect ECONNREFUSED 127.0.0.1:5432",
-            sessionId: STARTED_ID,
+            location: STARTED_ID,
             agentId: AGENT_ID,
             skipSentry: false,
             cause: failure,
@@ -1128,7 +1128,7 @@ describe("forwarding refusals", () => {
         {
           level: "error",
           text: `GET /serial?id=${SESSION_ID}&agent=${AGENT_ID} failed: unknown session "${SESSION_ID}"`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           skipSentry: true,
           cause: undefined,
@@ -1136,7 +1136,7 @@ describe("forwarding refusals", () => {
         {
           level: "error",
           text: `GET /follow?id=${SESSION_ID} failed: unknown session "${SESSION_ID}"`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: undefined,
           skipSentry: true,
           cause: undefined,
@@ -1167,9 +1167,9 @@ describe("forwarding refusals", () => {
         const empty = yield* Effect.flip(api.Sessions.follow({ query: { id: "" } }));
         expect(empty).toMatchObject({ _tag: "UnknownSession", message: 'unknown session ""' });
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.log.lines.map((line) => [line.text, line.sessionId, line.agentId])).toEqual([
-        ['POST /stop failed: unknown session "garbage"', undefined, AGENT_ID],
-        ['GET /follow?id= failed: unknown session ""', undefined, undefined],
+      expect(fixed.log.lines.map((line) => [line.text, line.location, line.agentId])).toEqual([
+        ['POST /stop failed: unknown session "garbage"', "server", AGENT_ID],
+        ['GET /follow?id= failed: unknown session ""', "server", undefined],
       ]);
     }),
   );
@@ -1204,14 +1204,14 @@ describe("forwarding refusals", () => {
         expect(fixed.log.lines[0]).toMatchObject({
           level: "error",
           text: `POST /send-keys failed: server ${SERVER_A} unreachable: connect ECONNREFUSED 10.0.0.5:42069`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           skipSentry: false,
         });
         expect(fixed.log.lines[0]?.cause).toBeInstanceOf(Error);
         expect(fixed.log.lines[1]).toMatchObject({
           text: `GET /follow?id=${SESSION_ID} failed: server ${SERVER_A} unreachable: connect ECONNREFUSED 10.0.0.5:42069`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: undefined,
           skipSentry: false,
         });
@@ -1250,7 +1250,7 @@ describe("forwarding refusals", () => {
         expect(fixed.log.lines[0]).toMatchObject({
           level: "error",
           text: `forward cut short; server ${SERVER_A} unreachable: read ECONNRESET`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: undefined,
           skipSentry: false,
         });
@@ -1280,7 +1280,7 @@ describe("forwarding refusals", () => {
         {
           level: "error",
           text: `GET /image?id=${SESSION_ID}&agent=${AGENT_ID} failed: connect ECONNREFUSED 127.0.0.1:5432`,
-          sessionId: SESSION_ID,
+          location: SESSION_ID,
           agentId: AGENT_ID,
           skipSentry: false,
           cause: failure,

--- a/test/support/log.ts
+++ b/test/support/log.ts
@@ -4,7 +4,7 @@ import * as Log from "../../src/observability/log.ts";
 export type Line = {
   readonly level: "info" | "warning" | "error" | "fatal";
   readonly text: string;
-  readonly sessionId: string | undefined;
+  readonly location: string | undefined;
   readonly agentId: string | undefined;
   readonly skipSentry: boolean;
   readonly cause: unknown;
@@ -29,7 +29,7 @@ export const fakeLog = (): FakeLog => {
         lines.push({
           level,
           text,
-          sessionId: report?.sessionId,
+          location: report?.location,
           agentId: report?.agentId,
           skipSentry: report?.skipSentry === true,
           cause: report?.cause,

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -228,13 +228,13 @@ export const fakeLogStore = (
       ),
     listLogs:
       options.listLogs ??
-      ((sessionId) =>
+      ((location) =>
         Effect.sync(() =>
           rows
-            .filter((row) => row.sessionId !== null && sameId(row.sessionId, sessionId))
+            .filter((row) => row.location !== null && row.location === location)
             .map((row, index) => ({
               id: index + 1,
-              sessionId: row.sessionId,
+              location: row.location,
               agentId: row.agentId,
               level: row.level,
               text: row.text,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames log attribution from UUID `session_id` to text `location`, so the same `Log` + `logs` table covers session lines, proxy-wide lines, and automation without a parallel logger.

**Vocabulary**
- `location`: session UUID when applicable, `"server"` for process-wide proxy/reverse-proxy lines, `"automation"` for the automation service
- On the automation process, process-wide `agentId` is also `"automation"` (ticket-scoped webhook lines keep the Linear ticket as `agentId`, with `location: "automation"`)

**Changes**
- Schema/migration `0009_logs_location` (after master’s `0008_server_type`): `logs.session_id` (uuid) → `logs.location` (text); nulls become `'server'`
- `Log` attribution + Sentry log tags use `location`
- Proxy / reverse-proxy process-wide lines use `Locations.server`
- Automation persists through `Log.layer` + DB with `ProcessAttribution` `{ location: "automation", agentId: "automation" }`
- Docs updated in `development.md`

**Rebase note**
- Rebased onto current `master`. Master already took `0008_server_type`, so this change is append-only as `0009_logs_location`.

## Evidence

Local `npm run check:fast` + `drizzle-kit check` after rebase:

```text
drizzle-kit check: Everything's fine
Test Files  46 passed (46)
Tests  862 passed (862)
```

## Test plan

- [x] `npm run check:fast`
- [x] `npx drizzle-kit check`
- [ ] CI green after rebase
- [ ] Integration tests with Docker (not available in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08884-018d-7530-aa4b-4ea72163f498?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08884-018d-7530-aa4b-4ea72163f498&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

