### PR TITLE
Dispatch automation jobs to live clients

### DIFF
--- a/src/automation-server/client.ts
+++ b/src/automation-server/client.ts
@@ -1,0 +1,74 @@
+import { Context, Effect, Layer, Option, Redacted, Schema } from "effect";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { HttpApiClient, HttpApiMiddleware } from "effect/unstable/httpapi";
+import * as Config from "../config.ts";
+import * as Api from "../shared/api.ts";
+import * as Contract from "../shared/contract.ts";
+import * as Errors from "../shared/errors.ts";
+
+export class OligarchyToken extends Context.Service<OligarchyToken>()(
+  "@oligarchy/automation-server/OligarchyToken",
+  { make: Config.oligarchyToken },
+) {
+  static readonly layer = Layer.effect(this)(this.make);
+}
+
+const WireError = Schema.fromJsonString(Schema.Struct({ error: Schema.String }));
+const decodeWireError = Schema.decodeUnknownOption(WireError);
+
+const bodyDetail = (text: string): string | undefined =>
+  Option.match(decodeWireError(text), {
+    onNone: () => (text === "" ? undefined : text),
+    onSome: (body) => body.error,
+  });
+
+const failed = (
+  url: string,
+  status: number | undefined,
+  text: string,
+  cause: unknown,
+): Errors.AutomationClientError => {
+  const detail = bodyDetail(text);
+  return Errors.AutomationClientError.make(
+    Object.assign(
+      {
+        message:
+          detail === undefined
+            ? `automation client: POST ${url}/run failed`
+            : `automation client: POST ${url}/run failed: ${detail}`,
+        cause,
+      },
+      status === undefined ? undefined : { status },
+    ),
+  );
+};
+
+// POST /run and wait for the client to finish. node:http has no ceiling of its own; a drive or
+// diagnose runs until the client answers, or until this fiber is interrupted.
+export const run = Effect.fn("run")(function* (url: string, prompt: string) {
+  const token = Redacted.value(yield* OligarchyToken);
+  const bearer = HttpApiMiddleware.layerClient(Api.BearerAuth, ({ next, request }) =>
+    next(HttpClientRequest.bearerToken(request, token)),
+  );
+  const middleware = yield* Effect.scoped(Layer.build(bearer));
+  const client = yield* HttpApiClient.make(Api.AutomationClientApi, {
+    baseUrl: url,
+    transformClient: HttpClient.filterStatusOk,
+  }).pipe(Effect.provide(middleware));
+  return yield* client.Runs.run({ payload: Contract.RunBody.make({ prompt }) }).pipe(
+    Effect.catch((error) => {
+      if (error._tag === "HttpClientError") {
+        const response = error.response;
+        if (response === undefined) {
+          return Effect.fail(failed(url, undefined, "", error));
+        }
+        return response.text.pipe(
+          Effect.orElseSucceed(() => ""),
+          Effect.flatMap((text) => Effect.fail(failed(url, response.status, text, error))),
+        );
+      }
+      return Effect.fail(failed(url, undefined, "", error));
+    }),
+    Effect.asVoid,
+  );
+});

--- a/src/automation-server/command.ts
+++ b/src/automation-server/command.ts
@@ -64,6 +64,6 @@ export const makeAutomationServerCommand = <RServe>(server: AutomationServer<RSe
       }),
   ).pipe(
     Command.withDescription(
-      "The automation server: POST /linear verifies a signed Linear webhook and enqueues drive or diagnose jobs from status changes",
+      "The automation server: POST /linear verifies a signed Linear webhook and enqueues drive or diagnose jobs, then dispatches them to live automation clients",
     ),
   );

--- a/src/automation-server/main.ts
+++ b/src/automation-server/main.ts
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
+import { NodeHttpClient, NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
 import { Cause, Deferred, Effect, Exit, Layer, type Runtime } from "effect";
 import { Command } from "effect/unstable/cli";
 import { HttpMiddleware, HttpRouter, HttpServerError } from "effect/unstable/http";
@@ -7,13 +7,16 @@ import * as Config from "../config.ts";
 import * as Automation from "../db/automation.ts";
 import * as Client from "../db/client.ts";
 import * as Logs from "../db/logs.ts";
+import * as Servers from "../db/servers.ts";
 import * as Tests from "../db/tests.ts";
 import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
 import * as Sentry from "../observability/sentry.ts";
 import * as Api from "../shared/api.ts";
+import * as AutomationClient from "./client.ts";
 import * as AutomationServerCommand from "./command.ts";
 import * as Handlers from "./handlers.ts";
+import * as Worker from "./worker.ts";
 
 const HOST = "127.0.0.1";
 
@@ -42,6 +45,7 @@ const ServerLive = (port: number) =>
       const log = yield* Log.Log;
       yield* log.acquireColor(Log.AutomationAgentId);
       yield* log.info(`automation server listening on ${HOST}:${String(port)}`, automationAttr);
+      yield* Worker.dispatch();
     }),
   ).pipe(
     Layer.provide(
@@ -56,20 +60,24 @@ const ServerLive = (port: number) =>
 
 const DatabaseLive = Layer.unwrap(Effect.map(Config.databaseUrl, Client.Database.layer));
 
-// LINEAR_WEBHOOK_SECRET signs POST /linear; DATABASE_URL holds the queue and the logs rows.
-// Sentry sits beneath Log so Log captures the reporter. Lines land in logs with
-// location/agentId "automation"; durable jobs remain automation_jobs.
+// LINEAR_WEBHOOK_SECRET signs POST /linear; OLIGARCHY_TOKEN authenticates POST /run to a
+// client; DATABASE_URL holds the queue, the live-server list and the logs rows. Sentry sits
+// beneath Log so Log captures the reporter. Lines land in logs with location/agentId
+// "automation"; durable jobs remain automation_jobs.
 const MainLive = Layer.mergeAll(
   Log.Log.layer,
   Handlers.LinearWebhookSecret.layer,
+  AutomationClient.OligarchyToken.layer,
   Tests.TestStore.layer,
   Automation.AutomationStore.layer,
+  Servers.ServerStore.layer,
 ).pipe(
   Layer.provideMerge(Logs.LogStore.layer),
   Layer.provideMerge(DatabaseLive),
   Layer.provideMerge(Sentry.SentryLive),
   Layer.provideMerge(Layer.succeed(Log.ProcessAttribution)(Log.AutomationProcessAttribution)),
   Layer.provideMerge(Config.providerLayer),
+  Layer.provideMerge(NodeHttpClient.layerNodeHttp),
   Layer.provideMerge(NodeServices.layer),
 );
 
@@ -78,9 +86,9 @@ const command = AutomationServerCommand.makeAutomationServerCommand({
   serverFailed,
 });
 
-// The graph is built before the command runs: a missing LINEAR_WEBHOOK_SECRET or DATABASE_URL is
-// the one failure no Log exists to record, so it is printed here. Every later failure logs its
-// own fatal line; a defect has nothing else to say for it.
+// The graph is built before the command runs: a missing LINEAR_WEBHOOK_SECRET, OLIGARCHY_TOKEN
+// or DATABASE_URL is the one failure no Log exists to record, so it is printed here. Every
+// later failure logs its own fatal line; a defect has nothing else to say for it.
 const program = Effect.gen(function* () {
   const services = yield* Layer.build(MainLive).pipe(Effect.tapCause(Render.reportFailure));
   yield* Command.run(command, { version: Api.VERSION }).pipe(

--- a/src/automation-server/prompts.ts
+++ b/src/automation-server/prompts.ts
@@ -1,0 +1,78 @@
+import { Array as Arr, Effect, FileSystem, Option, Result } from "effect";
+import * as Errors from "../shared/errors.ts";
+
+// The Cursor model id a driving or diagnosing agent is told it is running as.
+export const MODEL = "cursor-grok-4.6-high-fast";
+
+const besideModule = (relative: string): string =>
+  decodeURIComponent(new URL(relative, import.meta.url).pathname);
+
+// The guides a template may embed, by the name it uses. Read only when named, so an unreadable
+// guide cannot stop a rendering whose template does not embed it.
+const GUIDES: Readonly<Record<string, string>> = {
+  CTRL_DIAGNOSE_MD: besideModule("../../ctrl-diagnose.md"),
+};
+
+const PLACEHOLDER = /\{\{([A-Z_]+)\}\}/g;
+
+const read = Effect.fn("Prompts.read")(function* (path: string) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs
+    .readFileString(path)
+    .pipe(
+      Effect.mapError((error) =>
+        Errors.PromptError.make({ message: `prompt: ${error.message}`, cause: error }),
+      ),
+    );
+});
+
+const fill = (
+  template: string,
+  text: string,
+  values: Readonly<Record<string, string>>,
+): Result.Result<string, Errors.PromptError> => {
+  const missing: Array<string> = [];
+  const filled = text.replace(PLACEHOLDER, (match: string, name: string) => {
+    const value = values[name];
+    if (value === undefined) {
+      missing.push(name);
+      return match;
+    }
+    return value;
+  });
+  return Option.match(Arr.head(missing), {
+    onNone: () => Result.succeed(filled),
+    onSome: (name) =>
+      Result.fail(
+        Errors.PromptError.make({
+          message: `prompt: prompts/${template} uses {{${name}}}, which has no value`,
+        }),
+      ),
+  });
+};
+
+const render = Effect.fn("Prompts.render")(function* (
+  template: string,
+  values: Readonly<Record<string, string>>,
+) {
+  const text = yield* read(besideModule(`../../prompts/${template}`));
+  const known: Record<string, string> = { ...values };
+  for (const [name, path] of Object.entries(GUIDES)) {
+    if (text.includes(`{{${name}}}`)) {
+      known[name] = (yield* read(path)).trimEnd();
+    }
+  }
+  return yield* Effect.fromResult(fill(template, text, known));
+});
+
+export const drive = Effect.fn("Prompts.drive")(function* (ticket: string) {
+  return yield* render("driving-agent.html", { LINEAR_TICKET: ticket, MODEL });
+});
+
+export const diagnose = Effect.fn("Prompts.diagnose")(function* (ticket: string, resultId: string) {
+  return yield* render("diagnosing-agent.html", {
+    LINEAR_TICKET: ticket,
+    RESULT_ID: resultId,
+    MODEL,
+  });
+});

--- a/src/automation-server/prompts.ts
+++ b/src/automation-server/prompts.ts
@@ -1,8 +1,8 @@
 import { Array as Arr, Effect, FileSystem, Option, Result } from "effect";
 import * as Errors from "../shared/errors.ts";
 
-// The Cursor model id a driving or diagnosing agent is told it is running as.
-export const MODEL = "cursor-grok-4.6-high-fast";
+// The OpenCode model id a driving or diagnosing agent is told it is running as.
+export const MODEL = "opencode/muse-spark-1-3-contributor-free";
 
 const besideModule = (relative: string): string =>
   decodeURIComponent(new URL(relative, import.meta.url).pathname);

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -97,9 +97,15 @@ export const dispatch = Effect.fn("dispatch")(function* () {
               onFailure: outcomeFrom,
             }),
             Effect.flatMap((outcome) =>
-              logOutcome(job, outcome).pipe(
-                Effect.andThen(store.finish(job.id, outcome.status, outcome.reason)),
-              ),
+              Effect.gen(function* () {
+                const closed = yield* store.finish(job.id, outcome.status, outcome.reason);
+                if (!closed) {
+                  return yield* Effect.die(
+                    new Error(`finishAutomationJob: ${job.id} was not running`),
+                  );
+                }
+                return yield* logOutcome(job, outcome);
+              }),
             ),
           );
         }),

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -1,0 +1,124 @@
+import { Cause, Effect, Option, Schedule, Schema } from "effect";
+import * as Automation from "../db/automation.ts";
+import * as Servers from "../db/servers.ts";
+import * as Tests from "../db/tests.ts";
+import * as ExternalFailure from "../external-failure.ts";
+import * as Log from "../observability/log.ts";
+import * as Render from "../observability/render.ts";
+import * as Errors from "../shared/errors.ts";
+import * as AutomationClient from "./client.ts";
+import * as Prompts from "./prompts.ts";
+
+const DISPATCH_INTERVAL = "5 seconds";
+
+const isDatabaseError = Schema.is(Errors.DatabaseError);
+
+const detail = (error: unknown): string =>
+  isDatabaseError(error)
+    ? Render.errorDetail(ExternalFailure.causeOf(error))
+    : Render.errorDetail(error);
+
+type Outcome = {
+  readonly status: Automation.FinishStatus;
+  readonly reason: string | null;
+};
+
+const aborted: Outcome = {
+  status: "aborted",
+  reason: "automation server shutting down",
+};
+
+const outcomeFrom = (cause: Cause.Cause<unknown>): Outcome =>
+  Cause.hasInterruptsOnly(cause)
+    ? aborted
+    : { status: "failed", reason: Render.errorDetail(Cause.squash(cause)) };
+
+const execute = Effect.fn("execute")(function* (job: Automation.AutomationJobRow, url: string) {
+  const tests = yield* Tests.TestStore;
+  const log = yield* Log.Log;
+  const result = yield* tests.findResult(job.resultId);
+  if (Option.isNone(result) || result.value.linearId === null) {
+    return yield* Errors.AutomationClientError.make({ message: "no Linear ticket" });
+  }
+  const ticket = result.value.linearId;
+  const prompt =
+    job.action === "drive"
+      ? yield* Prompts.drive(ticket)
+      : yield* Prompts.diagnose(ticket, job.resultId);
+  yield* log.info(`dispatching ${job.action}; ${url}`, {
+    location: Log.Locations.automation,
+    agentId: ticket,
+  });
+  return yield* AutomationClient.run(url, prompt);
+});
+
+const logOutcome = Effect.fn("logOutcome")(function* (
+  job: Automation.AutomationJobRow,
+  outcome: Outcome,
+) {
+  const log = yield* Log.Log;
+  const attr = { location: Log.Locations.automation };
+  if (outcome.status === "succeeded") {
+    yield* log.info(`${job.action} succeeded`, attr);
+    return;
+  }
+  if (outcome.status === "aborted") {
+    yield* log.info(`${job.action} aborted`, attr);
+    return;
+  }
+  yield* log.error(`${job.action} failed; ${outcome.reason}`, attr);
+});
+
+// One job at a time, to the first live automation-client. A tick with no live client does not
+// claim. Claim is uninterruptible so a shutdown cannot leave a pending row half-taken; the HTTP
+// wait is restored so SIGTERM aborts an in-flight job; finish is uninterruptible so the write
+// lands. A tick that fails is one error line; the next tick runs.
+export const dispatch = Effect.fn("dispatch")(function* () {
+  const servers = yield* Servers.ServerStore;
+  const store = yield* Automation.AutomationStore;
+  const log = yield* Log.Log;
+
+  const tick = Effect.fn("tick")(function* () {
+    const live = yield* servers.listLiveServers("automation-client");
+    const url = live[0];
+    if (url === undefined) {
+      return;
+    }
+    yield* Effect.uninterruptibleMask((restore) =>
+      store.claim().pipe(
+        Effect.flatMap((maybe) => {
+          if (Option.isNone(maybe)) {
+            return Effect.void;
+          }
+          const job = maybe.value;
+          return restore(execute(job, url)).pipe(
+            Effect.matchCause({
+              onSuccess: (): Outcome => ({ status: "succeeded", reason: null }),
+              onFailure: outcomeFrom,
+            }),
+            Effect.flatMap((outcome) =>
+              logOutcome(job, outcome).pipe(
+                Effect.andThen(store.finish(job.id, outcome.status, outcome.reason)),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  });
+
+  yield* tick().pipe(
+    Effect.catchCause((cause) => {
+      if (Cause.hasInterruptsOnly(cause)) {
+        return Effect.failCause(cause);
+      }
+      const error = Cause.squash(cause);
+      return log.error(`dispatch tick failed: ${detail(error)}`, {
+        location: Log.Locations.automation,
+        cause: error,
+      });
+    }),
+    Effect.repeat(Schedule.spaced(DISPATCH_INTERVAL)),
+    Effect.forkScoped({ startImmediately: true }),
+  );
+});

--- a/src/db/automation.ts
+++ b/src/db/automation.ts
@@ -1,9 +1,11 @@
-import { Context, Effect, Layer } from "effect";
+import { and, eq, sql } from "drizzle-orm";
+import { Array as Arr, Context, Effect, Layer, Option } from "effect";
 import * as Client from "./client.ts";
 import * as DbSchema from "./schema.ts";
 
 export type AutomationJobRow = typeof DbSchema.automationJobs.$inferSelect;
 export type AutomationAction = AutomationJobRow["action"];
+export type FinishStatus = "succeeded" | "failed" | "aborted";
 
 export type EnqueueInput = {
   readonly resultId: string;
@@ -27,7 +29,63 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
         return row;
       });
 
-      return { enqueue };
+      // Oldest pending, locked for the transaction so a second claimer waits. Queue order is
+      // created_at; id breaks a tie.
+      const claim = Effect.fn("db.claimAutomationJob")(function* () {
+        return yield* database.transaction("claimAutomationJob", (tx) =>
+          Effect.gen(function* () {
+            const pending = yield* Client.attempt("claimAutomationJob", () =>
+              tx
+                .select()
+                .from(DbSchema.automationJobs)
+                .where(eq(DbSchema.automationJobs.status, "pending"))
+                .orderBy(DbSchema.automationJobs.createdAt, DbSchema.automationJobs.id)
+                .limit(1)
+                .for("update"),
+            );
+            const row = Arr.head(pending);
+            if (Option.isNone(row)) {
+              return Option.none();
+            }
+            const updated = yield* Client.attempt("claimAutomationJob", () =>
+              tx
+                .update(DbSchema.automationJobs)
+                .set({ status: "running", startedAt: sql`now()` })
+                .where(eq(DbSchema.automationJobs.id, row.value.id))
+                .returning(),
+            );
+            return Arr.head(updated);
+          }),
+        );
+      });
+
+      // Only a running row closes. reason is omitted when null so a previous value stays.
+      const finish = Effect.fn("db.finishAutomationJob")(function* (
+        id: string,
+        status: FinishStatus,
+        reason: string | null,
+      ) {
+        const rows = yield* database.run("finishAutomationJob", (db) =>
+          db
+            .update(DbSchema.automationJobs)
+            .set(
+              Object.assign(
+                { status, finishedAt: sql`now()` },
+                reason === null ? undefined : { reason },
+              ),
+            )
+            .where(
+              and(
+                eq(DbSchema.automationJobs.id, id),
+                eq(DbSchema.automationJobs.status, "running"),
+              ),
+            )
+            .returning({ id: DbSchema.automationJobs.id }),
+        );
+        return rows.length > 0;
+      });
+
+      return { enqueue, claim, finish };
     }),
   },
 ) {

--- a/src/db/servers.ts
+++ b/src/db/servers.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { Array as Arr, Context, Effect, Layer, Option } from "effect";
 import * as Client from "./client.ts";
 import * as DbSchema from "./schema.ts";
@@ -66,6 +66,24 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       return rows.map((row) => row.url);
     });
 
+    // Clients write every 30s; 45s is one missed beat plus a little. A null heartbeat is
+    // an operator-added row no process has claimed, so it is not live.
+    const listLiveServers = Effect.fn("db.listLiveServers")(function* (type: ServerType) {
+      const rows = yield* database.run("listLiveServers", (db) =>
+        db
+          .select({ url: DbSchema.servers.url })
+          .from(DbSchema.servers)
+          .where(
+            and(
+              eq(DbSchema.servers.type, type),
+              sql`${DbSchema.servers.heartbeatAt} > now() - interval '45 seconds'`,
+            ),
+          )
+          .orderBy(DbSchema.servers.createdAt, DbSchema.servers.url),
+      );
+      return rows.map((row) => row.url);
+    });
+
     // A session is routed once; a second insert is the primary key's DatabaseError by design.
     const routeSession = Effect.fn("db.routeSession")(function* (sessionId: string, url: string) {
       yield* database.run("routeSession", (db) =>
@@ -83,7 +101,15 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       return Option.map(Arr.head(rows), (row) => row.serverUrl);
     });
 
-    return { addServer, heartbeat, removeServer, listServers, routeSession, serverForSession };
+    return {
+      addServer,
+      heartbeat,
+      removeServer,
+      listServers,
+      listLiveServers,
+      routeSession,
+      serverForSession,
+    };
   }),
 }) {
   static readonly layer = Layer.effect(this)(this.make);

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -361,6 +361,16 @@ export class LinearError extends Schema.TaggedError<LinearError>(
   cause: Schema.optionalKey(Schema.Defect()),
 }) {}
 
+// POST /run to an automation-client: unreachable, or a non-2xx. Not an API error — the
+// automation server turns it into a failed job.
+export class AutomationClientError extends Schema.TaggedError<AutomationClientError>(
+  "@oligarchy/shared/errors/AutomationClientError",
+)("AutomationClientError", {
+  message: Schema.String,
+  status: Schema.optionalKey(Schema.Int),
+  cause: Schema.optionalKey(Schema.Defect()),
+}) {}
+
 // A prompt template that cannot be read, or names a placeholder its renderer has no value for.
 export class PromptError extends Schema.TaggedError<PromptError>(
   "@oligarchy/shared/errors/PromptError",

--- a/test/automation-server/client.unit.test.ts
+++ b/test/automation-server/client.unit.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Layer, Redacted } from "effect";
+import { TestClock } from "effect/testing";
+import { HttpClient, HttpClientError } from "effect/unstable/http";
+import * as AutomationClient from "../../src/automation-server/client.ts";
+import * as FakeHttp from "../support/fake-http.ts";
+
+const URL = "http://127.0.0.1:55333";
+const TOKEN = "test-token";
+const PROMPT = "drive OLI-42";
+
+const token = Layer.succeed(AutomationClient.OligarchyToken)(
+  AutomationClient.OligarchyToken.of(Redacted.make(TOKEN)),
+);
+
+const run = (http: Layer.Layer<HttpClient.HttpClient>) =>
+  AutomationClient.run(URL, PROMPT).pipe(Effect.provide(Layer.mergeAll(token, http)));
+
+describe("automation client POST /run happy path", () => {
+  it.effect("posts the prompt with the bearer token and succeeds on 200", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      yield* run(recorder.layer);
+      expect(recorder.requests).toHaveLength(1);
+      expect(recorder.requests[0]?.method).toBe("POST");
+      expect(recorder.requests[0]?.url).toBe(`${URL}/run`);
+      expect(recorder.requests[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+      expect(JSON.parse(recorder.requests[0]?.body ?? "")).toEqual({ prompt: PROMPT });
+    }),
+  );
+});
+
+describe("automation client POST /run unhappy path", () => {
+  it.effect("a 500 is AutomationClientError with the body's error and status 500", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(() =>
+        FakeHttp.json({ error: "opencode exited 1" }, 500),
+      );
+      const error = yield* Effect.flip(run(recorder.layer));
+      expect(error).toMatchObject({
+        _tag: "AutomationClientError",
+        status: 500,
+        message: `automation client: POST ${URL}/run failed: opencode exited 1`,
+      });
+      expect(error.cause).toBeDefined();
+    }),
+  );
+
+  it.effect("an unreachable client has no status and carries the cause", () =>
+    Effect.gen(function* () {
+      const layer = FakeHttp.respondWith((request) =>
+        Effect.fail(
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.TransportError({
+              request,
+              cause: new Error("connect ECONNREFUSED 127.0.0.1:55333"),
+            }),
+          }),
+        ),
+      );
+      const error = yield* Effect.flip(run(layer));
+      expect(error._tag).toBe("AutomationClientError");
+      expect(error.status).toBeUndefined();
+      expect(error.message).toBe(`automation client: POST ${URL}/run failed`);
+      expect(error.cause).toBeDefined();
+    }),
+  );
+});
+
+describe("automation client POST /run has no timeout", () => {
+  it.effect("is still waiting after two hours", () =>
+    Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(run(FakeHttp.never));
+      yield* TestClock.adjust("2 hours");
+      expect(fiber.pollUnsafe()).toBeUndefined();
+    }),
+  );
+});

--- a/test/automation-server/prompts.unit.test.ts
+++ b/test/automation-server/prompts.unit.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { NodeFileSystem } from "@effect/platform-node";
+import { Effect, FileSystem, Layer } from "effect";
+import * as Prompts from "../../src/automation-server/prompts.ts";
+import * as FakeFs from "../support/fake-fs.ts";
+
+const TICKET = "OLI-42";
+const RESULT_ID = "22222222-2222-4222-8222-222222222222";
+
+const real = <A, E>(self: Effect.Effect<A, E, FileSystem.FileSystem>) =>
+  self.pipe(Effect.provide(NodeFileSystem.layer));
+
+// A FileSystem over the prompt files: each path answers with the text scripted for its file name
+// (`contents of <name>` when none is), or fails as an unreadable file would when `unreadable`
+// matches it. Every read is recorded so a test can say which files a rendering touched.
+const promptFs = (
+  options: {
+    readonly unreadable?: RegExp;
+    readonly contents?: Readonly<Record<string, string>>;
+  } = {},
+): { readonly reads: Array<string>; readonly layer: Layer.Layer<FileSystem.FileSystem> } => {
+  const reads: Array<string> = [];
+  const layer = FileSystem.layerNoop({
+    readFileString: (path) =>
+      Effect.suspend(() => {
+        reads.push(path);
+        const name = path.slice(path.lastIndexOf("/") + 1);
+        return options.unreadable?.test(path) === true
+          ? Effect.fail(FakeFs.permissionDenied("open", path))
+          : Effect.succeed(options.contents?.[name] ?? `contents of ${name}`);
+      }),
+  });
+  return { reads, layer };
+};
+
+const fileNames = (paths: ReadonlyArray<string>): ReadonlyArray<string> =>
+  paths.map((path) => path.slice(path.lastIndexOf("/") + 1));
+
+describe("drive happy path", () => {
+  it.effect("fills the ticket and the model", () =>
+    Effect.gen(function* () {
+      const fs = promptFs({
+        contents: {
+          "driving-agent.html": "ticket {{LINEAR_TICKET}} as {{MODEL}}",
+        },
+      });
+      const text = yield* Prompts.drive(TICKET).pipe(Effect.provide(fs.layer));
+      expect(text).toBe(`ticket ${TICKET} as ${Prompts.MODEL}`);
+      expect(fileNames(fs.reads)).toEqual(["driving-agent.html"]);
+    }),
+  );
+
+  it.effect("driving-agent.html: the ticket, the model, no leftover placeholders", () =>
+    Effect.gen(function* () {
+      const text = yield* real(Prompts.drive(TICKET));
+      expect(text.includes("{{")).toBe(false);
+      expect(text).toContain(TICKET);
+      expect(text).toContain(Prompts.MODEL);
+      expect(text).toContain("driving agent");
+    }),
+  );
+});
+
+describe("diagnose happy path", () => {
+  it.effect("fills the ticket, result, model, and the named diagnose guide", () =>
+    Effect.gen(function* () {
+      const fs = promptFs({
+        contents: {
+          "diagnosing-agent.html":
+            "{{LINEAR_TICKET}} {{RESULT_ID}} {{MODEL}}\n<guide>\n{{CTRL_DIAGNOSE_MD}}\n</guide>",
+          "ctrl-diagnose.md": "# Control\n\nDiagnose the session.\n",
+        },
+      });
+      const text = yield* Prompts.diagnose(TICKET, RESULT_ID).pipe(Effect.provide(fs.layer));
+      expect(text).toBe(
+        `${TICKET} ${RESULT_ID} ${Prompts.MODEL}\n<guide>\n# Control\n\nDiagnose the session.\n</guide>`,
+      );
+      expect(fileNames(fs.reads)).toEqual(["diagnosing-agent.html", "ctrl-diagnose.md"]);
+    }),
+  );
+
+  it.effect(
+    "diagnosing-agent.html: the ticket, result, model, guide, no leftover placeholders",
+    () =>
+      Effect.gen(function* () {
+        const text = yield* real(Prompts.diagnose(TICKET, RESULT_ID));
+        expect(text.includes("{{")).toBe(false);
+        expect(text).toContain(TICKET);
+        expect(text).toContain(RESULT_ID);
+        expect(text).toContain(Prompts.MODEL);
+        expect(text).toContain("# Control");
+        expect(text).toContain("## session");
+        expect(text).toContain("Post-run reviewer");
+      }),
+  );
+});
+
+describe("drive and diagnose unhappy path", () => {
+  it.effect("the first placeholder without a value is the one named", () =>
+    Effect.gen(function* () {
+      const fs = promptFs({
+        contents: { "driving-agent.html": "{{LINEAR_TICKET}} {{NOPE}} {{ALSO}}" },
+      });
+      const error = yield* Effect.flip(Prompts.drive(TICKET).pipe(Effect.provide(fs.layer)));
+      expect(error).toMatchObject({
+        _tag: "PromptError",
+        message: "prompt: prompts/driving-agent.html uses {{NOPE}}, which has no value",
+      });
+      expect(error.cause).toBeUndefined();
+    }),
+  );
+
+  it.effect("an unreadable template is a PromptError naming it, before any guide is read", () =>
+    Effect.gen(function* () {
+      const fs = promptFs({ unreadable: /driving-agent\.html$/ });
+      const error = yield* Effect.flip(Prompts.drive(TICKET).pipe(Effect.provide(fs.layer)));
+      expect(error._tag).toBe("PromptError");
+      expect(error.message).toMatch(/^prompt: .*driving-agent\.html/);
+      expect(error.cause).toBeDefined();
+      expect(fileNames(fs.reads)).toEqual(["driving-agent.html"]);
+    }),
+  );
+
+  it.effect("an unreadable guide the template names is a PromptError naming the guide", () =>
+    Effect.gen(function* () {
+      const fs = promptFs({
+        unreadable: /ctrl-diagnose\.md$/,
+        contents: { "diagnosing-agent.html": "{{CTRL_DIAGNOSE_MD}} {{LINEAR_TICKET}}" },
+      });
+      const error = yield* Effect.flip(
+        Prompts.diagnose(TICKET, RESULT_ID).pipe(Effect.provide(fs.layer)),
+      );
+      expect(error._tag).toBe("PromptError");
+      expect(error.message).toMatch(/^prompt: .*ctrl-diagnose\.md/);
+      expect(error.cause).toBeDefined();
+      expect(fileNames(fs.reads)).toEqual(["diagnosing-agent.html", "ctrl-diagnose.md"]);
+    }),
+  );
+
+  it.effect("an unreadable guide the template does not name cannot stop a drive", () =>
+    Effect.gen(function* () {
+      const fs = promptFs({
+        unreadable: /ctrl-diagnose\.md$/,
+        contents: { "driving-agent.html": "ticket {{LINEAR_TICKET}}" },
+      });
+      const text = yield* Prompts.drive(TICKET).pipe(Effect.provide(fs.layer));
+      expect(text).toBe(`ticket ${TICKET}`);
+      expect(fileNames(fs.reads)).toEqual(["driving-agent.html"]);
+    }),
+  );
+});

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -1,0 +1,381 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Deferred, Effect, Exit, FileSystem, Layer, Redacted, Scope } from "effect";
+import { TestClock } from "effect/testing";
+import { HttpClient, HttpClientError } from "effect/unstable/http";
+import * as AutomationClient from "../../src/automation-server/client.ts";
+import * as Prompts from "../../src/automation-server/prompts.ts";
+import * as Worker from "../../src/automation-server/worker.ts";
+import * as FakeFs from "../support/fake-fs.ts";
+import * as FakeHttp from "../support/fake-http.ts";
+import * as FakeLog from "../support/log.ts";
+import * as Stores from "../support/stores.ts";
+
+const URL = "http://127.0.0.1:55333";
+const TOKEN = "test-token";
+const TICKET = "OLI-42";
+const RESULT_ID = "22222222-2222-4222-8222-222222222222";
+const RUN_ID = "11111111-1111-4111-8111-111111111111";
+const STATS = {
+  qemus: 0,
+  memory: { totalBytes: 1, usedBytes: 0 },
+  cpu: { mean1m: 0, mean2m: 0, mean3m: 0 },
+};
+
+const token = Layer.succeed(AutomationClient.OligarchyToken)(
+  AutomationClient.OligarchyToken.of(Redacted.make(TOKEN)),
+);
+
+const scriptsFs = FileSystem.layerNoop({
+  readFileString: (path) =>
+    Effect.succeed(
+      path.endsWith("driving-agent.html")
+        ? "drive {{LINEAR_TICKET}} as {{MODEL}}"
+        : path.endsWith("diagnosing-agent.html")
+          ? "diagnose {{LINEAR_TICKET}} {{RESULT_ID}} {{MODEL}}\n{{CTRL_DIAGNOSE_MD}}"
+          : path.endsWith("ctrl-diagnose.md")
+            ? "# Control"
+            : `contents of ${path}`,
+    ),
+});
+
+const DRIVE_PROMPT = `drive ${TICKET} as ${Prompts.MODEL}`;
+const DIAGNOSE_PROMPT = `diagnose ${TICKET} ${RESULT_ID} ${Prompts.MODEL}\n# Control`;
+
+const seedResult = (tests: Stores.FakeTestStore, linearId: string | null = TICKET) => {
+  tests.results.push({
+    id: RESULT_ID,
+    runId: RUN_ID,
+    definitionId: 1,
+    sessionId: null,
+    model: null,
+    linearId,
+    status: "pending",
+    reason: null,
+    createdAt: new Date(),
+    finishedAt: null,
+  });
+};
+
+const seedJob = (
+  automation: Stores.FakeAutomationStore,
+  action: "drive" | "diagnose" = "drive",
+  resultId = RESULT_ID,
+) => {
+  automation.jobs.push({
+    id: `00000000-0000-4000-8000-${String(automation.jobs.length + 1).padStart(12, "0")}`,
+    resultId,
+    action,
+    status: "pending",
+    reason: null,
+    createdAt: new Date(),
+    startedAt: null,
+    finishedAt: null,
+  });
+};
+
+const seedLiveClient = (servers: Stores.FakeServerStore, url = URL) => {
+  servers.servers.push({ url, type: "automation-client" });
+  servers.heartbeats.push({ url, type: "automation-client", stats: STATS });
+};
+
+type Harness = {
+  readonly automation: Stores.FakeAutomationStore;
+  readonly servers: Stores.FakeServerStore;
+  readonly tests: Stores.FakeTestStore;
+  readonly log: FakeLog.FakeLog;
+};
+
+const harness = (): Harness => ({
+  automation: Stores.fakeAutomationStore(),
+  servers: Stores.fakeServerStore(),
+  tests: Stores.fakeTestStore(),
+  log: FakeLog.fakeLog(),
+});
+
+const layers = (
+  fixed: Harness,
+  http: Layer.Layer<HttpClient.HttpClient>,
+  fs: Layer.Layer<FileSystem.FileSystem> = scriptsFs,
+) =>
+  Layer.mergeAll(
+    fixed.automation.layer,
+    fixed.servers.layer,
+    fixed.tests.layer,
+    fixed.log.layer,
+    token,
+    fs,
+  ).pipe(Layer.provideMerge(http));
+
+const start = (
+  fixed: Harness,
+  http: Layer.Layer<HttpClient.HttpClient>,
+  fs?: Layer.Layer<FileSystem.FileSystem>,
+) =>
+  Effect.gen(function* () {
+    const scope = yield* Scope.make();
+    yield* Worker.dispatch().pipe(Effect.provide(layers(fixed, http, fs)), Scope.provide(scope));
+    return scope;
+  });
+
+const settle = (jobs: Array<{ status: string }>, status: string) =>
+  Effect.gen(function* () {
+    for (let i = 0; i < 1_000; i++) {
+      if (jobs.some((job) => job.status === status)) {
+        return yield* Effect.void;
+      }
+      yield* Effect.yieldNow;
+    }
+    return yield* Effect.die(`job did not become ${status}: ${JSON.stringify(jobs)}`);
+  });
+
+describe("dispatch happy path", () => {
+  it.effect("claims the job before POST /run", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      seedLiveClient(fixed.servers);
+      const started = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const http = FakeHttp.recordRequests(() =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(started, undefined);
+          yield* Deferred.await(release);
+          return FakeHttp.json({ ok: "true" });
+        }),
+      );
+      yield* start(fixed, http.layer);
+      yield* Deferred.await(started);
+      expect(fixed.automation.jobs[0]?.status).toBe("running");
+      expect(http.requests).toHaveLength(1);
+      yield* Deferred.succeed(release, undefined);
+      yield* settle(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs[0]?.status).toBe("succeeded");
+    }),
+  );
+
+  it.effect("a drive job posts the driving prompt and succeeds on 200", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation, "drive");
+      seedLiveClient(fixed.servers);
+      const http = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      yield* start(fixed, http.layer);
+      yield* settle(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs[0]).toMatchObject({
+        status: "succeeded",
+        reason: null,
+        finishedAt: expect.any(Date),
+      });
+      expect(JSON.parse(http.requests[0]?.body ?? "")).toEqual({ prompt: DRIVE_PROMPT });
+      expect(FakeLog.texts(fixed.log)).toEqual([`dispatching drive; ${URL}`, "drive succeeded"]);
+      expect(fixed.log.lines[0]?.agentId).toBe(TICKET);
+    }),
+  );
+
+  it.effect("a diagnose job posts the diagnosing prompt and succeeds on 200", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation, "diagnose");
+      seedLiveClient(fixed.servers);
+      const http = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      yield* start(fixed, http.layer);
+      yield* settle(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs[0]?.status).toBe("succeeded");
+      expect(JSON.parse(http.requests[0]?.body ?? "")).toEqual({ prompt: DIAGNOSE_PROMPT });
+      expect(FakeLog.texts(fixed.log)).toEqual([
+        `dispatching diagnose; ${URL}`,
+        "diagnose succeeded",
+      ]);
+    }),
+  );
+
+  it.effect("the next pending job runs after five seconds", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation, "drive");
+      seedJob(fixed.automation, "diagnose");
+      seedLiveClient(fixed.servers);
+      const http = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      yield* start(fixed, http.layer);
+      yield* settle(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs.map((job) => job.status)).toEqual(["succeeded", "pending"]);
+      yield* TestClock.adjust("5 seconds");
+      yield* settle(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs.every((job) => job.status === "succeeded")).toBe(true);
+      expect(http.requests).toHaveLength(2);
+    }),
+  );
+
+  it.effect("a hang is still running after two hours, then succeeds when the client answers", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      seedLiveClient(fixed.servers);
+      const started = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const http = FakeHttp.recordRequests(() =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(started, undefined);
+          yield* Deferred.await(release);
+          return FakeHttp.json({ ok: "true" });
+        }),
+      );
+      yield* start(fixed, http.layer);
+      yield* Deferred.await(started);
+      yield* TestClock.adjust("2 hours");
+      expect(fixed.automation.jobs[0]?.status).toBe("running");
+      yield* Deferred.succeed(release, undefined);
+      yield* settle(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs[0]?.status).toBe("succeeded");
+    }),
+  );
+});
+
+describe("dispatch unhappy path", () => {
+  it.effect("a 500 marks the job failed with the client's error", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      seedLiveClient(fixed.servers);
+      const http = FakeHttp.recordRequests(() =>
+        FakeHttp.json({ error: "opencode exited 1" }, 500),
+      );
+      yield* start(fixed, http.layer);
+      yield* settle(fixed.automation.jobs, "failed");
+      expect(fixed.automation.jobs[0]).toMatchObject({
+        status: "failed",
+        reason: `automation client: POST ${URL}/run failed: opencode exited 1`,
+      });
+      expect(FakeLog.texts(fixed.log)).toEqual([
+        `dispatching drive; ${URL}`,
+        `drive failed; automation client: POST ${URL}/run failed: opencode exited 1`,
+      ]);
+    }),
+  );
+
+  it.effect("closing the scope mid-request aborts the job", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      seedLiveClient(fixed.servers);
+      const started = yield* Deferred.make<void>();
+      const http = FakeHttp.recordRequests(() =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(started, undefined);
+          return yield* Effect.never;
+        }),
+      );
+      const scope = yield* start(fixed, http.layer);
+      yield* Deferred.await(started);
+      expect(fixed.automation.jobs[0]?.status).toBe("running");
+      yield* Scope.close(scope, Exit.void);
+      yield* settle(fixed.automation.jobs, "aborted");
+      expect(fixed.automation.jobs[0]).toMatchObject({
+        status: "aborted",
+        reason: "automation server shutting down",
+      });
+      expect(FakeLog.texts(fixed.log)).toContain("drive aborted");
+    }),
+  );
+
+  it.effect("no live automation-client does not claim and does not POST", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      yield* start(fixed, FakeHttp.die);
+      yield* Effect.yieldNow;
+      expect(fixed.automation.jobs[0]?.status).toBe("pending");
+      expect(FakeLog.texts(fixed.log)).toEqual([]);
+    }),
+  );
+
+  it.effect("a qemu-only fleet does not claim", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      fixed.servers.servers.push({ url: URL, type: "qemu" });
+      fixed.servers.heartbeats.push({ url: URL, type: "qemu", stats: STATS });
+      yield* start(fixed, FakeHttp.die);
+      yield* Effect.yieldNow;
+      expect(fixed.automation.jobs[0]?.status).toBe("pending");
+    }),
+  );
+
+  it.effect("no pending job does not POST", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedLiveClient(fixed.servers);
+      yield* start(fixed, FakeHttp.die);
+      yield* Effect.yieldNow;
+      expect(fixed.automation.jobs).toEqual([]);
+      expect(FakeLog.texts(fixed.log)).toEqual([]);
+    }),
+  );
+
+  it.effect("an unreachable client marks the job failed", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      seedLiveClient(fixed.servers);
+      const http = FakeHttp.respondWith((request) =>
+        Effect.fail(
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.TransportError({
+              request,
+              cause: new Error("connect ECONNREFUSED 127.0.0.1:55333"),
+            }),
+          }),
+        ),
+      );
+      yield* start(fixed, http);
+      yield* settle(fixed.automation.jobs, "failed");
+      expect(fixed.automation.jobs[0]).toMatchObject({
+        status: "failed",
+        reason: `automation client: POST ${URL}/run failed`,
+      });
+    }),
+  );
+
+  it.effect("a prompt that cannot be rendered marks the claimed job failed and does not POST", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      seedLiveClient(fixed.servers);
+      const fs = FileSystem.layerNoop({
+        readFileString: (path) => Effect.fail(FakeFs.permissionDenied("open", path)),
+      });
+      yield* start(fixed, FakeHttp.die, fs);
+      yield* settle(fixed.automation.jobs, "failed");
+      expect(fixed.automation.jobs[0]?.status).toBe("failed");
+      expect(fixed.automation.jobs[0]?.reason).toMatch(/^prompt:/);
+    }),
+  );
+
+  it.effect("a result with no Linear ticket fails after claim and does not POST", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests, null);
+      seedJob(fixed.automation);
+      seedLiveClient(fixed.servers);
+      yield* start(fixed, FakeHttp.die);
+      yield* settle(fixed.automation.jobs, "failed");
+      expect(fixed.automation.jobs[0]).toMatchObject({
+        status: "failed",
+        reason: "no Linear ticket",
+      });
+      expect(FakeLog.texts(fixed.log)).toEqual(["drive failed; no Linear ticket"]);
+    }),
+  );
+});

--- a/test/integration/automation-server.integration.test.ts
+++ b/test/integration/automation-server.integration.test.ts
@@ -1,6 +1,11 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHmac, randomUUID } from "node:crypto";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,6 +21,7 @@ import * as Postgres from "../support/postgres.ts";
 
 const AUTOMATION_SERVER = fileURLToPath(new URL("../../automation-server", import.meta.url));
 const WEBHOOK_SECRET = "whsec_test";
+const TOKEN = "test-token";
 const UNREACHABLE = "postgres://user:sentinel-pw@127.0.0.1:1/oligarchy";
 const EXIT_WITHIN_MS = 60_000;
 
@@ -41,6 +47,7 @@ const environment = (home: string, overrides: Record<string, string>): NodeJS.Pr
     ...process.env,
     HOME: home,
     LINEAR_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    OLIGARCHY_TOKEN: TOKEN,
     DATABASE_URL: dbUrl === "" ? UNREACHABLE : dbUrl,
     NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --disable-warning=ExperimentalWarning`.trim(),
     https_proxy: "http://127.0.0.1:1",
@@ -49,7 +56,6 @@ const environment = (home: string, overrides: Record<string, string>): NodeJS.Pr
     ...overrides,
   };
   delete env.FORCE_COLOR;
-  delete env.OLIGARCHY_TOKEN;
   return env;
 };
 
@@ -231,6 +237,16 @@ describe("automation server startup refusals", () => {
       const { code } = await process.exited;
       expect(code).toBe(1);
       expect(process.stderr()).toContain("LINEAR_WEBHOOK_SECRET is not set");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live("a missing OLIGARCHY_TOKEN exits 1 with OLIGARCHY_TOKEN is not set", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomationServer([], { OLIGARCHY_TOKEN: "" });
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("OLIGARCHY_TOKEN is not set");
       expect(process.stdout()).not.toContain("listening");
     }),
   );
@@ -425,4 +441,167 @@ describeServing("automation server serving", () => {
   );
 
   it.live("exits 0 on SIGTERM", () => Effect.promise(() => served("SIGTERM")), 120_000);
+});
+
+const STATS: DbSchema.ServerStats = {
+  qemus: 0,
+  memory: { totalBytes: 1, usedBytes: 0 },
+  cpu: { mean1m: 0, mean2m: 0, mean3m: 0 },
+};
+
+const seedLiveClient = async (url: string) => {
+  const client = new Client({ connectionString: Postgres.getDbUrl() });
+  await client.connect();
+  try {
+    const db = drizzle({ client, schema: DbSchema });
+    await db.insert(DbSchema.servers).values({
+      url,
+      type: "automation-client",
+      heartbeatAt: new Date(),
+      generation: 1,
+      stats: STATS,
+    });
+  } finally {
+    await client.end();
+  }
+};
+
+const removeServer = async (url: string) => {
+  const client = new Client({ connectionString: Postgres.getDbUrl() });
+  await client.connect();
+  try {
+    const db = drizzle({ client, schema: DbSchema });
+    await db.delete(DbSchema.servers).where(eq(DbSchema.servers.url, url));
+  } finally {
+    await client.end();
+  }
+};
+
+const seedJob = async (resultId: string, action: "drive" | "diagnose") => {
+  const client = new Client({ connectionString: Postgres.getDbUrl() });
+  await client.connect();
+  try {
+    const db = drizzle({ client, schema: DbSchema });
+    await db.insert(DbSchema.automationJobs).values({ resultId, action, status: "pending" });
+  } finally {
+    await client.end();
+  }
+};
+
+const waitForJob = async (
+  resultId: string,
+  status: string,
+  timeoutMs = 15_000,
+): Promise<(typeof DbSchema.automationJobs)["$inferSelect"]> => {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const jobs = await jobsFor(resultId);
+    const job = jobs[0];
+    if (job !== undefined && job.status === status) {
+      return job;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  const jobs = await jobsFor(resultId);
+  throw new Error(`job did not become ${status}: ${JSON.stringify(jobs)}`);
+};
+
+const serveClient = (
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ readonly url: string; readonly close: () => Promise<void> }> =>
+  new Promise((resolve, reject) => {
+    const server = createHttpServer(handler);
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        url: `http://127.0.0.1:${String(portOf(server.address()))}`,
+        close: () => new Promise((done) => server.close(() => done())),
+      });
+    });
+  });
+
+describeServing("automation server dispatch", () => {
+  it.live("a live client that answers 200 marks the job succeeded", () =>
+    Effect.promise(async () => {
+      const client = await serveClient((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: "true" }));
+      });
+      const linearId = `OLI-${randomUUID().slice(0, 8)}`;
+      const resultId = await seedResult(linearId);
+      await seedJob(resultId, "drive");
+      await seedLiveClient(client.url);
+      const port = await freePort();
+      const process = spawnAutomationServer(["--port", String(port)]);
+      try {
+        await process.waitFor(/automation server listening/);
+        const job = await waitForJob(resultId, "succeeded");
+        expect(job).toMatchObject({ action: "drive", status: "succeeded", reason: null });
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+        await removeServer(client.url);
+        await client.close();
+      }
+    }),
+  );
+
+  it.live("a live client that answers 500 marks the job failed", () =>
+    Effect.promise(async () => {
+      const client = await serveClient((_req, res) => {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "opencode exited 1" }));
+      });
+      const linearId = `OLI-${randomUUID().slice(0, 8)}`;
+      const resultId = await seedResult(linearId);
+      await seedJob(resultId, "drive");
+      await seedLiveClient(client.url);
+      const port = await freePort();
+      const process = spawnAutomationServer(["--port", String(port)]);
+      try {
+        await process.waitFor(/automation server listening/);
+        const job = await waitForJob(resultId, "failed");
+        expect(job.status).toBe("failed");
+        expect(job.reason).toContain("opencode exited 1");
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+        await removeServer(client.url);
+        await client.close();
+      }
+    }),
+  );
+
+  it.live("SIGTERM while the client is still running aborts the job and exits 0", () =>
+    Effect.promise(async () => {
+      const client = await serveClient(() => {});
+      const linearId = `OLI-${randomUUID().slice(0, 8)}`;
+      const resultId = await seedResult(linearId);
+      await seedJob(resultId, "drive");
+      await seedLiveClient(client.url);
+      const port = await freePort();
+      const process = spawnAutomationServer(["--port", String(port)]);
+      try {
+        await process.waitFor(/automation server listening/);
+        await waitForJob(resultId, "running");
+        process.child.kill("SIGTERM");
+        const { code } = await process.exited;
+        expect(code).toBe(0);
+        const jobs = await jobsFor(resultId);
+        expect(jobs).toEqual([
+          expect.objectContaining({
+            status: "aborted",
+            reason: "automation server shutting down",
+          }),
+        ]);
+      } finally {
+        if (process.child.exitCode === null && process.child.signalCode === null) {
+          process.child.kill("SIGKILL");
+          await process.exited;
+        }
+        await removeServer(client.url);
+        await client.close();
+      }
+    }),
+  );
 });

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -1103,6 +1103,81 @@ Postgres.describeWithDatabase("database", () => {
         }),
     );
 
+    scoped.effect("AutomationStore claims the oldest pending job, then none", () =>
+      Effect.gen(function* () {
+        const tests = yield* Tests.TestStore;
+        const automation = yield* Automation.AutomationStore;
+        const definition = Option.getOrThrow(yield* tests.findTestDefinition("lock-screen"));
+        const first = yield* tests.createRun({
+          iso: "https://example.com/omarchy.iso",
+          serverUrl: "http://127.0.0.1:42069",
+          definitions: [{ id: definition.id }],
+        });
+        const second = yield* tests.createRun({
+          iso: "https://example.com/omarchy.iso",
+          serverUrl: "http://127.0.0.1:42069",
+          definitions: [{ id: definition.id }],
+        });
+        const older = yield* automation.enqueue({ resultId: first.results[0].id, action: "drive" });
+        const newer = yield* automation.enqueue({
+          resultId: second.results[0].id,
+          action: "drive",
+        });
+        const claimed = yield* automation.claim();
+        expect(Option.isSome(claimed)).toBe(true);
+        if (Option.isSome(claimed)) {
+          expect(claimed.value).toMatchObject({
+            id: older.id,
+            status: "running",
+          });
+          expect(claimed.value.startedAt).toBeInstanceOf(Date);
+        }
+        const next = yield* automation.claim();
+        expect(Option.isSome(next)).toBe(true);
+        if (Option.isSome(next)) {
+          expect(next.value.id).toBe(newer.id);
+        }
+        expect(yield* automation.claim()).toEqual(Option.none());
+      }),
+    );
+
+    scoped.effect("AutomationStore finish closes a running job and refuses a second close", () =>
+      Effect.gen(function* () {
+        const tests = yield* Tests.TestStore;
+        const automation = yield* Automation.AutomationStore;
+        const database = yield* Client.Database;
+        const definition = Option.getOrThrow(yield* tests.findTestDefinition("lock-screen"));
+        const created = yield* tests.createRun({
+          iso: "https://example.com/omarchy.iso",
+          serverUrl: "http://127.0.0.1:42069",
+          definitions: [{ id: definition.id }],
+        });
+        const enqueued = yield* automation.enqueue({
+          resultId: created.results[0].id,
+          action: "drive",
+        });
+        const claimed = yield* automation.claim();
+        expect(Option.isSome(claimed)).toBe(true);
+        expect(yield* automation.finish(enqueued.id, "succeeded", null)).toBe(true);
+        const [row] = yield* database.run("select", (db) =>
+          db
+            .select()
+            .from(DbSchema.automationJobs)
+            .where(eq(DbSchema.automationJobs.id, enqueued.id)),
+        );
+        expect(row).toMatchObject({ status: "succeeded", reason: null });
+        expect(row?.finishedAt).toBeInstanceOf(Date);
+        expect(yield* automation.finish(enqueued.id, "failed", "nope")).toBe(false);
+        const [again] = yield* database.run("select", (db) =>
+          db
+            .select()
+            .from(DbSchema.automationJobs)
+            .where(eq(DbSchema.automationJobs.id, enqueued.id)),
+        );
+        expect(again).toMatchObject({ status: "succeeded", reason: null });
+      }),
+    );
+
     scoped.effect(
       "ServerStore registers a url once as a qemu server, lists the qemu servers in registration order, forgets it",
       () =>
@@ -1291,6 +1366,52 @@ Postgres.describeWithDatabase("database", () => {
         expect(yield* store.listServers("qemu")).not.toContain(url);
         expect(yield* store.removeServer(url)).toBe(true);
       }),
+    );
+
+    scoped.effect(
+      "ServerStore listLiveServers keeps a 44s heartbeat and drops a 46s one, the wrong type, and a null heartbeat",
+      () =>
+        Effect.gen(function* () {
+          const store = yield* Servers.ServerStore;
+          const database = yield* Client.Database;
+          const stats: DbSchema.ServerStats = {
+            qemus: 0,
+            memory: { totalBytes: 1, usedBytes: 0 },
+            cpu: { mean1m: 0, mean2m: 0, mean3m: 0 },
+          };
+          const fresh = `http://10.0.0.20:${uuid().slice(0, 8)}`;
+          const stale = `http://10.0.0.21:${uuid().slice(0, 8)}`;
+          const qemu = `http://10.0.0.22:${uuid().slice(0, 8)}`;
+          const silent = `http://10.0.0.23:${uuid().slice(0, 8)}`;
+          yield* store.heartbeat(fresh, "automation-client", stats);
+          yield* store.heartbeat(stale, "automation-client", stats);
+          yield* store.heartbeat(qemu, "qemu", stats);
+          yield* store.addServer(silent, "automation-client");
+          yield* database.run("stamp", (db) =>
+            db
+              .update(DbSchema.servers)
+              .set({ heartbeatAt: sql`now() - interval '44 seconds'` })
+              .where(eq(DbSchema.servers.url, fresh)),
+          );
+          yield* database.run("stamp", (db) =>
+            db
+              .update(DbSchema.servers)
+              .set({ heartbeatAt: sql`now() - interval '46 seconds'` })
+              .where(eq(DbSchema.servers.url, stale)),
+          );
+          const live = yield* store.listLiveServers("automation-client");
+          expect(live).toContain(fresh);
+          expect(live).not.toContain(stale);
+          expect(live).not.toContain(qemu);
+          expect(live).not.toContain(silent);
+          expect(yield* store.listServers("automation-client")).toEqual(
+            expect.arrayContaining([fresh, stale, silent]),
+          );
+          expect(yield* store.removeServer(fresh)).toBe(true);
+          expect(yield* store.removeServer(stale)).toBe(true);
+          expect(yield* store.removeServer(qemu)).toBe(true);
+          expect(yield* store.removeServer(silent)).toBe(true);
+        }),
     );
 
     scoped.effect("ServerStore routes a session once and answers where it went", () =>

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -547,6 +547,36 @@ export const fakeAutomationStore = (
         jobs.push(row);
         return row;
       }),
+    claim: () =>
+      Effect.sync(() => {
+        const pending = jobs
+          .filter((job) => job.status === "pending")
+          .sort(
+            (left, right) =>
+              left.createdAt.getTime() - right.createdAt.getTime() ||
+              left.id.localeCompare(right.id),
+          );
+        const job = pending[0];
+        if (job === undefined) {
+          return Option.none();
+        }
+        job.status = "running";
+        job.startedAt = new Date();
+        return Option.some(job);
+      }),
+    finish: (id, status, reason) =>
+      Effect.sync(() => {
+        const job = jobs.find((row) => row.id === id && row.status === "running");
+        if (job === undefined) {
+          return false;
+        }
+        job.status = status;
+        job.finishedAt = new Date();
+        if (reason !== null) {
+          job.reason = reason;
+        }
+        return true;
+      }),
     ...overrides,
   });
   return { jobs, layer: Layer.succeed(Automation.AutomationStore)(service) };
@@ -612,6 +642,15 @@ export const fakeServerStore = (
     listServers: (type) =>
       Effect.sync(() =>
         servers.filter((server) => server.type === type).map((server) => server.url),
+      ),
+    // Any heartbeat marks the url live: the 45s window is a real-database concern.
+    listLiveServers: (type) =>
+      Effect.sync(() =>
+        servers
+          .filter(
+            (server) => server.type === type && heartbeats.some((beat) => beat.url === server.url),
+          )
+          .map((server) => server.url),
       ),
     routeSession: (sessionId, url) =>
       routes.has(sessionId)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The automation server now dispatches pending work-queue jobs to automation clients that have heartbeated in the last 45 seconds.

**Behavior**
- Only `automation-client` servers with a heartbeat in the last 45 seconds are eligible (clients ping every 30s).
- A pending job is marked `running` before `POST /run`.
- Drive jobs get `prompts/driving-agent.html`; diagnose jobs get `prompts/diagnosing-agent.html`.
- The agent is told it is running as `opencode/muse-spark-1-3-contributor-free`.
- The HTTP call has no timeout — it waits until the client finishes.
- Outcomes:
  - **200** → `succeeded`
  - **500** → `failed`
  - Server shutdown (SIGINT/SIGTERM) while a job is in flight → `aborted` with reason `automation server shutting down`
- The job row is closed before the outcome is logged. A `finish` that does not land is a defect.

**Requires** `OLIGARCHY_TOKEN` on the automation server (same bearer the client already checks).

**Tests**
- Unit: prompt fill, HTTP client (200/500/unreachable/no timeout), worker (claim-before-send, 200/500/abort, no live client, hang). `npm run check:fast` is green (938 unit tests).
- Integration: claim/finish/listLiveServers and process tests for token / 200 / 500 / SIGTERM abort. CI on this branch passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08d3f-c688-7b00-9348-413e452f314a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08d3f-c688-7b00-9348-413e452f314a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

