### PR TITLE
Add the automation client POST /run

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -5,7 +5,7 @@ cd "$(dirname "$0")/.."
 # Nothing here needs DATABASE_URL, and environment builds run install without agent secrets,
 # so it must not be required; start.sh reports it missing at boot instead.
 
-# v2 runs on Node 26 (package.json engines, CI). The base image ships Node 22, whose npm 10
+# The project runs on Node 26 (package.json engines, CI). The base image ships Node 22, whose npm 10
 # resolves vite's optional esbuild peer differently and rejects package-lock.json under npm ci.
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 if [ ! -s "$NVM_DIR/nvm.sh" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,4 @@
 /node_modules
 /.wrangler
 /v1/node_modules
-/v2/node_modules
-/v2/.wrangler
 /tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
-Two kinds of agent work here. The code lives in `v2/`; `v1/` is the previous implementation, kept
-runnable and untouched as a reference.
+Two kinds of agent work here.
 
-- A developing agent changes the code under `v2/`. Read [v2/development.md](v2/development.md).
+- A developing agent changes the code. Read [development.md](development.md).
 - A driving agent uses `./client` to drive a guest and `./ctrl` to record the result for a task given
-  in Linear. It never reads or changes code. Read [v2/client.md](v2/client.md) and
-  [v2/ctrl.md](v2/ctrl.md); their first lines are a table of contents, consult that first.
+  in Linear. It never reads or changes code. Read [client.md](client.md) and
+  [ctrl.md](ctrl.md); their first lines are a table of contents, consult that first.

--- a/automation-client
+++ b/automation-client
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node --experimental-strip-types --import "$(dirname "$0")/src/observability/instrument.ts" "$(dirname "$0")/src/automation-client/main.ts" "$@"

--- a/development.md
+++ b/development.md
@@ -14,7 +14,8 @@ exist.
 ## Toolchain
 
 - Run on Node 26 with npm. Every executable is a `#!/bin/sh` wrapper running
-  `node --experimental-strip-types` (`./qemu-server`, `./qemu-reverse-proxy` and `./automation-server` add
+  `node --experimental-strip-types` (`./qemu-server`, `./qemu-reverse-proxy`, `./automation-server`
+  and `./automation-client` add
   `--import ./src/observability/instrument.ts`); types are stripped, not transformed, so
   `erasableSyntaxOnly` stays on.
 - Install with `npm ci`; `prepare` runs `effect-tsgo patch --oxlint` so the `effecttsgo/*` rules
@@ -68,11 +69,11 @@ Durable preferences from the maintainer; when they conflict with generic best pr
 ## Layout
 
 - The root holds `AGENTS.md`, the executable wrappers (`./client`, `./client-with-image`,
-  `./ctrl`, `./qemu-server`, `./qemu-reverse-proxy`, `./automation-server`, `./session`), the tooling files,
+  `./ctrl`, `./qemu-server`, `./qemu-reverse-proxy`, `./automation-server`, `./automation-client`, `./session`), the tooling files,
   `drizzle/` (migrations), `public/` and `prompts/`, the operator documents, this document, `src/`
   and `test/`.
 - `src/` is one directory per process plus the shared kernel (`src/shared/`, `src/config.ts`,
-  `src/external-failure.ts`, `src/observability/`, `src/db/`); `main.ts` files are the entries.
+  `src/cli.ts`, `src/external-failure.ts`, `src/observability/`, `src/db/`); `main.ts` files are the entries.
 - `src/dashboard/` is a Hono Worker, not Effect: it has no Effect runtime, reaches Postgres
   through Hyperdrive and drizzle with one `pg.Client` per request ended in `finally` (a client
   left open holds a Hyperdrive connection past the response), never calls the qemu server's API, and
@@ -755,7 +756,7 @@ statement inside with `Client.attempt("endSession", () => tx.update(...))`.
 ## Sentry
 
 - Initialise the SDK before any Effect code in `src/observability/instrument.ts`, loaded by the
-  `qemu-server`, `qemu-reverse-proxy` and `automation-server` wrappers' `--import`: `Sentry.init({ dsn: SENTRY_DSN,
+  `qemu-server`, `qemu-reverse-proxy`, `automation-server` and `automation-client` wrappers' `--import`: `Sentry.init({ dsn: SENTRY_DSN,
   tracesSampleRate: 1,
   traceLifecycle: "stream", integrations: [Sentry.httpIntegration({ spans: false }),
   Sentry.nativeNodeFetchIntegration({ spans: false })] })`. `SENTRY_DSN` in `dsn.ts` is the one

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "oligarchy-v2",
+  "name": "oligarchy",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "oligarchy-v2",
+      "name": "oligarchy",
       "dependencies": {
         "@effect/platform-node": "4.0.0-rc.112",
         "@sentry/cloudflare": "10.73.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oligarchy-v2",
+  "name": "oligarchy",
   "private": true,
   "bin": {
     "client": "src/client/main.ts",
@@ -14,6 +14,7 @@
     "qemu-server": "node --experimental-strip-types --import ./src/observability/instrument.ts src/qemu-server/main.ts",
     "qemu-reverse-proxy": "node --experimental-strip-types --import ./src/observability/instrument.ts src/qemu-reverse-proxy/main.ts",
     "automation-server": "node --experimental-strip-types --import ./src/observability/instrument.ts src/automation-server/main.ts",
+    "automation-client": "node --experimental-strip-types --import ./src/observability/instrument.ts src/automation-client/main.ts",
     "dev": "wrangler dev --remote",
     "check:lint": "oxlint --deny-warnings .",
     "check:format": "oxfmt --check .",

--- a/src/automation-client/command.ts
+++ b/src/automation-client/command.ts
@@ -1,8 +1,11 @@
 import { Deferred, Effect, Layer } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import type { HttpServerError } from "effect/unstable/http";
+import * as Client from "../db/client.ts";
+import * as ExternalFailure from "../external-failure.ts";
 import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
+import * as Errors from "../shared/errors.ts";
 
 // One above the automation server's, so both run on one host in development.
 const DEFAULT_PORT = 54322;
@@ -11,6 +14,12 @@ export type AutomationClient<RServe> = {
   readonly serve: (port: number) => Layer.Layer<never, HttpServerError.ServeError, RServe>;
   readonly serverFailed: Deferred.Deferred<never, HttpServerError.ServeError>;
 };
+
+type StartupError = Errors.DatabaseError | HttpServerError.ServeError;
+
+// A ServeError says nothing itself; the bind or accept error it wraps does.
+const detail = (error: StartupError): string =>
+  error._tag === "ServeError" ? Render.errorDetail(error.cause) : Render.errorDetail(error);
 
 export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RServe>) =>
   Command.make(
@@ -24,12 +33,25 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
     ({ port }) =>
       Effect.gen(function* () {
         const log = yield* Log.Log;
-        return yield* Effect.raceFirst(
-          Layer.launch(server.serve(port)),
-          Deferred.await(server.serverFailed),
-        ).pipe(
+        const database = yield* Client.Database;
+        const startup = Effect.gen(function* () {
+          yield* database.ping.pipe(
+            Effect.mapError((error) =>
+              Errors.DatabaseError.make({
+                operation: "ping",
+                message: `database unreachable: ${Render.errorDetail(ExternalFailure.causeOf(error))}`,
+                cause: error,
+              }),
+            ),
+          );
+          return yield* Effect.raceFirst(
+            Layer.launch(server.serve(port)),
+            Deferred.await(server.serverFailed),
+          );
+        });
+        return yield* startup.pipe(
           Effect.tapError((error) =>
-            log.fatal(`automation client: ${Render.errorDetail(error.cause)}`, {
+            log.fatal(`automation client: ${detail(error)}`, {
               location: Log.Locations.automationClient,
               agentId: Log.AutomationClientAgentId,
               cause: error,

--- a/src/automation-client/command.ts
+++ b/src/automation-client/command.ts
@@ -1,0 +1,44 @@
+import { Deferred, Effect, Layer } from "effect";
+import { Command, Flag } from "effect/unstable/cli";
+import type { HttpServerError } from "effect/unstable/http";
+import * as Log from "../observability/log.ts";
+import * as Render from "../observability/render.ts";
+
+// One above the automation server's, so both run on one host in development.
+const DEFAULT_PORT = 54322;
+
+export type AutomationClient<RServe> = {
+  readonly serve: (port: number) => Layer.Layer<never, HttpServerError.ServeError, RServe>;
+  readonly serverFailed: Deferred.Deferred<never, HttpServerError.ServeError>;
+};
+
+export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RServe>) =>
+  Command.make(
+    "automation-client",
+    {
+      port: Flag.integer("port").pipe(
+        Flag.withDefault(DEFAULT_PORT),
+        Flag.withDescription("Listen port"),
+      ),
+    },
+    ({ port }) =>
+      Effect.gen(function* () {
+        const log = yield* Log.Log;
+        return yield* Effect.raceFirst(
+          Layer.launch(server.serve(port)),
+          Deferred.await(server.serverFailed),
+        ).pipe(
+          Effect.tapError((error) =>
+            log.fatal(`automation client: ${Render.errorDetail(error.cause)}`, {
+              location: Log.Locations.automationClient,
+              agentId: Log.AutomationClientAgentId,
+              cause: error,
+            }),
+          ),
+        );
+      }),
+  ).pipe(
+    Command.withDescription(
+      "The automation client: POST /run launches OpenCode with a prompt and waits until it finishes",
+    ),
+  );

--- a/src/automation-client/handlers.ts
+++ b/src/automation-client/handlers.ts
@@ -9,7 +9,9 @@ import * as OpenCode from "./opencode.ts";
 
 const ok = Contract.Ok.make({});
 
-export const BearerAuthLive = Layer.unwrap(Effect.map(Config.oligarchyToken, Middleware.bearerAuth));
+export const BearerAuthLive = Layer.unwrap(
+  Effect.map(Config.oligarchyToken, Middleware.bearerAuth),
+);
 
 export const RunsLive = HttpApiBuilder.group(Api.AutomationClientApi, "Runs", (handlers) =>
   handlers.handle("run", ({ payload }) =>

--- a/src/automation-client/handlers.ts
+++ b/src/automation-client/handlers.ts
@@ -1,6 +1,5 @@
 import { Effect, Layer } from "effect";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
-import * as Config from "../config.ts";
 import * as QemuServerHandlers from "../qemu-server/handlers.ts";
 import * as Middleware from "../qemu-server/middleware.ts";
 import * as Api from "../shared/api.ts";
@@ -9,23 +8,26 @@ import * as OpenCode from "./opencode.ts";
 
 const ok = Contract.Ok.make({});
 
-export const BearerAuthLive = Layer.unwrap(
-  Effect.map(Config.oligarchyToken, Middleware.bearerAuth),
-);
+// A client that disconnects mid-run must not kill OpenCode: the work is the process, not the
+// HTTP conversation that launched it.
+const uninterruptible = { uninterruptible: true } as const;
 
 export const RunsLive = HttpApiBuilder.group(Api.AutomationClientApi, "Runs", (handlers) =>
-  handlers.handle("run", ({ payload }) =>
-    Effect.gen(function* () {
-      yield* OpenCode.run(payload.prompt);
-      return ok;
-    }),
+  handlers.handle(
+    "run",
+    ({ payload }) =>
+      Effect.gen(function* () {
+        yield* OpenCode.run(payload.prompt);
+        return ok;
+      }),
+    uninterruptible,
   ),
 );
 
 export const routes = Layer.mergeAll(
   HttpApiBuilder.layer(Api.AutomationClientApi).pipe(
     Layer.provide(RunsLive),
-    Layer.provide(Middleware.ApiBoundaryLive),
+    Layer.provide(Layer.mergeAll(Middleware.BearerAuthLive, Middleware.ApiBoundaryLive)),
   ),
   QemuServerHandlers.NotFoundRoute,
 );

--- a/src/automation-client/handlers.ts
+++ b/src/automation-client/handlers.ts
@@ -1,0 +1,29 @@
+import { Effect, Layer } from "effect";
+import { HttpApiBuilder } from "effect/unstable/httpapi";
+import * as Config from "../config.ts";
+import * as QemuServerHandlers from "../qemu-server/handlers.ts";
+import * as Middleware from "../qemu-server/middleware.ts";
+import * as Api from "../shared/api.ts";
+import * as Contract from "../shared/contract.ts";
+import * as OpenCode from "./opencode.ts";
+
+const ok = Contract.Ok.make({});
+
+export const BearerAuthLive = Layer.unwrap(Effect.map(Config.oligarchyToken, Middleware.bearerAuth));
+
+export const RunsLive = HttpApiBuilder.group(Api.AutomationClientApi, "Runs", (handlers) =>
+  handlers.handle("run", ({ payload }) =>
+    Effect.gen(function* () {
+      yield* OpenCode.run(payload.prompt);
+      return ok;
+    }),
+  ),
+);
+
+export const routes = Layer.mergeAll(
+  HttpApiBuilder.layer(Api.AutomationClientApi).pipe(
+    Layer.provide(RunsLive),
+    Layer.provide(Middleware.ApiBoundaryLive),
+  ),
+  QemuServerHandlers.NotFoundRoute,
+);

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -1,0 +1,77 @@
+import { createServer } from "node:http";
+import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
+import { Cause, Deferred, Effect, Exit, Layer, type Runtime } from "effect";
+import { Command } from "effect/unstable/cli";
+import { HttpMiddleware, HttpRouter, HttpServerError } from "effect/unstable/http";
+import * as Config from "../config.ts";
+import * as Log from "../observability/log.ts";
+import * as Render from "../observability/render.ts";
+import * as Sentry from "../observability/sentry.ts";
+import * as Api from "../shared/api.ts";
+import * as AutomationClientCommand from "./command.ts";
+import * as Handlers from "./handlers.ts";
+
+const HOST = "127.0.0.1";
+
+const automationClientAttr = Log.AutomationClientProcessAttribution;
+
+// stdout is the convenience copy of the log; Sentry is the record. A write refused by a full
+// filesystem is dropped, never an uncaught exception per line (see the qemu server's main).
+process.stdout.on("error", () => {});
+process.stderr.on("error", () => {});
+
+// The platform drops its error listener once the server is up; a later error still needs the
+// fatal line and exit 1. Only the first counts.
+const server = createServer();
+const serverFailed = Deferred.makeUnsafe<never, HttpServerError.ServeError>();
+server.on("error", (cause) => {
+  Deferred.doneUnsafe(serverFailed, Exit.fail(new HttpServerError.ServeError({ cause })));
+});
+
+const ServerLive = (port: number) =>
+  Layer.effectDiscard(
+    Effect.gen(function* () {
+      const log = yield* Log.Log;
+      yield* log.acquireColor(Log.AutomationClientAgentId);
+      yield* log.info(
+        `automation client listening on ${HOST}:${String(port)}`,
+        automationClientAttr,
+      );
+    }),
+  ).pipe(
+    Layer.provide(
+      HttpRouter.serve(Handlers.routes, {
+        disableLogger: true,
+        disableListenLog: true,
+      }).pipe(Layer.provide(NodeHttpServer.layer(() => server, { host: HOST, port }))),
+    ),
+    Layer.provide(Layer.succeed(HttpMiddleware.TracerDisabledWhen)(() => true)),
+  );
+
+const MainLive = Layer.mergeAll(Log.Log.layerStdout, Handlers.BearerAuthLive).pipe(
+  Layer.provideMerge(Sentry.SentryLive),
+  Layer.provideMerge(Layer.succeed(Log.ProcessAttribution)(Log.AutomationClientProcessAttribution)),
+  Layer.provideMerge(Config.providerLayer),
+  Layer.provideMerge(NodeServices.layer),
+);
+
+const command = AutomationClientCommand.makeAutomationClientCommand({
+  serve: ServerLive,
+  serverFailed,
+});
+
+// The graph is built before the command runs: a missing OLIGARCHY_TOKEN is the one failure no
+// Log exists to record, so it is printed here. Every later failure logs its own fatal line.
+const program = Effect.gen(function* () {
+  const services = yield* Layer.build(MainLive).pipe(Effect.tapCause(Render.reportFailure));
+  yield* Command.run(command, { version: Api.VERSION }).pipe(
+    Effect.provide(services),
+    Effect.tapDefect((defect) => Render.reportFailure(Cause.die(defect))),
+  );
+}).pipe(Effect.scoped);
+
+const teardown: Runtime.Teardown = (exit, onExit) => {
+  onExit(Exit.isFailure(exit) && !Cause.hasInterruptsOnly(exit.cause) ? 1 : 0);
+};
+
+NodeRuntime.runMain(program, { disableErrorReporting: true, teardown });

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -4,6 +4,8 @@ import { Cause, Deferred, Effect, Exit, Layer, type Runtime } from "effect";
 import { Command } from "effect/unstable/cli";
 import { HttpMiddleware, HttpRouter, HttpServerError } from "effect/unstable/http";
 import * as Config from "../config.ts";
+import * as Client from "../db/client.ts";
+import * as Logs from "../db/logs.ts";
 import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
 import * as Sentry from "../observability/sentry.ts";
@@ -15,8 +17,8 @@ const HOST = "127.0.0.1";
 
 const automationClientAttr = Log.AutomationClientProcessAttribution;
 
-// stdout is the convenience copy of the log; Sentry is the record. A write refused by a full
-// filesystem is dropped, never an uncaught exception per line (see the qemu server's main).
+// stdout is the convenience copy of the log; the rows and Sentry are the record. A write refused
+// by a full filesystem is dropped, never an uncaught exception per line (see the qemu server's main).
 process.stdout.on("error", () => {});
 process.stderr.on("error", () => {});
 
@@ -48,7 +50,15 @@ const ServerLive = (port: number) =>
     Layer.provide(Layer.succeed(HttpMiddleware.TracerDisabledWhen)(() => true)),
   );
 
-const MainLive = Layer.mergeAll(Log.Log.layerStdout, Handlers.BearerAuthLive).pipe(
+const DatabaseLive = Layer.unwrap(
+  Effect.map(Config.ProxyConfig, (config) => Client.Database.layer(config.databaseUrl)),
+);
+
+// Sentry sits beneath Log so the log rows flush before Sentry does, and Log captures the reporter.
+const MainLive = Log.Log.layer.pipe(
+  Layer.provideMerge(Logs.LogStore.layer),
+  Layer.provideMerge(DatabaseLive),
+  Layer.provideMerge(Config.ProxyConfig.layer),
   Layer.provideMerge(Sentry.SentryLive),
   Layer.provideMerge(Layer.succeed(Log.ProcessAttribution)(Log.AutomationClientProcessAttribution)),
   Layer.provideMerge(Config.providerLayer),
@@ -60,8 +70,9 @@ const command = AutomationClientCommand.makeAutomationClientCommand({
   serverFailed,
 });
 
-// The graph is built before the command runs: a missing OLIGARCHY_TOKEN is the one failure no
-// Log exists to record, so it is printed here. Every later failure logs its own fatal line.
+// The graph is built before the command runs: a missing variable or a bad DATABASE_URL is the one
+// failure no Log exists to record, so it is printed here. Every later failure logs its own fatal
+// line; a defect has nothing else to say for it.
 const program = Effect.gen(function* () {
   const services = yield* Layer.build(MainLive).pipe(Effect.tapCause(Render.reportFailure));
   yield* Command.run(command, { version: Api.VERSION }).pipe(

--- a/src/automation-client/opencode.ts
+++ b/src/automation-client/opencode.ts
@@ -5,6 +5,6 @@ import * as Errors from "../shared/errors.ts";
 export const BIN = "opencode";
 
 export const run = (prompt: string) =>
-  Cli.run(BIN, ["run", prompt]).pipe(
+  Cli.run(BIN, ["run", "--", prompt]).pipe(
     Effect.mapError((error) => Errors.RunFailed.make({ message: error.message, cause: error })),
   );

--- a/src/automation-client/opencode.ts
+++ b/src/automation-client/opencode.ts
@@ -1,0 +1,10 @@
+import { Effect } from "effect";
+import * as Cli from "../cli.ts";
+import * as Errors from "../shared/errors.ts";
+
+export const BIN = "opencode";
+
+export const run = (prompt: string) =>
+  Cli.run(BIN, ["run", prompt]).pipe(
+    Effect.mapError((error) => Errors.RunFailed.make({ message: error.message, cause: error })),
+  );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,8 +42,12 @@ export const run = Effect.fn("Cli.run")(function* (command: string, args: Readon
       );
       const trimmed = stderr.trim();
       if (code !== 0) {
-        return yield* failed(command, trimmed === "" ? `${command} exited ${String(code)}` : trimmed);
+        return yield* failed(
+          command,
+          trimmed === "" ? `${command} exited ${String(code)}` : trimmed,
+        );
       }
+      return yield* Effect.void;
     }),
   );
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,46 @@
+import { Effect, Stream } from "effect";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as ExternalFailure from "./external-failure.ts";
+import * as Render from "./observability/render.ts";
+import * as Errors from "./shared/errors.ts";
+
+const detail = (error: unknown): string =>
+  ExternalFailure.describeThrowable(ExternalFailure.causeOf(error), Render.errorDetail(error));
+
+const failed = (command: string, message: string, cause?: unknown): Errors.CliFailed =>
+  cause === undefined
+    ? Errors.CliFailed.make({ command, message })
+    : Errors.CliFailed.make({ command, message, cause });
+
+export const run = Effect.fn("Cli.run")(function* (command: string, args: ReadonlyArray<string>) {
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const handle = yield* spawner
+        .spawn(
+          ChildProcess.make(command, args, {
+            stdin: "ignore",
+            stdout: "ignore",
+            stderr: "pipe",
+            extendEnv: true,
+            detached: false,
+          }),
+        )
+        .pipe(Effect.mapError((error) => failed(command, detail(error), error)));
+      const [stderr, code] = yield* Effect.all(
+        [
+          Stream.mkString(Stream.decodeText(handle.stderr)).pipe(Effect.orDie),
+          handle.exitCode.pipe(Effect.mapError((error) => failed(command, detail(error), error))),
+        ],
+        { concurrency: "unbounded" },
+      );
+      if (code !== 0) {
+        const trimmed = stderr.trim();
+        return yield* failed(
+          command,
+          trimmed === "" ? `${command} exited ${String(code)}` : trimmed,
+        );
+      }
+    }),
+  );
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,13 +34,13 @@ export const run = Effect.fn("Cli.run")(function* (command: string, args: Readon
         ],
         { concurrency: "unbounded" },
       );
-      if (code !== 0) {
-        const trimmed = stderr.trim();
-        return yield* failed(
-          command,
-          trimmed === "" ? `${command} exited ${String(code)}` : trimmed,
-        );
-      }
+      const trimmed = stderr.trim();
+      yield* Effect.succeed(code).pipe(
+        Effect.filterOrFail(
+          (exit) => exit === 0,
+          (exit) => failed(command, trimmed === "" ? `${command} exited ${String(exit)}` : trimmed),
+        ),
+      );
     }),
   );
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,8 @@ import * as ExternalFailure from "./external-failure.ts";
 import * as Render from "./observability/render.ts";
 import * as Errors from "./shared/errors.ts";
 
+export const FORCE_KILL_AFTER = "5 seconds";
+
 const detail = (error: unknown): string =>
   ExternalFailure.describeThrowable(ExternalFailure.causeOf(error), Render.errorDetail(error));
 
@@ -24,23 +26,24 @@ export const run = Effect.fn("Cli.run")(function* (command: string, args: Readon
             stderr: "pipe",
             extendEnv: true,
             detached: false,
+            killSignal: "SIGTERM",
+            forceKillAfter: FORCE_KILL_AFTER,
           }),
         )
         .pipe(Effect.mapError((error) => failed(command, detail(error), error)));
       const [stderr, code] = yield* Effect.all(
         [
-          Stream.mkString(Stream.decodeText(handle.stderr)).pipe(Effect.orDie),
+          Stream.mkString(Stream.decodeText(handle.stderr)).pipe(
+            Effect.mapError((error) => failed(command, detail(error), error)),
+          ),
           handle.exitCode.pipe(Effect.mapError((error) => failed(command, detail(error), error))),
         ],
         { concurrency: "unbounded" },
       );
       const trimmed = stderr.trim();
-      yield* Effect.succeed(code).pipe(
-        Effect.filterOrFail(
-          (exit) => exit === 0,
-          (exit) => failed(command, trimmed === "" ? `${command} exited ${String(exit)}` : trimmed),
-        ),
-      );
+      if (code !== 0) {
+        return yield* failed(command, trimmed === "" ? `${command} exited ${String(code)}` : trimmed);
+      }
     }),
   );
 });

--- a/src/observability/log.ts
+++ b/src/observability/log.ts
@@ -15,17 +15,20 @@ import * as Errors from "../shared/errors.ts";
 import type * as Domain from "../shared/domain.ts";
 import * as Render from "./render.ts";
 
-// location is a text bucket: a session UUID, Locations.server, or Locations.automation.
+// location is a text bucket: a session UUID, Locations.server, Locations.automation, or
+// Locations.automationClient.
 export type Attribution = { readonly location?: string; readonly agentId?: string };
 export type Report = Attribution & { readonly cause?: unknown; readonly skipSentry?: true };
 
 export const Locations = {
   automation: "automation",
+  automationClient: "automation-client",
   server: "server",
 } as const;
 
 // The automation server logs with agentId === Locations.automation as well.
 export const AutomationAgentId = Locations.automation;
+export const AutomationClientAgentId = Locations.automationClient;
 
 // Fallback attribution when a log line has no session: qemu-server-wide "server", or automation's
 // own bucket. Processes override this Reference at the top of their layer graph.
@@ -42,6 +45,11 @@ export const ProcessAttribution = Context.Reference<ProcessAttribution>(
 export const AutomationProcessAttribution: ProcessAttribution = {
   location: Locations.automation,
   agentId: AutomationAgentId,
+};
+
+export const AutomationClientProcessAttribution: ProcessAttribution = {
+  location: Locations.automationClient,
+  agentId: AutomationClientAgentId,
 };
 
 export type LogService = {

--- a/src/qemu-server/middleware.ts
+++ b/src/qemu-server/middleware.ts
@@ -39,6 +39,7 @@ const isApiError: (value: unknown) => value is Errors.ApiError = Schema.is(
     Errors.Internal,
     Errors.ServerFailed,
     Errors.NoServer,
+    Errors.RunFailed,
   ]),
 );
 
@@ -59,6 +60,7 @@ const attribution = (error: Errors.ApiError, fallback: Log.ProcessAttribution): 
   switch (error._tag) {
     case "Unauthorized":
     case "NotFound":
+    case "RunFailed":
       return fallback;
     case "Forbidden":
       return { location: error.sessionId, agentId: error.agentId };

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -175,4 +175,17 @@ export class Linear extends HttpApiGroup.make("Linear").add(linear).middleware(A
 
 export class AutomationServerApi extends HttpApi.make("OligarchyAutomationServer").add(Linear) {}
 
+export const run = HttpApiEndpoint.post("run", "/run", {
+  payload: Contract.RunBody,
+  success: Contract.Ok,
+  error: Errors.RunFailedWire,
+});
+
+export class Runs extends HttpApiGroup.make("Runs")
+  .add(run)
+  .middleware(BearerAuth)
+  .middleware(ApiBoundary) {}
+
+export class AutomationClientApi extends HttpApi.make("OligarchyAutomationClient").add(Runs) {}
+
 export const VERSION = "0.0.0";

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -106,6 +106,10 @@ export class Servers extends Schema.Class<Servers>("@oligarchy/shared/contract/S
   servers: Schema.Array(Server),
 }) {}
 
+export class RunBody extends Schema.Class<RunBody>("@oligarchy/shared/contract/RunBody")({
+  prompt: Schema.String,
+}) {}
+
 const STORED_IMAGE_ORIGIN = "https://oligarchy.trm.sh";
 
 export const StoredImageUrl = (id: string): string => `${STORED_IMAGE_ORIGIN}/images/${id}`;

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -148,6 +148,14 @@ export class NoServer extends Schema.TaggedError<NoServer>("@oligarchy/shared/er
   override readonly [ErrorReporter.ignore] = true;
 }
 
+export class RunFailed extends Schema.TaggedError<RunFailed>("@oligarchy/shared/errors/RunFailed")(
+  "RunFailed",
+  { message: Schema.String, cause: Schema.optionalKey(Schema.Defect()) },
+  { httpApiStatus: 500 },
+) {
+  override readonly [ErrorReporter.ignore] = true;
+}
+
 export type ApiError =
   | BadRequest
   | Unauthorized
@@ -159,7 +167,8 @@ export type ApiError =
   | ExchangeFailed
   | Internal
   | ServerFailed
-  | NoServer;
+  | NoServer
+  | RunFailed;
 
 const resolveHttpApiStatus = SchemaAST.resolveAt("httpApiStatus");
 
@@ -182,6 +191,7 @@ const apiErrorClasses = {
   Internal,
   ServerFailed,
   NoServer,
+  RunFailed,
 } satisfies Record<ApiError["_tag"], Schema.Top>;
 
 export const apiStatus = (error: ApiError): number => httpStatus(apiErrorClasses[error._tag]);
@@ -248,6 +258,10 @@ export const ServerFailedWire = wireError(
 export const NoServerWire = wireError(
   NoServer,
   (message) => ({ _tag: "NoServer", message }) as const,
+);
+export const RunFailedWire = wireError(
+  RunFailed,
+  (message) => ({ _tag: "RunFailed", message }) as const,
 );
 
 // ---------------------------------------------------------------------------
@@ -364,6 +378,15 @@ export class ChildExit extends Schema.TaggedError<ChildExit>("@oligarchy/shared/
     return this.stderr;
   }
 }
+
+export class CliFailed extends Schema.TaggedError<CliFailed>("@oligarchy/shared/errors/CliFailed")(
+  "CliFailed",
+  {
+    command: Schema.String,
+    message: Schema.String,
+    cause: Schema.optionalKey(Schema.Defect()),
+  },
+) {}
 
 export class PngDecodeError extends Schema.TaggedError<PngDecodeError>(
   "@oligarchy/shared/errors/PngDecodeError",

--- a/test/automation-client/command.unit.test.ts
+++ b/test/automation-client/command.unit.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import {
+  Cause,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Layer,
+  Path,
+  Stdio,
+  Terminal,
+} from "effect";
+import { TestConsole } from "effect/testing";
+import { Command } from "effect/unstable/cli";
+import { HttpServerError } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import * as AutomationClientCommand from "../../src/automation-client/command.ts";
+import * as Api from "../../src/shared/api.ts";
+import * as FakeLog from "../support/log.ts";
+
+const CliTestLayer = Layer.mergeAll(
+  FileSystem.layerNoop({}),
+  Path.layer,
+  Stdio.layerTest({}),
+  Layer.succeed(Terminal.Terminal)(
+    Terminal.make({
+      columns: Effect.succeed(80),
+      rows: Effect.succeed(24),
+      readInput: Effect.die("unused"),
+      readLine: Effect.die("unused"),
+      display: () => Effect.void,
+    }),
+  ),
+  Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+    ChildProcessSpawner.make(() => Effect.die("unused")),
+  ),
+);
+
+const fakeServer = () => {
+  const served: Array<number> = [];
+  const listening = Deferred.makeUnsafe<void>();
+  const serverFailed = Deferred.makeUnsafe<never, HttpServerError.ServeError>();
+  const server: AutomationClientCommand.AutomationClient<never> = {
+    serve: (port) =>
+      Layer.effectDiscard(
+        Effect.gen(function* () {
+          served.push(port);
+          yield* Deferred.succeed(listening, undefined);
+        }),
+      ),
+    serverFailed,
+  };
+  return { served, listening, serverFailed, server };
+};
+
+const run = (
+  server: AutomationClientCommand.AutomationClient<never>,
+  args: ReadonlyArray<string>,
+  log: FakeLog.FakeLog,
+) =>
+  Command.runWith(AutomationClientCommand.makeAutomationClientCommand(server), {
+    version: Api.VERSION,
+  })(args).pipe(Effect.provide(Layer.mergeAll(CliTestLayer, log.layer)));
+
+describe("automation client command flags", () => {
+  it.effect("--port must be an integer", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(run(fake.server, ["--port", "forty"], log));
+      expect(error._tag).toBe("ShowHelp");
+      expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("--help prints the help, succeeds and touches nothing", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const exit = yield* Effect.exit(run(fake.server, ["--help"], log));
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([]);
+      const stdout = yield* TestConsole.logLines;
+      expect(stdout.join("\n")).toContain("automation-client");
+      expect(stdout.join("\n")).toContain("--port");
+      expect(stdout.join("\n")).not.toContain("--display");
+    }),
+  );
+
+  it.effect("defaults to port 54322 and listens", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const fiber = yield* Effect.forkChild(run(fake.server, [], log));
+      yield* Deferred.await(fake.listening);
+      yield* Fiber.interrupt(fiber);
+      const exit = yield* Fiber.await(fiber);
+      expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+      expect(fake.served).toEqual([54322]);
+      expect(log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("--port 1234 reaches the server as given", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const fiber = yield* Effect.forkChild(run(fake.server, ["--port", "1234"], log));
+      yield* Deferred.await(fake.listening);
+      yield* Fiber.interrupt(fiber);
+      expect(fake.served).toEqual([1234]);
+    }),
+  );
+});
+
+describe("automation client command startup failures", () => {
+  it.effect("a server error after listen fails the handler with the error's detail", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const fiber = yield* Effect.forkChild(run(fake.server, [], log));
+      yield* Deferred.await(fake.listening);
+      const cause = new Error("accept EMFILE: too many open files");
+      yield* Deferred.fail(fake.serverFailed, new HttpServerError.ServeError({ cause }));
+      const exit = yield* Fiber.await(fiber);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasInterruptsOnly(exit.cause)).toBe(false);
+        expect(Cause.squash(exit.cause)).toMatchObject({ _tag: "ServeError", cause });
+      }
+      expect(log.lines).toHaveLength(1);
+      expect(log.lines[0]).toMatchObject({
+        level: "fatal",
+        text: "automation client: accept EMFILE: too many open files",
+        skipSentry: false,
+      });
+    }),
+  );
+
+  it.effect("a listen failure is fatal with the bind error's message", () =>
+    Effect.gen(function* () {
+      const cause = new Error("listen EADDRINUSE: address already in use 127.0.0.1:54322");
+      const fake = fakeServer();
+      const failing: AutomationClientCommand.AutomationClient<never> = {
+        ...fake.server,
+        serve: () => Layer.effectDiscard(Effect.fail(new HttpServerError.ServeError({ cause }))),
+      };
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(run(failing, ["--port", "54322"], log));
+      expect(error).toMatchObject({ _tag: "ServeError", cause });
+      expect(log.lines.map((line) => [line.level, line.text])).toEqual([
+        ["fatal", "automation client: listen EADDRINUSE: address already in use 127.0.0.1:54322"],
+      ]);
+    }),
+  );
+});

--- a/test/automation-client/command.unit.test.ts
+++ b/test/automation-client/command.unit.test.ts
@@ -17,7 +17,9 @@ import { Command } from "effect/unstable/cli";
 import { HttpServerError } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as AutomationClientCommand from "../../src/automation-client/command.ts";
+import * as Client from "../../src/db/client.ts";
 import * as Api from "../../src/shared/api.ts";
+import * as Errors from "../../src/shared/errors.ts";
 import * as FakeLog from "../support/log.ts";
 
 const CliTestLayer = Layer.mergeAll(
@@ -55,14 +57,24 @@ const fakeServer = () => {
   return { served, listening, serverFailed, server };
 };
 
+const DatabaseLive = (ping: Effect.Effect<void, Errors.DatabaseError> = Effect.void) =>
+  Layer.succeed(Client.Database)(
+    Client.Database.of({
+      run: () => Effect.die("unused"),
+      transaction: () => Effect.die("unused"),
+      ping,
+    }),
+  );
+
 const run = (
   server: AutomationClientCommand.AutomationClient<never>,
   args: ReadonlyArray<string>,
   log: FakeLog.FakeLog,
+  database: Layer.Layer<Client.Database> = DatabaseLive(),
 ) =>
   Command.runWith(AutomationClientCommand.makeAutomationClientCommand(server), {
     version: Api.VERSION,
-  })(args).pipe(Effect.provide(Layer.mergeAll(CliTestLayer, log.layer)));
+  })(args).pipe(Effect.provide(Layer.mergeAll(CliTestLayer, log.layer, database)));
 
 describe("automation client command flags", () => {
   it.effect("--port must be an integer", () =>
@@ -80,7 +92,22 @@ describe("automation client command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const exit = yield* Effect.exit(run(fake.server, ["--help"], log));
+      const exit = yield* Effect.exit(
+        run(
+          fake.server,
+          ["--help"],
+          log,
+          DatabaseLive(
+            Effect.fail(
+              Errors.DatabaseError.make({
+                operation: "ping",
+                message: "database request failed",
+                cause: new Error("connect ECONNREFUSED"),
+              }),
+            ),
+          ),
+        ),
+      );
       expect(Exit.isSuccess(exit)).toBe(true);
       expect(fake.served).toEqual([]);
       expect(log.lines).toEqual([]);
@@ -91,7 +118,7 @@ describe("automation client command flags", () => {
     }),
   );
 
-  it.effect("defaults to port 54322 and listens", () =>
+  it.effect("defaults to port 54322, pings the database, and listens", () =>
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
@@ -118,6 +145,49 @@ describe("automation client command flags", () => {
 });
 
 describe("automation client command startup failures", () => {
+  it.effect("an unreachable database is fatal and never listens (unhappy)", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const unreachable = Errors.DatabaseError.make({
+        operation: "ping",
+        message: "database request failed",
+        cause: new Error("connect ECONNREFUSED"),
+      });
+      const error = yield* Effect.flip(
+        run(fake.server, [], log, DatabaseLive(Effect.fail(unreachable))),
+      );
+      expect(error).toMatchObject({
+        _tag: "DatabaseError",
+        operation: "ping",
+        message: "database unreachable: connect ECONNREFUSED",
+      });
+      expect(fake.served).toEqual([]);
+      expect(log.lines.map((line) => [line.level, line.text])).toEqual([
+        ["fatal", "automation client: database unreachable: connect ECONNREFUSED"],
+      ]);
+    }),
+  );
+
+  it.effect("a ping failure without a nested cause reports the driver's own message", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(
+        run(
+          fake.server,
+          [],
+          log,
+          DatabaseLive(
+            Effect.fail(Errors.DatabaseError.make({ operation: "ping", message: "pool ended" })),
+          ),
+        ),
+      );
+      expect(error).toMatchObject({ message: "database unreachable: pool ended" });
+      expect(log.lines[0]?.text).toBe("automation client: database unreachable: pool ended");
+    }),
+  );
+
   it.effect("a server error after listen fails the handler with the error's detail", () =>
     Effect.gen(function* () {
       const fake = fakeServer();
@@ -138,6 +208,7 @@ describe("automation client command startup failures", () => {
         text: "automation client: accept EMFILE: too many open files",
         skipSentry: false,
       });
+      expect(log.lines[0]?.cause).toMatchObject({ _tag: "ServeError", cause });
     }),
   );
 

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Fiber, Layer } from "effect";
+import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
+import { NodeHttpServer } from "@effect/platform-node";
+import * as Handlers from "../../src/automation-client/handlers.ts";
+import * as OpenCode from "../../src/automation-client/opencode.ts";
+import * as Log from "../../src/observability/log.ts";
+import * as Support from "../support/config.ts";
+import * as FakeLog from "../support/log.ts";
+import * as FakeSpawner from "../support/fake-spawner.ts";
+import * as Reporter from "../support/reporter.ts";
+
+const TOKEN = "test-token";
+
+type Fixture = {
+  readonly spawner: FakeSpawner.FakeSpawner;
+  readonly log: FakeLog.FakeLog;
+  readonly reporter: Reporter.Collector;
+};
+
+const fixture = (script: FakeSpawner.Script = () => ({ exitCode: 0 })): Fixture => ({
+  spawner: FakeSpawner.fakeSpawner(script),
+  log: FakeLog.fakeLog(),
+  reporter: Reporter.collect(),
+});
+
+const serve = (fixed: Fixture) =>
+  HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
+    Layer.provide(Layer.mergeAll(fixed.spawner.layer, fixed.log.layer, Handlers.BearerAuthLive)),
+    Layer.provide(Layer.succeed(Log.ProcessAttribution)(Log.AutomationClientProcessAttribution)),
+    Layer.provide(Support.withEnv({ OLIGARCHY_TOKEN: TOKEN })),
+    Layer.provideMerge(NodeHttpServer.layerTest),
+    Layer.provideMerge(fixed.reporter.layer),
+  );
+
+const headers = { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" };
+
+const run = (http: HttpClient.HttpClient, prompt = "do the work", extraHeaders = headers) =>
+  http.post("/run", {
+    headers: extraHeaders,
+    body: HttpBody.text(JSON.stringify({ prompt }), "application/json"),
+  });
+
+describe("POST /run happy path", () => {
+  it.effect("answers ok after opencode exits 0 and ignores its printout", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({ exitCode: 0, stdout: "the written result" }));
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* run(http, "fix the bug");
+        expect(response.status).toBe(200);
+        expect(yield* response.json).toEqual({ ok: "true" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.spawner.spawned).toMatchObject([
+        { command: OpenCode.BIN, args: ["run", "fix the bug"] },
+      ]);
+      expect(fixed.log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("waits until opencode exits before answering 200", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({}));
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const pending = yield* Effect.forkChild(run(http));
+        yield* Effect.yieldNow;
+        expect(pending.pollUnsafe()).toBeUndefined();
+        yield* fixed.spawner.spawned[0]?.exit(0) ?? Effect.void;
+        const response = yield* Fiber.join(pending);
+        expect(response.status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+    }),
+  );
+});
+
+describe("POST /run authentication and decoding", () => {
+  it.effect("refuses a missing bearer with 401 and one error line", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* run(http, "do the work", {
+          "content-type": "application/json",
+        });
+        expect(response.status).toBe(401);
+        expect(yield* response.json).toEqual({ error: "unauthorized" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.spawner.spawned).toEqual([]);
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /run failed: unauthorized",
+          location: "automation-client",
+          agentId: "automation-client",
+          skipSentry: true,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
+  it.effect("a wrong bearer is 401 too", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* run(http, "do the work", {
+          authorization: "Bearer wrong",
+          "content-type": "application/json",
+        });
+        expect(response.status).toBe(401);
+        expect(yield* response.json).toEqual({ error: "unauthorized" });
+      }).pipe(Effect.provide(serve(fixed)));
+    }),
+  );
+
+  it.effect("a body without prompt is 400", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* http.post("/run", {
+          headers,
+          body: HttpBody.text("{}", "application/json"),
+        });
+        expect(response.status).toBe(400);
+        expect((yield* response.json) as { error: string }).toMatchObject({
+          error: expect.stringContaining("prompt") as string,
+        });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.spawner.spawned).toEqual([]);
+    }),
+  );
+});
+
+describe("POST /run unhappy path", () => {
+  it.effect("returns 500 with the spawn error when opencode cannot be opened", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({ spawnError: "spawn opencode ENOENT" }));
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* run(http);
+        expect(response.status).toBe(500);
+        expect(yield* response.json).toEqual({ error: "spawn opencode ENOENT" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.log.lines.map((line) => [line.level, line.text, line.skipSentry])).toEqual([
+        ["error", "POST /run failed: spawn opencode ENOENT", false],
+      ]);
+    }),
+  );
+
+  it.effect("returns 500 with the error opencode printed when it exits non-zero", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({ exitCode: 1, stderr: "out of token credits\n" }));
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* run(http);
+        expect(response.status).toBe(500);
+        expect(yield* response.json).toEqual({ error: "out of token credits" });
+      }).pipe(Effect.provide(serve(fixed)));
+    }),
+  );
+});
+
+describe("catch-all", () => {
+  it.effect("GET /run and GET /nope are 404 not found and never logged", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        for (const path of ["/run", "/nope"]) {
+          const response = yield* http.get(path, { headers: { authorization: `Bearer ${TOKEN}` } });
+          expect(response.status).toBe(404);
+          expect(yield* response.json).toEqual({ error: "not found" });
+        }
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.log.lines).toEqual([]);
+      expect(fixed.spawner.spawned).toEqual([]);
+    }),
+  );
+});

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -1,17 +1,22 @@
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
-import { Effect, Fiber, Layer, Schema } from "effect";
+import { Cause, Effect, Exit, Fiber, Layer, Redacted, Schema } from "effect";
 import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
 import { NodeHttpServer } from "@effect/platform-node";
 import * as Handlers from "../../src/automation-client/handlers.ts";
 import * as OpenCode from "../../src/automation-client/opencode.ts";
+import * as Config from "../../src/config.ts";
 import * as Log from "../../src/observability/log.ts";
-import * as Support from "../support/config.ts";
 import * as FakeLog from "../support/log.ts";
 import * as FakeSpawner from "../support/fake-spawner.ts";
 import * as Reporter from "../support/reporter.ts";
 
 const TOKEN = "test-token";
+
+const ProxyConfigLive = Layer.succeed(Config.ProxyConfig)({
+  token: Redacted.make(TOKEN),
+  databaseUrl: Redacted.make("postgres://unused"),
+});
 
 type Fixture = {
   readonly spawner: FakeSpawner.FakeSpawner;
@@ -27,9 +32,8 @@ const fixture = (script: FakeSpawner.Script = () => ({ exitCode: 0 })): Fixture 
 
 const serve = (fixed: Fixture) =>
   HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
-    Layer.provide(Layer.mergeAll(fixed.spawner.layer, fixed.log.layer, Handlers.BearerAuthLive)),
+    Layer.provide(Layer.mergeAll(fixed.spawner.layer, fixed.log.layer, ProxyConfigLive)),
     Layer.provide(Layer.succeed(Log.ProcessAttribution)(Log.AutomationClientProcessAttribution)),
-    Layer.provide(Support.withEnv({ OLIGARCHY_TOKEN: TOKEN })),
     Layer.provideMerge(NodeHttpServer.layerTest),
     Layer.provideMerge(fixed.reporter.layer),
   );
@@ -59,7 +63,7 @@ describe("POST /run happy path", () => {
         expect(yield* response.json).toEqual({ ok: "true" });
       }).pipe(Effect.provide(serve(fixed)));
       expect(fixed.spawner.spawned).toMatchObject([
-        { command: OpenCode.BIN, args: ["run", "fix the bug"] },
+        { command: OpenCode.BIN, args: ["run", "--", "fix the bug"] },
       ]);
       expect(fixed.log.lines).toEqual([]);
     }),
@@ -168,6 +172,33 @@ describe("POST /run unhappy path", () => {
         const response = yield* run(http);
         expect(response.status).toBe(500);
         expect(yield* response.json).toEqual({ error: "out of token credits" });
+      }).pipe(Effect.provide(serve(fixed)));
+    }),
+  );
+});
+
+describe("interruption", () => {
+  it.effect("POST /run finishes opencode even when the client disconnects mid-run", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({}));
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const pending = yield* Effect.forkChild(run(http));
+        for (let i = 0; i < 100 && fixed.spawner.spawned[0] === undefined; i++) {
+          yield* Effect.yieldNow;
+        }
+        const spawned = fixed.spawner.spawned[0];
+        expect(spawned).toBeDefined();
+        yield* Fiber.interrupt(pending);
+        const exit = yield* Fiber.await(pending);
+        expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+        expect(yield* (spawned?.isRunning ?? Effect.succeed(false))).toBe(true);
+        yield* spawned?.exit(0) ?? Effect.void;
+        for (let i = 0; i < 100 && (yield* (spawned?.isRunning ?? Effect.succeed(false))); i++) {
+          yield* Effect.yieldNow;
+        }
+        expect(yield* (spawned?.isRunning ?? Effect.succeed(true))).toBe(false);
+        expect(spawned?.kills).toEqual([]);
       }).pipe(Effect.provide(serve(fixed)));
     }),
   );

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -192,12 +192,12 @@ describe("interruption", () => {
         yield* Fiber.interrupt(pending);
         const exit = yield* Fiber.await(pending);
         expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
-        expect(yield* (spawned?.isRunning ?? Effect.succeed(false))).toBe(true);
+        expect(yield* spawned?.isRunning ?? Effect.succeed(false)).toBe(true);
         yield* spawned?.exit(0) ?? Effect.void;
-        for (let i = 0; i < 100 && (yield* (spawned?.isRunning ?? Effect.succeed(false))); i++) {
+        for (let i = 0; i < 100 && (yield* spawned?.isRunning ?? Effect.succeed(false)); i++) {
           yield* Effect.yieldNow;
         }
-        expect(yield* (spawned?.isRunning ?? Effect.succeed(true))).toBe(false);
+        expect(yield* spawned?.isRunning ?? Effect.succeed(true)).toBe(false);
         expect(spawned?.kills).toEqual([]);
       }).pipe(Effect.provide(serve(fixed)));
     }),

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
-import { Effect, Fiber, Layer } from "effect";
+import { Effect, Fiber, Layer, Schema } from "effect";
 import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
 import { NodeHttpServer } from "@effect/platform-node";
 import * as Handlers from "../../src/automation-client/handlers.ts";
@@ -36,7 +36,13 @@ const serve = (fixed: Fixture) =>
 
 const headers = { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" };
 
-const run = (http: HttpClient.HttpClient, prompt = "do the work", extraHeaders = headers) =>
+const decodeErrorBody = Schema.decodeUnknownSync(Schema.Struct({ error: Schema.String }));
+
+const run = (
+  http: HttpClient.HttpClient,
+  prompt = "do the work",
+  extraHeaders: Record<string, string> = headers,
+) =>
   http.post("/run", {
     headers: extraHeaders,
     body: HttpBody.text(JSON.stringify({ prompt }), "application/json"),
@@ -65,7 +71,10 @@ describe("POST /run happy path", () => {
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
         const pending = yield* Effect.forkChild(run(http));
-        yield* Effect.yieldNow;
+        for (let i = 0; i < 100 && fixed.spawner.spawned[0] === undefined; i++) {
+          yield* Effect.yieldNow;
+        }
+        expect(fixed.spawner.spawned[0]).toBeDefined();
         expect(pending.pollUnsafe()).toBeUndefined();
         yield* fixed.spawner.spawned[0]?.exit(0) ?? Effect.void;
         const response = yield* Fiber.join(pending);
@@ -127,9 +136,8 @@ describe("POST /run authentication and decoding", () => {
           body: HttpBody.text("{}", "application/json"),
         });
         expect(response.status).toBe(400);
-        expect((yield* response.json) as { error: string }).toMatchObject({
-          error: expect.stringContaining("prompt") as string,
-        });
+        const body = decodeErrorBody(yield* response.json);
+        expect(body.error).toContain("prompt");
       }).pipe(Effect.provide(serve(fixed)));
       expect(fixed.spawner.spawned).toEqual([]);
     }),

--- a/test/automation-client/opencode.unit.test.ts
+++ b/test/automation-client/opencode.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as OpenCode from "../../src/automation-client/opencode.ts";
+import * as FakeSpawner from "../support/fake-spawner.ts";
+
+describe("OpenCode.run happy path", () => {
+  it.effect("launches opencode run with the prompt and succeeds when it exits 0", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({
+        exitCode: 0,
+        stdout: "the written result",
+      }));
+      yield* OpenCode.run("do the work").pipe(Effect.provide(spawner.layer));
+      expect(spawner.spawned).toMatchObject([
+        { command: OpenCode.BIN, args: ["run", "do the work"] },
+      ]);
+    }),
+  );
+});
+
+describe("OpenCode.run unhappy path", () => {
+  it.effect("forwards a spawn failure as RunFailed", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({
+        spawnError: "spawn opencode ENOENT",
+      }));
+      const error = yield* Effect.flip(
+        OpenCode.run("do the work").pipe(Effect.provide(spawner.layer)),
+      );
+      expect(error._tag).toBe("RunFailed");
+      expect(error.message).toBe("spawn opencode ENOENT");
+    }),
+  );
+
+  it.effect("forwards the command's error when it exits non-zero", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({
+        exitCode: 1,
+        stderr: "out of token credits\n",
+      }));
+      const error = yield* Effect.flip(
+        OpenCode.run("do the work").pipe(Effect.provide(spawner.layer)),
+      );
+      expect(error._tag).toBe("RunFailed");
+      expect(error.message).toBe("out of token credits");
+    }),
+  );
+});

--- a/test/automation-client/opencode.unit.test.ts
+++ b/test/automation-client/opencode.unit.test.ts
@@ -18,7 +18,7 @@ describe("OpenCode.run happy path", () => {
     }),
   );
 
-  it.effect("passes a dashed prompt after -- so opencode does not treat it as a flag", () => {
+  it.effect("passes a dashed prompt after -- so opencode does not treat it as a flag", () =>
     Effect.gen(function* () {
       const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
       yield* OpenCode.run("--help").pipe(Effect.provide(spawner.layer));

--- a/test/automation-client/opencode.unit.test.ts
+++ b/test/automation-client/opencode.unit.test.ts
@@ -13,7 +13,17 @@ describe("OpenCode.run happy path", () => {
       }));
       yield* OpenCode.run("do the work").pipe(Effect.provide(spawner.layer));
       expect(spawner.spawned).toMatchObject([
-        { command: OpenCode.BIN, args: ["run", "do the work"] },
+        { command: OpenCode.BIN, args: ["run", "--", "do the work"] },
+      ]);
+    }),
+  );
+
+  it.effect("passes a dashed prompt after -- so opencode does not treat it as a flag", () => {
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+      yield* OpenCode.run("--help").pipe(Effect.provide(spawner.layer));
+      expect(spawner.spawned).toMatchObject([
+        { command: OpenCode.BIN, args: ["run", "--", "--help"] },
       ]);
     }),
   );

--- a/test/cli.unit.test.ts
+++ b/test/cli.unit.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Fiber } from "effect";
+import * as Cli from "../src/cli.ts";
+import * as FakeSpawner from "./support/fake-spawner.ts";
+
+describe("Cli.run happy path", () => {
+  it.effect("spawns the command with its args and succeeds when it exits 0", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({
+        exitCode: 0,
+        stdout: "printed result",
+        stderr: "noise",
+      }));
+      yield* Cli.run("tool", ["--flag", "value"]).pipe(Effect.provide(spawner.layer));
+      expect(spawner.spawned).toHaveLength(1);
+      expect(spawner.spawned[0]).toMatchObject({
+        command: "tool",
+        args: ["--flag", "value"],
+        options: {
+          stdin: "ignore",
+          stdout: "ignore",
+          stderr: "pipe",
+          extendEnv: true,
+          detached: false,
+        },
+      });
+    }),
+  );
+
+  it.effect("waits until the command exits before succeeding", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({}));
+      const running = yield* Effect.forkChild(
+        Cli.run("tool", ["wait"]).pipe(Effect.provide(spawner.layer)),
+      );
+      yield* Effect.yieldNow;
+      expect(running.pollUnsafe()).toBeUndefined();
+      yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
+      yield* Fiber.join(running);
+    }),
+  );
+});
+
+describe("Cli.run unhappy path", () => {
+  it.effect("fails with the spawn error when the binary cannot be opened", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({
+        spawnError: "spawn tool ENOENT",
+      }));
+      const error = yield* Effect.flip(
+        Cli.run("tool", ["run"]).pipe(Effect.provide(spawner.layer)),
+      );
+      expect(error._tag).toBe("CliFailed");
+      expect(error.command).toBe("tool");
+      expect(error.message).toBe("spawn tool ENOENT");
+    }),
+  );
+
+  it.effect("forwards stderr when the command exits non-zero", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({
+        exitCode: 1,
+        stderr: "out of token credits\n",
+      }));
+      const error = yield* Effect.flip(
+        Cli.run("tool", ["run"]).pipe(Effect.provide(spawner.layer)),
+      );
+      expect(error._tag).toBe("CliFailed");
+      expect(error.message).toBe("out of token credits");
+    }),
+  );
+
+  it.effect("names the exit when the command exits non-zero with empty stderr", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 2 }));
+      const error = yield* Effect.flip(Cli.run("tool", []).pipe(Effect.provide(spawner.layer)));
+      expect(error.message).toBe("tool exited 2");
+    }),
+  );
+
+  it.effect("fails with the signal when the command dies before exiting", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({}));
+      const running = yield* Effect.forkChild(
+        Effect.flip(Cli.run("tool", ["run"]).pipe(Effect.provide(spawner.layer))),
+      );
+      yield* Effect.yieldNow;
+      yield* spawner.spawned[0]?.die("SIGKILL") ?? Effect.void;
+      const error = yield* Fiber.join(running);
+      expect(error._tag).toBe("CliFailed");
+      expect(error.message).toContain("SIGKILL");
+    }),
+  );
+});

--- a/test/cli.unit.test.ts
+++ b/test/cli.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
-import { Effect, Fiber, Layer, Sink, Stream } from "effect";
+import { Effect, Fiber, Layer, PlatformError, Sink, Stream } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as Cli from "../src/cli.ts";
 import * as FakeSpawner from "./support/fake-spawner.ts";
@@ -98,7 +98,13 @@ describe("Cli.run unhappy path", () => {
 
   it.effect("forwards a stderr stream failure as CliFailed, not a defect", () =>
     Effect.gen(function* () {
-      const cause = new Error("stderr pipe broken");
+      const cause = PlatformError.systemError({
+        _tag: "Unknown",
+        module: "ChildProcess",
+        method: "stderr",
+        description: "stderr pipe broken",
+        cause: new Error("stderr pipe broken"),
+      });
       const layer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
         ChildProcessSpawner.make(() =>
           Effect.succeed(

--- a/test/cli.unit.test.ts
+++ b/test/cli.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
-import { Effect, Fiber } from "effect";
+import { Effect, Fiber, Layer, Sink, Stream } from "effect";
+import { ChildProcessSpawner } from "effect/unstable/process";
 import * as Cli from "../src/cli.ts";
 import * as FakeSpawner from "./support/fake-spawner.ts";
 
@@ -23,6 +24,8 @@ describe("Cli.run happy path", () => {
           stderr: "pipe",
           extendEnv: true,
           detached: false,
+          killSignal: "SIGTERM",
+          forceKillAfter: Cli.FORCE_KILL_AFTER,
         },
       });
     }),
@@ -90,6 +93,34 @@ describe("Cli.run unhappy path", () => {
       const error = yield* Fiber.join(running);
       expect(error._tag).toBe("CliFailed");
       expect(error.message).toContain("SIGKILL");
+    }),
+  );
+
+  it.effect("forwards a stderr stream failure as CliFailed, not a defect", () =>
+    Effect.gen(function* () {
+      const cause = new Error("stderr pipe broken");
+      const layer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
+        ChildProcessSpawner.make(() =>
+          Effect.succeed(
+            ChildProcessSpawner.makeHandle({
+              pid: ChildProcessSpawner.ProcessId(1),
+              exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+              isRunning: Effect.succeed(false),
+              kill: () => Effect.void,
+              stdin: Sink.drain,
+              stdout: Stream.empty,
+              stderr: Stream.fail(cause),
+              all: Stream.fail(cause),
+              getInputFd: () => Sink.drain,
+              getOutputFd: () => Stream.empty,
+              unref: Effect.succeed(Effect.void),
+            }),
+          ),
+        ),
+      );
+      const error = yield* Effect.flip(Cli.run("tool", []).pipe(Effect.provide(layer)));
+      expect(error._tag).toBe("CliFailed");
+      expect(error.message).toBe("stderr pipe broken");
     }),
   );
 });

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { env as processEnv } from "node:process";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -179,10 +180,12 @@ describe("automation client POST /run", () => {
       const process = spawnAutomationClient(
         ["--port", String(port)],
         {},
-        `${bin}:${process.env.PATH ?? ""}`,
+        `${bin}:${processEnv.PATH ?? ""}`,
       );
       try {
-        await process.waitFor(new RegExp(`automation client listening on 127.0.0.1:${String(port)}`));
+        await process.waitFor(
+          new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
+        );
         const response = await request(
           port,
           { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
@@ -205,10 +208,12 @@ describe("automation client POST /run", () => {
       const process = spawnAutomationClient(
         ["--port", String(port)],
         {},
-        `${bin}:${process.env.PATH ?? ""}`,
+        `${bin}:${processEnv.PATH ?? ""}`,
       );
       try {
-        await process.waitFor(new RegExp(`automation client listening on 127.0.0.1:${String(port)}`));
+        await process.waitFor(
+          new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
+        );
         const response = await request(
           port,
           { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
@@ -231,10 +236,12 @@ describe("automation client POST /run", () => {
       const process = spawnAutomationClient(
         ["--port", String(port)],
         {},
-        `${bin}:${process.env.PATH ?? ""}`,
+        `${bin}:${processEnv.PATH ?? ""}`,
       );
       try {
-        await process.waitFor(new RegExp(`automation client listening on 127.0.0.1:${String(port)}`));
+        await process.waitFor(
+          new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
+        );
         const response = await request(
           port,
           { "content-type": "application/json" },

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -1,0 +1,252 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+
+const AUTOMATION_CLIENT = fileURLToPath(new URL("../../automation-client", import.meta.url));
+const TOKEN = "t";
+const EXIT_WITHIN_MS = 60_000;
+
+type Process = {
+  readonly child: ChildProcess;
+  readonly stdout: () => string;
+  readonly stderr: () => string;
+  readonly exited: Promise<{ readonly code: number | null; readonly signal: string | null }>;
+  readonly waitFor: (pattern: RegExp, timeoutMs?: number) => Promise<void>;
+};
+
+const environment = (
+  home: string,
+  path: string,
+  overrides: Record<string, string>,
+): NodeJS.ProcessEnv => {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: home,
+    PATH: path,
+    OLIGARCHY_TOKEN: TOKEN,
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --disable-warning=ExperimentalWarning`.trim(),
+    https_proxy: "http://127.0.0.1:1",
+    http_proxy: "http://127.0.0.1:1",
+    no_proxy: "",
+    ...overrides,
+  };
+  delete env.FORCE_COLOR;
+  return env;
+};
+
+const spawnAutomationClient = (
+  args: ReadonlyArray<string>,
+  overrides: Record<string, string> = {},
+  path = process.env.PATH ?? "",
+): Process => {
+  const home = mkdtempSync(join(tmpdir(), "oligarchy-automation-client-home-"));
+  const cwd = mkdtempSync(join(tmpdir(), "oligarchy-automation-client-cwd-"));
+  const child = spawn(AUTOMATION_CLIENT, args, {
+    cwd,
+    env: environment(home, path, overrides),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  const listeners = new Set<() => void>();
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (data: string) => {
+    stdout += data;
+    for (const listener of listeners) listener();
+  });
+  child.stderr.on("data", (data: string) => {
+    stderr += data;
+    for (const listener of listeners) listener();
+  });
+  const exited = new Promise<{ code: number | null; signal: string | null }>((resolve, reject) => {
+    const timer = setTimeout(() => child.kill("SIGKILL"), EXIT_WITHIN_MS);
+    child.on("error", (cause) => {
+      clearTimeout(timer);
+      reject(cause);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      rmSync(cwd, { recursive: true, force: true });
+      rmSync(home, { recursive: true, force: true });
+      for (const listener of listeners) listener();
+      resolve({ code, signal });
+    });
+  });
+  const waitFor = (pattern: RegExp, timeoutMs = 30_000) =>
+    new Promise<void>((resolve, reject) => {
+      const check = () => {
+        if (pattern.test(stdout) || pattern.test(stderr)) {
+          listeners.delete(check);
+          clearTimeout(timer);
+          resolve();
+        } else if (child.exitCode !== null) {
+          listeners.delete(check);
+          clearTimeout(timer);
+          reject(
+            new Error(
+              `automation client exited ${String(child.exitCode)} before ${pattern.source}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+            ),
+          );
+        }
+      };
+      const timer = setTimeout(() => {
+        listeners.delete(check);
+        reject(new Error(`no ${pattern.source} within ${String(timeoutMs)}ms\nstdout:\n${stdout}`));
+      }, timeoutMs);
+      listeners.add(check);
+      check();
+    });
+  return { child, stdout: () => stdout, stderr: () => stderr, exited, waitFor };
+};
+
+const portOf = (address: string | AddressInfo | null): number =>
+  typeof address === "object" && address !== null ? address.port : 0;
+
+const occupy = (): Promise<{ readonly port: number; readonly release: () => Promise<void> }> =>
+  new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        port: portOf(server.address()),
+        release: () => new Promise((done) => server.close(() => done())),
+      });
+    });
+  });
+
+const freePort = async (): Promise<number> => {
+  const { port, release } = await occupy();
+  await release();
+  return port;
+};
+
+const installOpencode = (script: string): string => {
+  const bin = mkdtempSync(join(tmpdir(), "oligarchy-opencode-"));
+  const file = join(bin, "opencode");
+  writeFileSync(file, `#!/bin/sh\n${script}\n`);
+  chmodSync(file, 0o755);
+  return bin;
+};
+
+const request = (port: number, headers: Record<string, string>, body: string) =>
+  fetch(`http://127.0.0.1:${String(port)}/run`, { method: "POST", headers, body });
+
+describe("automation client startup refusals", () => {
+  it.live("--help exits 0 and lists --port alone", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomationClient(["--help"]);
+      const { code } = await process.exited;
+      expect(code).toBe(0);
+      expect(process.stdout()).toContain("automation-client");
+      expect(process.stdout()).toContain("--port");
+      expect(process.stdout()).not.toContain("--display");
+    }),
+  );
+
+  it.live("a --port that is not an integer exits 1 with a usage error", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomationClient(["--port", "forty"]);
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("forty");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live("a missing OLIGARCHY_TOKEN exits 1 with OLIGARCHY_TOKEN is not set", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomationClient([], { OLIGARCHY_TOKEN: "" });
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("OLIGARCHY_TOKEN is not set");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+});
+
+describe("automation client POST /run", () => {
+  it.live("answers 200 when opencode exits 0", () =>
+    Effect.promise(async () => {
+      const bin = installOpencode("exit 0");
+      const port = await freePort();
+      const process = spawnAutomationClient(
+        ["--port", String(port)],
+        {},
+        `${bin}:${process.env.PATH ?? ""}`,
+      );
+      try {
+        await process.waitFor(new RegExp(`automation client listening on 127.0.0.1:${String(port)}`));
+        const response = await request(
+          port,
+          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          JSON.stringify({ prompt: "do the work" }),
+        );
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ ok: "true" });
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+        rmSync(bin, { recursive: true, force: true });
+      }
+    }),
+  );
+
+  it.live("answers 500 with opencode's error when it exits non-zero", () =>
+    Effect.promise(async () => {
+      const bin = installOpencode("echo out of token credits >&2; exit 1");
+      const port = await freePort();
+      const process = spawnAutomationClient(
+        ["--port", String(port)],
+        {},
+        `${bin}:${process.env.PATH ?? ""}`,
+      );
+      try {
+        await process.waitFor(new RegExp(`automation client listening on 127.0.0.1:${String(port)}`));
+        const response = await request(
+          port,
+          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          JSON.stringify({ prompt: "do the work" }),
+        );
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ error: "out of token credits" });
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+        rmSync(bin, { recursive: true, force: true });
+      }
+    }),
+  );
+
+  it.live("answers 401 without the bearer", () =>
+    Effect.promise(async () => {
+      const bin = installOpencode("exit 0");
+      const port = await freePort();
+      const process = spawnAutomationClient(
+        ["--port", String(port)],
+        {},
+        `${bin}:${process.env.PATH ?? ""}`,
+      );
+      try {
+        await process.waitFor(new RegExp(`automation client listening on 127.0.0.1:${String(port)}`));
+        const response = await request(
+          port,
+          { "content-type": "application/json" },
+          JSON.stringify({ prompt: "do the work" }),
+        );
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: "unauthorized" });
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+        rmSync(bin, { recursive: true, force: true });
+      }
+    }),
+  );
+});

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -5,13 +5,21 @@ import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect } from "vitest";
+import { describe, expect, inject } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect } from "effect";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Client } from "pg";
+import * as DbSchema from "../../src/db/schema.ts";
+import * as Postgres from "../support/postgres.ts";
 
 const AUTOMATION_CLIENT = fileURLToPath(new URL("../../automation-client", import.meta.url));
 const TOKEN = "t";
+const UNREACHABLE = "postgres://user:sentinel-pw@127.0.0.1:1/oligarchy";
 const EXIT_WITHIN_MS = 60_000;
+
+const dbUrl = inject("dbUrl");
 
 type Process = {
   readonly child: ChildProcess;
@@ -31,6 +39,7 @@ const environment = (
     HOME: home,
     PATH: path,
     OLIGARCHY_TOKEN: TOKEN,
+    DATABASE_URL: dbUrl === "" ? UNREACHABLE : dbUrl,
     NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --disable-warning=ExperimentalWarning`.trim(),
     https_proxy: "http://127.0.0.1:1",
     http_proxy: "http://127.0.0.1:1",
@@ -136,8 +145,25 @@ const installOpencode = (script: string): string => {
   return bin;
 };
 
+const lines = (output: string): ReadonlyArray<string> =>
+  output.split("\n").filter((line) => line !== "");
+
 const request = (port: number, headers: Record<string, string>, body: string) =>
   fetch(`http://127.0.0.1:${String(port)}/run`, { method: "POST", headers, body });
+
+const logsForClient = async () => {
+  const client = new Client({ connectionString: Postgres.getDbUrl() });
+  await client.connect();
+  try {
+    const db = drizzle({ client, schema: DbSchema });
+    return await db
+      .select()
+      .from(DbSchema.logs)
+      .where(eq(DbSchema.logs.location, "automation-client"));
+  } finally {
+    await client.end();
+  }
+};
 
 describe("automation client startup refusals", () => {
   it.live("--help exits 0 and lists --port alone", () =>
@@ -167,12 +193,63 @@ describe("automation client startup refusals", () => {
       const { code } = await process.exited;
       expect(code).toBe(1);
       expect(process.stderr()).toContain("OLIGARCHY_TOKEN is not set");
+      expect(process.stderr()).not.toContain("sentinel-pw");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live("a missing DATABASE_URL exits 1 with DATABASE_URL is not set", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomationClient([], { DATABASE_URL: "" });
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("DATABASE_URL is not set");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live("an unreachable database exits 1 and never listens", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomationClient([], { DATABASE_URL: UNREACHABLE });
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      const fatal = lines(process.stdout()).find((line) =>
+        line.startsWith("[automation-client] automation-client: fatal: automation client: "),
+      );
+      expect(fatal, process.stdout()).toBeDefined();
+      expect(fatal).toContain("database unreachable");
+      expect(process.stdout()).not.toContain("sentinel-pw");
+      expect(process.stderr()).not.toContain("sentinel-pw");
       expect(process.stdout()).not.toContain("listening");
     }),
   );
 });
 
-describe("automation client POST /run", () => {
+const describeWithDatabase = dbUrl === "" ? describe.skip : describe;
+
+describeWithDatabase("automation client startup refusals with a database", () => {
+  it.live("an occupied port exits 1 with EADDRINUSE", () =>
+    Effect.promise(async () => {
+      const { port, release } = await occupy();
+      try {
+        const process = spawnAutomationClient(["--port", String(port)]);
+        const { code } = await process.exited;
+        expect(code).toBe(1);
+        const fatal = lines(process.stdout()).find((line) =>
+          line.startsWith("[automation-client] automation-client: fatal: automation client: "),
+        );
+        expect(fatal, process.stdout()).toBeDefined();
+        expect(fatal).toContain("EADDRINUSE");
+        expect(fatal).toContain(`127.0.0.1:${String(port)}`);
+        expect(process.stdout()).not.toContain("listening");
+      } finally {
+        await release();
+      }
+    }),
+  );
+});
+
+describeWithDatabase("automation client POST /run", () => {
   it.live("answers 200 when opencode exits 0", () =>
     Effect.promise(async () => {
       const bin = installOpencode("exit 0");
@@ -229,7 +306,7 @@ describe("automation client POST /run", () => {
     }),
   );
 
-  it.live("answers 401 without the bearer", () =>
+  it.live("answers 401 without the bearer and persists the error in logs", () =>
     Effect.promise(async () => {
       const bin = installOpencode("exit 0");
       const port = await freePort();
@@ -249,6 +326,8 @@ describe("automation client POST /run", () => {
         );
         expect(response.status).toBe(401);
         expect(await response.json()).toEqual({ error: "unauthorized" });
+        const rows = await logsForClient();
+        expect(rows.some((row) => row.text.includes("POST /run failed: unauthorized"))).toBe(true);
       } finally {
         process.child.kill("SIGTERM");
         await process.exited;

--- a/test/integration/client.integration.test.ts
+++ b/test/integration/client.integration.test.ts
@@ -6,8 +6,8 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import * as StubProxy from "../support/stub-proxy.ts";
 
-// The root wrapper, which execs v2/client.
-const CLIENT = fileURLToPath(new URL("../../../client", import.meta.url));
+// The root wrapper.
+const CLIENT = fileURLToPath(new URL("../../client", import.meta.url));
 const EXIT_WITHIN_MS = 30_000;
 const SESSION = "session-1";
 const AGENT = "agent-1";

--- a/test/integration/session.integration.test.ts
+++ b/test/integration/session.integration.test.ts
@@ -11,10 +11,10 @@ import * as DbSchema from "../../src/db/schema.ts";
 import * as Postgres from "../support/postgres.ts";
 import * as StubProxy from "../support/stub-proxy.ts";
 
-const ROOT = resolve(import.meta.dirname, "../../..");
+const ROOT = resolve(import.meta.dirname, "../..");
 const SESSION = resolve(ROOT, "session");
-const CLIENT_MAIN = resolve(ROOT, "v2/src/client/main.ts");
-const CTRL_MAIN = resolve(ROOT, "v2/src/ctrl/main.ts");
+const CLIENT_MAIN = resolve(ROOT, "src/client/main.ts");
+const CTRL_MAIN = resolve(ROOT, "src/ctrl/main.ts");
 const { SESSION_ID, FOLLOWED_ID, ENDED_ID, DROPPED_ID, ENDLESS_ID } = StubProxy;
 const ESC = String.fromCharCode(27);
 const ALT_SCREEN_ON = `${ESC}[?1049h`;

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -256,3 +256,28 @@ describe("AutomationServerApi", () => {
     expect(routes(Api.QemuReverseProxyApi).map(({ path }) => path)).not.toContain("/linear");
   });
 });
+
+describe("AutomationClientApi", () => {
+  const client = Api.AutomationClientApi;
+
+  it("declares POST /run and nothing else", () => {
+    const table = routes(client).map(({ method, path }) => `${method} ${path}`);
+    expect(table).toEqual(["POST /run"]);
+    expect(HttpApiClient.urlBuilder(client).Runs.run()).toBe("/run");
+  });
+
+  it("requires the bearer and applies BearerAuth then ApiBoundary", () => {
+    const spec = OpenApi.fromApi(client);
+    const run = byIdentifier(client, "run");
+    expect(run.group).toBe("Runs");
+    expect(run.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);
+    expect(spec.paths["/run"]?.post?.security).toEqual([{ bearer: [] }]);
+    expect(run.errors).toEqual([400, 401, 500]);
+  });
+
+  it("is its own api: no other process answers /run", () => {
+    expect(routes(Api.QemuServerApi).map(({ path }) => path)).not.toContain("/run");
+    expect(routes(Api.QemuReverseProxyApi).map(({ path }) => path)).not.toContain("/run");
+    expect(routes(Api.AutomationServerApi).map(({ path }) => path)).not.toContain("/run");
+  });
+});

--- a/test/shared/errors.unit.test.ts
+++ b/test/shared/errors.unit.test.ts
@@ -106,6 +106,12 @@ const cases: ReadonlyArray<WireCase> = [
     error: Errors.NoServer.make({ message: "no server registered", agentId: AGENT_ID }),
     status: 503,
   },
+  {
+    name: "RunFailed",
+    wire: Errors.RunFailedWire,
+    error: Errors.RunFailed.make({ message: "out of token credits" }),
+    status: 500,
+  },
 ];
 
 describe("API error wire codecs", () => {
@@ -238,5 +244,7 @@ describe("domain error messages", () => {
     expect(Errors.LinearError.make({ operation: "team", message: "x" })._tag).toBe("LinearError");
     expect(Errors.PngDecodeError.make({ message: "x" })._tag).toBe("PngDecodeError");
     expect(Errors.LogLine.make({ text: "x", level: "error" })._tag).toBe("LogLine");
+    expect(Errors.CliFailed.make({ command: "tool", message: "x" })._tag).toBe("CliFailed");
+    expect(Errors.RunFailed.make({ message: "x" })._tag).toBe("RunFailed");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Align the automation client with the same Database, ProxyConfig, LogStore, and middleware graph the other HTTP processes use.

## What changed

- `./automation-client` now reads `OLIGARCHY_TOKEN` and `DATABASE_URL` from `Config.ProxyConfig`, persists logs through `Log.Log.layer` + `LogStore`, and pings Postgres before listen.
- Routes use shared `Middleware.BearerAuthLive` and `ApiBoundaryLive` instead of a local token layer.
- `POST /run` is uninterruptible so a client disconnect does not kill OpenCode.
- The CLI runner maps stderr stream failures as `CliFailed`, sends `SIGTERM` then force-kills after 5 seconds, and OpenCode receives the prompt after `--`.

## Tests

- `npm run check:fast` is green: 903 unit tests.
- Automation-client integration: 5 passed (help, bad port, missing token, missing `DATABASE_URL`, unreachable database). 4 skipped here because Docker is not available (occupied port and live `POST /run`).

This is still just the client: one `POST /run` that launches `opencode run` and waits. No dispatcher, tickets, or job claim.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08d01-0b64-7029-9d8e-485f091d6ea7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08d01-0b64-7029-9d8e-485f091d6ea7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

