### PR TITLE
Add ./ctrl automation --list

### DIFF
--- a/ctrl.md
+++ b/ctrl.md
@@ -18,6 +18,7 @@ Consult this table of contents first. Read only the section you need.
 | [error-type new](#error-type-new) | 211 |
 | [error-type list](#error-type-list) | 226 |
 | [diagnose](#diagnose) | 240 |
+| [automation --list](#automation---list) | 261 |
 
 ## Important
 
@@ -42,6 +43,7 @@ If you are an agent driving a guest, you need two of these: [test start](#test-s
 ./ctrl error-type new  --key <key> --description <text>
 ./ctrl error-type list [--json]
 ./ctrl diagnose       --session-id <id> --verdict passed|failed [--type <key>] --summary <text> --model <id>
+./ctrl automation --list [--count <n>]
 ```
 
 The action comes first. Every value is a flag; there are no positional arguments. Flags may sit in any order after the action.
@@ -254,4 +256,20 @@ Records the post-run diagnosis: a reviewer's verdict on one session that has end
 ```bash
 ./ctrl diagnose --session-id 6f1c...e2a9 --verdict failed --type guest_boot_hang --summary "Serial stops after 'Waiting for root device'; the ISO never mounted" --model <the Cursor model id you are running as>
 ./ctrl diagnose --session-id 6f1c...e2a9 --verdict passed --summary "The last image shows the lock screen with the clock; matches the proof" --model <the Cursor model id you are running as>
+```
+
+## automation --list
+
+```
+./ctrl automation --list [--count <n>]
+```
+
+Prints the automation queue from the database, never an endpoint: every running job, then every pending job, then the most recently completed jobs. Each job is one line: the status, colored (yellow `running`, gray `pending`, green `succeeded`, red `failed`, bright red `aborted`, magenta `timed_out`); the action (`drive` or `diagnose`); how long ago (`5s ago`, `12m ago`, `1h30m ago`, `3d5h ago`) — running from when it started, pending from when it was queued, completed from when it finished; the Linear ticket, or `—` when none; then the test name. Empty groups still print their header. Not used while driving a guest.
+
+- `--list` — required.
+- `--count <n>` — how many completed jobs to print, at least 1. Default 10. Running and pending are always printed in full.
+
+```bash
+./ctrl automation --list
+./ctrl automation --list --count 25
 ```

--- a/src/ctrl/command.ts
+++ b/src/ctrl/command.ts
@@ -3,6 +3,7 @@ import { CliError, Command, Flag } from "effect/unstable/cli";
 import type { HttpClient } from "effect/unstable/http";
 import * as Config from "../config.ts";
 import * as Actions from "../db/actions.ts";
+import * as Automation from "../db/automation.ts";
 import * as DebugLogs from "../db/debug-logs.ts";
 import * as Client from "../db/client.ts";
 import * as Diagnosis from "../db/diagnosis.ts";
@@ -28,6 +29,7 @@ export type Stores =
   | DebugLogs.DebugLogStore
   | Diagnosis.DiagnosisStore
   | Tests.TestStore
+  | Automation.AutomationStore
   | Log.Log;
 
 // ctrl is the record keeper: every read and write is a database call. It never talks to a qemu server;
@@ -44,6 +46,7 @@ const databaseLayers = (url: Redacted.Redacted): Layer.Layer<Stores, Errors.Data
   Layer.mergeAll(
     Sessions.SessionStore.layer,
     Tests.TestStore.layer,
+    Automation.AutomationStore.layer,
     DebugLogs.DebugLogStore.layer,
     Diagnosis.DiagnosisStore.layer,
     Log.Log.layer,
@@ -562,6 +565,16 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     });
   });
 
+  // automation --list [--count <n>]
+  const automationList = Effect.fn("ctrl.automation.list")(function* (input: {
+    readonly count: number;
+  }) {
+    const automation = yield* Automation.AutomationStore;
+    const queue = yield* automation.listJobs(input.count);
+    const now = yield* Clock.currentTimeMillis;
+    yield* printLines(Render.renderAutomationJobs(queue, now));
+  });
+
   // session list [--count <n>] [--active] [--json]
   const sessionList = Effect.fn("ctrl.session.list")(function* (input: {
     readonly count: number;
@@ -896,6 +909,22 @@ export const makeCtrlCommand = (deps: Deps = live) => {
     Command.withSubcommands([errorTypeNewCommand, errorTypeListCommand]),
   );
 
+  const automationCommand = Command.make(
+    "automation",
+    {
+      list: Flag.boolean("list").pipe(
+        Flag.withDefault(Effect.fail(new CliError.MissingOption({ option: "list" }))),
+        Flag.withDescription("List automation jobs from the database"),
+      ),
+      count: Flag.integer("count").pipe(
+        Flag.withSchema(Count),
+        Flag.withDefault(DEFAULT_COUNT),
+        Flag.withDescription("How many of the most recently completed jobs to print"),
+      ),
+    },
+    ({ count }) => automationList({ count }),
+  ).pipe(Command.withDescription("automation --list [--count <n>]"), Command.provide(withDb));
+
   const diagnoseCommand = Command.make(
     "diagnose",
     {
@@ -931,6 +960,7 @@ export const makeCtrlCommand = (deps: Deps = live) => {
       sessionCommand,
       errorTypeCommand,
       diagnoseCommand,
+      automationCommand,
     ]),
   );
 };

--- a/src/ctrl/render.ts
+++ b/src/ctrl/render.ts
@@ -19,8 +19,35 @@ export const STATUS_COLOR: Readonly<Record<Domain.SessionStatus, string>> = {
   timed_out: "\x1b[35m",
 };
 
+export type AutomationJobRow = {
+  readonly ticket: string | null;
+  readonly test: string;
+  readonly action: "drive" | "diagnose";
+  readonly status: "pending" | "running" | "succeeded" | "failed" | "aborted" | "timed_out";
+  readonly createdAt: Date;
+  readonly startedAt: Date | null;
+  readonly finishedAt: Date | null;
+};
+
+export type AutomationQueue = {
+  readonly running: ReadonlyArray<AutomationJobRow>;
+  readonly pending: ReadonlyArray<AutomationJobRow>;
+  readonly completed: ReadonlyArray<AutomationJobRow>;
+};
+
+export const JOB_STATUS_COLOR: Readonly<Record<AutomationJobRow["status"], string>> = {
+  pending: "\x1b[90m",
+  running: "\x1b[33m",
+  succeeded: "\x1b[32m",
+  failed: "\x1b[31m",
+  aborted: "\x1b[91m",
+  timed_out: "\x1b[35m",
+};
+
 const RESET = "\x1b[0m";
 const STATUS_WIDTH = "downloading".length;
+const JOB_STATUS_WIDTH = "succeeded".length;
+const ACTION_WIDTH = "diagnose".length;
 const AGE_WIDTH = "23h59m ago".length + 1;
 
 export const json = (value: unknown): string => JSON.stringify(value);
@@ -56,6 +83,33 @@ export const renderSessions = (
   asJson: boolean,
   now: number,
 ): ReadonlyArray<string> => (asJson ? [json(rows)] : rows.map((row) => sessionLine(row, now)));
+
+const jobStamp = (row: AutomationJobRow): Date => {
+  if (row.status === "pending") {
+    return row.createdAt;
+  }
+  if (row.status === "running") {
+    return row.startedAt ?? row.createdAt;
+  }
+  return row.finishedAt ?? row.startedAt ?? row.createdAt;
+};
+
+const jobLine = (row: AutomationJobRow, now: number): string => {
+  const status = `${JOB_STATUS_COLOR[row.status]}${row.status.padEnd(JOB_STATUS_WIDTH)}${RESET}`;
+  return `${status}  ${row.action.padEnd(ACTION_WIDTH)}  ${age(now, jobStamp(row)).padEnd(AGE_WIDTH)}  ${row.ticket ?? "—"}  ${row.test}`;
+};
+
+export const renderAutomationJobs = (
+  queue: AutomationQueue,
+  now: number,
+): ReadonlyArray<string> => [
+  "running",
+  ...queue.running.map((row) => jobLine(row, now)),
+  "pending",
+  ...queue.pending.map((row) => jobLine(row, now)),
+  "completed",
+  ...queue.completed.map((row) => jobLine(row, now)),
+];
 
 export const renderTestDefinitions = (
   rows: ReadonlyArray<TestDefinitionRow>,

--- a/src/db/automation.ts
+++ b/src/db/automation.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { Array as Arr, Context, Effect, Layer, Option } from "effect";
 import * as Client from "./client.ts";
 import * as DbSchema from "./schema.ts";
@@ -6,6 +6,24 @@ import * as DbSchema from "./schema.ts";
 export type AutomationJobRow = typeof DbSchema.automationJobs.$inferSelect;
 export type AutomationAction = AutomationJobRow["action"];
 export type FinishStatus = "succeeded" | "failed" | "aborted";
+
+export type AutomationJobListRow = {
+  readonly ticket: string | null;
+  readonly test: string;
+  readonly action: AutomationJobRow["action"];
+  readonly status: AutomationJobRow["status"];
+  readonly createdAt: Date;
+  readonly startedAt: Date | null;
+  readonly finishedAt: Date | null;
+};
+
+export type AutomationQueue = {
+  readonly running: ReadonlyArray<AutomationJobListRow>;
+  readonly pending: ReadonlyArray<AutomationJobListRow>;
+  readonly completed: ReadonlyArray<AutomationJobListRow>;
+};
+
+const COMPLETED = ["succeeded", "failed", "aborted", "timed_out"] as const;
 
 export type EnqueueInput = {
   readonly resultId: string;
@@ -85,7 +103,57 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
         return rows.length > 0;
       });
 
-      return { enqueue, claim, finish };
+      // Running and pending are the whole live queue, diagnoses first then created_at.
+      // Completed is every terminal status, newest finished first, cut at count.
+      const listJobs = Effect.fn("db.listAutomationJobs")(function* (count: number) {
+        const columns = {
+          ticket: DbSchema.testResults.linearId,
+          test: DbSchema.testDefinitions.name,
+          action: DbSchema.automationJobs.action,
+          status: DbSchema.automationJobs.status,
+          createdAt: DbSchema.automationJobs.createdAt,
+          startedAt: DbSchema.automationJobs.startedAt,
+          finishedAt: DbSchema.automationJobs.finishedAt,
+        };
+        const diagnosesFirst = desc(sql`${DbSchema.automationJobs.action} = ${"diagnose"}`);
+        const jobs = (db: Client.Db) =>
+          db
+            .select(columns)
+            .from(DbSchema.automationJobs)
+            .innerJoin(
+              DbSchema.testResults,
+              eq(DbSchema.testResults.id, DbSchema.automationJobs.resultId),
+            )
+            .innerJoin(
+              DbSchema.testDefinitions,
+              eq(DbSchema.testDefinitions.id, DbSchema.testResults.definitionId),
+            );
+        const running: ReadonlyArray<AutomationJobListRow> = yield* database.run(
+          "listAutomationJobs",
+          (db) =>
+            jobs(db)
+              .where(eq(DbSchema.automationJobs.status, "running"))
+              .orderBy(diagnosesFirst, DbSchema.automationJobs.createdAt),
+        );
+        const pending: ReadonlyArray<AutomationJobListRow> = yield* database.run(
+          "listAutomationJobs",
+          (db) =>
+            jobs(db)
+              .where(eq(DbSchema.automationJobs.status, "pending"))
+              .orderBy(diagnosesFirst, DbSchema.automationJobs.createdAt),
+        );
+        const completed: ReadonlyArray<AutomationJobListRow> = yield* database.run(
+          "listAutomationJobs",
+          (db) =>
+            jobs(db)
+              .where(inArray(DbSchema.automationJobs.status, COMPLETED))
+              .orderBy(desc(DbSchema.automationJobs.finishedAt))
+              .limit(count),
+        );
+        return { running, pending, completed };
+      });
+
+      return { enqueue, claim, finish, listJobs };
     }),
   },
 ) {

--- a/test/ctrl/command.unit.test.ts
+++ b/test/ctrl/command.unit.test.ts
@@ -1301,11 +1301,11 @@ describe("automation --list", () => {
       expect(Exit.isSuccess(exit)).toBe(true);
       expect(yield* stdout).toEqual([
         "running",
-        `\x1b[33mrunning  ${JOB_RESET}  drive      5s ago       OLI-42  lock-screen`,
+        `\x1b[33mrunning  ${JOB_RESET}  drive     5s ago       OLI-42  lock-screen`,
         "pending",
         `\x1b[90mpending  ${JOB_RESET}  diagnose  1m ago       OLI-43  lock-screen`,
         "completed",
-        `\x1b[32msucceeded${JOB_RESET}  drive      1m ago       OLI-41  Open a terminal`,
+        `\x1b[32msucceeded${JOB_RESET}  drive     1m ago       OLI-41  Open a terminal`,
       ]);
       expect(h.touched).toEqual(["database"]);
     }),
@@ -1355,9 +1355,9 @@ describe("automation --list", () => {
         "running",
         `\x1b[33mrunning  ${JOB_RESET}  diagnose  2s ago       OLI-50  lock-screen`,
         "pending",
-        `\x1b[90mpending  ${JOB_RESET}  drive      10s ago      OLI-51  lock-screen`,
+        `\x1b[90mpending  ${JOB_RESET}  drive     10s ago      OLI-51  lock-screen`,
         "completed",
-        `\x1b[31mfailed   ${JOB_RESET}  drive      30s ago      OLI-52  lock-screen`,
+        `\x1b[31mfailed   ${JOB_RESET}  drive     30s ago      OLI-52  lock-screen`,
       ]);
     }),
   );

--- a/test/ctrl/command.unit.test.ts
+++ b/test/ctrl/command.unit.test.ts
@@ -1232,6 +1232,164 @@ describe("session list", () => {
 });
 
 // ---------------------------------------------------------------------------
+// automation --list
+// ---------------------------------------------------------------------------
+
+type AutomationJobRow = typeof DbSchema.automationJobs.$inferSelect;
+
+const JOB_RESET = "\x1b[0m";
+
+const listedJob = (
+  fields: Pick<AutomationJobRow, "status" | "action"> &
+    Partial<AutomationJobRow> & {
+      readonly ticket?: string | null;
+      readonly test?: string;
+    },
+): AutomationJobRow & { readonly ticket: string | null; readonly test: string } => ({
+  id: fields.id ?? "00000000-0000-4000-8000-000000000001",
+  resultId: fields.resultId ?? RESULT_ID,
+  action: fields.action,
+  status: fields.status,
+  reason: fields.reason ?? null,
+  createdAt: fields.createdAt ?? ago(90),
+  startedAt: fields.startedAt ?? (fields.status === "pending" ? null : ago(5)),
+  finishedAt:
+    fields.finishedAt ??
+    (fields.status === "pending" || fields.status === "running" ? null : ago(60)),
+  ticket: fields.ticket ?? "OLI-42",
+  test: fields.test ?? "lock-screen",
+});
+
+describe("automation --list", () => {
+  it.effect("prints running, then pending, then completed, from the database (happy)", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(NOW);
+      const h = harness();
+      h.stores.automation.jobs.push(
+        listedJob({
+          id: "00000000-0000-4000-8000-000000000001",
+          status: "running",
+          action: "drive",
+          createdAt: ago(300),
+          startedAt: ago(5),
+          ticket: "OLI-42",
+          test: "lock-screen",
+        }),
+        listedJob({
+          id: "00000000-0000-4000-8000-000000000002",
+          resultId: OTHER_RESULT_ID,
+          status: "pending",
+          action: "diagnose",
+          createdAt: ago(90),
+          startedAt: null,
+          ticket: "OLI-43",
+          test: "lock-screen",
+        }),
+        listedJob({
+          id: "00000000-0000-4000-8000-000000000003",
+          resultId: "44444444-4444-4444-8444-444444444444",
+          status: "succeeded",
+          action: "drive",
+          createdAt: ago(3_600),
+          startedAt: ago(3_000),
+          finishedAt: ago(60),
+          ticket: "OLI-41",
+          test: "Open a terminal",
+        }),
+      );
+      const exit = yield* h.run(["automation", "--list"]);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* stdout).toEqual([
+        "running",
+        `\x1b[33mrunning  ${JOB_RESET}  drive      5s ago       OLI-42  lock-screen`,
+        "pending",
+        `\x1b[90mpending  ${JOB_RESET}  diagnose  1m ago       OLI-43  lock-screen`,
+        "completed",
+        `\x1b[32msucceeded${JOB_RESET}  drive      1m ago       OLI-41  Open a terminal`,
+      ]);
+      expect(h.touched).toEqual(["database"]);
+    }),
+  );
+
+  it.effect("lists every running and pending job, and --count bounds only completed (happy)", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(NOW);
+      const h = harness();
+      h.stores.automation.jobs.push(
+        listedJob({
+          id: "00000000-0000-4000-8000-000000000011",
+          status: "running",
+          action: "diagnose",
+          startedAt: ago(2),
+          ticket: "OLI-50",
+        }),
+        listedJob({
+          id: "00000000-0000-4000-8000-000000000012",
+          resultId: OTHER_RESULT_ID,
+          status: "pending",
+          action: "drive",
+          createdAt: ago(10),
+          startedAt: null,
+          ticket: "OLI-51",
+        }),
+        listedJob({
+          id: "00000000-0000-4000-8000-000000000013",
+          resultId: "44444444-4444-4444-8444-444444444444",
+          status: "failed",
+          action: "drive",
+          finishedAt: ago(30),
+          ticket: "OLI-52",
+        }),
+        listedJob({
+          id: "00000000-0000-4000-8000-000000000014",
+          resultId: "55555555-5555-4555-8555-555555555555",
+          status: "succeeded",
+          action: "diagnose",
+          finishedAt: ago(90),
+          ticket: "OLI-53",
+        }),
+      );
+      const exit = yield* h.run(["automation", "--list", "--count=1"]);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* stdout).toEqual([
+        "running",
+        `\x1b[33mrunning  ${JOB_RESET}  diagnose  2s ago       OLI-50  lock-screen`,
+        "pending",
+        `\x1b[90mpending  ${JOB_RESET}  drive      10s ago      OLI-51  lock-screen`,
+        "completed",
+        `\x1b[31mfailed   ${JOB_RESET}  drive      30s ago      OLI-52  lock-screen`,
+      ]);
+    }),
+  );
+
+  it.effect("prints the three headers when there are no jobs (happy)", () =>
+    Effect.gen(function* () {
+      const h = harness();
+      const exit = yield* h.run(["automation", "--list"]);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      expect(yield* stdout).toEqual(["running", "pending", "completed"]);
+    }),
+  );
+
+  it.effect(
+    "rejects automation without --list, a count below one, and a non-integer count (unhappy)",
+    () =>
+      Effect.gen(function* () {
+        const h = harness();
+        const bare = yield* h.run(["automation"]);
+        expect(helpErrors(bare).join("\n")).toMatch(/Missing required flag: --list/);
+        const zero = yield* h.run(["automation", "--list", "--count", "0"]);
+        expect(helpErrors(zero).join("\n")).toMatch(
+          /Invalid value for flag --count: "0".*count must be at least 1/s,
+        );
+        const word = yield* h.run(["automation", "--list", "--count", "ten"]);
+        expect(helpErrors(word).join("\n")).toMatch(/Invalid value for flag --count: "ten"/);
+        expect(h.touched).toEqual([]);
+      }),
+  );
+});
+
+// ---------------------------------------------------------------------------
 // error-type new / list
 // ---------------------------------------------------------------------------
 
@@ -2353,6 +2511,7 @@ describe("environment order", () => {
           NEW_TYPE,
           ["error-type", "list"],
           DIAGNOSE,
+          ["automation", "--list"],
         ]) {
           const exit = yield* h.run(args, {
             DATABASE_URL: "",
@@ -2404,6 +2563,7 @@ describe("--server-url", () => {
     NEW_TYPE,
     ["error-type", "list"],
     DIAGNOSE,
+    ["automation", "--list"],
   ].map((args) => [...args, "--server-url", SERVER]);
 
   it.effect("is required on test new (unhappy)", () =>
@@ -2485,6 +2645,7 @@ describe("--server-url", () => {
         NEW_TYPE,
         ["error-type", "list"],
         DIAGNOSE,
+        ["automation", "--list"],
       ]) {
         expect(Exit.isSuccess(yield* h.run(args, env)), args.join(" ")).toBe(true);
       }
@@ -2664,6 +2825,7 @@ describe("--help", () => {
           ["error-type", "new", "--help"],
           ["error-type", "list", "--help"],
           ["diagnose", "--help"],
+          ["automation", "--help"],
         ]) {
           // The built-in --help renders and succeeds; runMain exits 0.
           const exit = yield* h.run(args, {});
@@ -2675,6 +2837,7 @@ describe("--help", () => {
         expect(printed).toMatch(/session/);
         expect(printed).toMatch(/error-type/);
         expect(printed).toMatch(/diagnose/);
+        expect(printed).toMatch(/automation/);
         expect(printed.includes("--dump")).toBe(false);
       }),
   );

--- a/test/ctrl/render.unit.test.ts
+++ b/test/ctrl/render.unit.test.ts
@@ -261,11 +261,11 @@ describe("renderAutomationJobs happy path", () => {
     );
     expect(lines).toEqual([
       "running",
-      `\x1b[33mrunning  ${JOB_RESET}  drive      5s ago       OLI-42  lock-screen`,
+      `\x1b[33mrunning  ${JOB_RESET}  drive     5s ago       OLI-42  lock-screen`,
       "pending",
       `\x1b[90mpending  ${JOB_RESET}  diagnose  1m ago       OLI-43  lock-screen`,
       "completed",
-      `\x1b[32msucceeded${JOB_RESET}  drive      1h ago       OLI-41  Open a terminal`,
+      `\x1b[32msucceeded${JOB_RESET}  drive     1h30m ago    OLI-41  Open a terminal`,
     ]);
   });
 
@@ -334,11 +334,11 @@ describe("renderAutomationJobs happy path", () => {
     );
     expect(lines).toEqual([
       "running",
-      `\x1b[33mrunning  ${JOB_RESET}  drive      5s ago       OLI-10  lock-screen`,
+      `\x1b[33mrunning  ${JOB_RESET}  drive     5s ago       OLI-10  lock-screen`,
       "pending",
       `\x1b[90mpending  ${JOB_RESET}  diagnose  1m ago       OLI-11  lock-screen`,
       "completed",
-      `\x1b[31mfailed   ${JOB_RESET}  drive      1m ago       OLI-12  lock-screen`,
+      `\x1b[31mfailed   ${JOB_RESET}  drive     1m ago       OLI-12  lock-screen`,
     ]);
   });
 
@@ -354,7 +354,7 @@ describe("renderAutomationJobs happy path", () => {
     expect(lines).toEqual([
       "running",
       "pending",
-      `\x1b[90mpending  ${JOB_RESET}  drive      5s ago       —  lock-screen`,
+      `\x1b[90mpending  ${JOB_RESET}  drive     5s ago       —  lock-screen`,
       "completed",
     ]);
   });
@@ -380,7 +380,7 @@ describe("renderAutomationJobs unhappy path", () => {
     );
     expect(lines).toEqual([
       "running",
-      `\x1b[33mrunning  ${JOB_RESET}  drive      0s ago       OLI-9  lock-screen`,
+      `\x1b[33mrunning  ${JOB_RESET}  drive     0s ago       OLI-9  lock-screen`,
       "pending",
       "completed",
     ]);

--- a/test/ctrl/render.unit.test.ts
+++ b/test/ctrl/render.unit.test.ts
@@ -227,3 +227,162 @@ describe("renderTestDefinitionHistory unhappy path", () => {
     expect(Render.renderTestDefinitionHistory([], true)).toEqual(["[]"]);
   });
 });
+
+const JOB_RESET = "\x1b[0m";
+
+const job = (
+  status: Render.AutomationJobRow["status"],
+  action: Render.AutomationJobRow["action"],
+  secondsAgo: number,
+  ticket: string | null,
+  test: string,
+): Render.AutomationJobRow => {
+  const stamp = ago(secondsAgo);
+  return {
+    ticket,
+    test,
+    action,
+    status,
+    createdAt: stamp,
+    startedAt: status === "pending" ? null : stamp,
+    finishedAt: status === "pending" || status === "running" ? null : stamp,
+  };
+};
+
+describe("renderAutomationJobs happy path", () => {
+  it("prints running, then pending, then completed, each under its header", () => {
+    const lines = Render.renderAutomationJobs(
+      {
+        running: [job("running", "drive", 5, "OLI-42", "lock-screen")],
+        pending: [job("pending", "diagnose", 90, "OLI-43", "lock-screen")],
+        completed: [job("succeeded", "drive", 90 * 60, "OLI-41", "Open a terminal")],
+      },
+      NOW,
+    );
+    expect(lines).toEqual([
+      "running",
+      `\x1b[33mrunning  ${JOB_RESET}  drive      5s ago       OLI-42  lock-screen`,
+      "pending",
+      `\x1b[90mpending  ${JOB_RESET}  diagnose  1m ago       OLI-43  lock-screen`,
+      "completed",
+      `\x1b[32msucceeded${JOB_RESET}  drive      1h ago       OLI-41  Open a terminal`,
+    ]);
+  });
+
+  it("colors every job status: gray pending, yellow running, green succeeded, red failed, bright red aborted, magenta timed_out", () => {
+    const statuses = ["pending", "running", "succeeded", "failed", "aborted", "timed_out"] as const;
+    const lines = Render.renderAutomationJobs(
+      {
+        running: [job("running", "drive", 1, "OLI-1", "t")],
+        pending: [job("pending", "drive", 1, "OLI-2", "t")],
+        completed: statuses
+          .filter((status) => status !== "pending" && status !== "running")
+          .map((status, index) => job(status, "drive", 1, `OLI-${String(index + 3)}`, "t")),
+      },
+      NOW,
+    );
+    const colored = lines.filter((line) => line.includes(JOB_RESET));
+    expect(colored.map((line) => line.slice(0, line.indexOf(JOB_RESET)))).toEqual([
+      "\x1b[33mrunning  ",
+      "\x1b[90mpending  ",
+      "\x1b[32msucceeded",
+      "\x1b[31mfailed   ",
+      "\x1b[91maborted  ",
+      "\x1b[35mtimed_out",
+    ]);
+    expect(Object.keys(Render.JOB_STATUS_COLOR).sort()).toEqual([...statuses].sort());
+  });
+
+  it("ages a running job from startedAt, a pending job from createdAt, and a completed job from finishedAt", () => {
+    const lines = Render.renderAutomationJobs(
+      {
+        running: [
+          {
+            ticket: "OLI-10",
+            test: "lock-screen",
+            action: "drive",
+            status: "running",
+            createdAt: ago(300),
+            startedAt: ago(5),
+            finishedAt: null,
+          },
+        ],
+        pending: [
+          {
+            ticket: "OLI-11",
+            test: "lock-screen",
+            action: "diagnose",
+            status: "pending",
+            createdAt: ago(90),
+            startedAt: null,
+            finishedAt: null,
+          },
+        ],
+        completed: [
+          {
+            ticket: "OLI-12",
+            test: "lock-screen",
+            action: "drive",
+            status: "failed",
+            createdAt: ago(3_600),
+            startedAt: ago(3_000),
+            finishedAt: ago(60),
+          },
+        ],
+      },
+      NOW,
+    );
+    expect(lines).toEqual([
+      "running",
+      `\x1b[33mrunning  ${JOB_RESET}  drive      5s ago       OLI-10  lock-screen`,
+      "pending",
+      `\x1b[90mpending  ${JOB_RESET}  diagnose  1m ago       OLI-11  lock-screen`,
+      "completed",
+      `\x1b[31mfailed   ${JOB_RESET}  drive      1m ago       OLI-12  lock-screen`,
+    ]);
+  });
+
+  it("prints — when a job has no ticket", () => {
+    const lines = Render.renderAutomationJobs(
+      {
+        running: [],
+        pending: [job("pending", "drive", 5, null, "lock-screen")],
+        completed: [],
+      },
+      NOW,
+    );
+    expect(lines).toEqual([
+      "running",
+      "pending",
+      `\x1b[90mpending  ${JOB_RESET}  drive      5s ago       —  lock-screen`,
+      "completed",
+    ]);
+  });
+});
+
+describe("renderAutomationJobs unhappy path", () => {
+  it("prints the three headers and no job lines when every list is empty", () => {
+    expect(Render.renderAutomationJobs({ running: [], pending: [], completed: [] }, NOW)).toEqual([
+      "running",
+      "pending",
+      "completed",
+    ]);
+  });
+
+  it("renders a stamp ahead of this clock as 0s ago, never a negative age", () => {
+    const lines = Render.renderAutomationJobs(
+      {
+        running: [job("running", "drive", -45, "OLI-9", "lock-screen")],
+        pending: [],
+        completed: [],
+      },
+      NOW,
+    );
+    expect(lines).toEqual([
+      "running",
+      `\x1b[33mrunning  ${JOB_RESET}  drive      0s ago       OLI-9  lock-screen`,
+      "pending",
+      "completed",
+    ]);
+  });
+});

--- a/test/integration/ctrl.integration.test.ts
+++ b/test/integration/ctrl.integration.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import * as DbSchema from "../../src/db/schema.ts";
@@ -130,6 +130,85 @@ const seedResult = async (sessionId: string | null): Promise<string> => {
 const lines = (text: string): ReadonlyArray<string> =>
   text.split("\n").filter((line) => line !== "");
 
+type SeededJob = {
+  readonly ticket: string | null;
+  readonly action: (typeof DbSchema.automationJobs.$inferInsert)["action"];
+  readonly status: (typeof DbSchema.automationJobs.$inferInsert)["status"];
+  readonly queuedSecondsAgo: number;
+  readonly startedSecondsAgo?: number;
+  readonly finishedSecondsAgo?: number;
+};
+
+const secondsAgo = (seconds: number) => sql`now() - make_interval(secs => ${seconds})`;
+
+// One definition, and per job its own run and result. The jobs already in the container go
+// first: this listing is its own to arrange.
+const seedAutomationJobs = async (jobs: ReadonlyArray<SeededJob>): Promise<void> => {
+  const client = new Client({ connectionString: Postgres.getDbUrl() });
+  await client.connect();
+  try {
+    const db = drizzle({ client });
+    await db.delete(DbSchema.automationJobs);
+    const [definition] = await db
+      .insert(DbSchema.testDefinitions)
+      .values({
+        name: `automation-list-${randomUUID()}`,
+        description: "d",
+        instruction: "i",
+        proof: "p",
+      })
+      .returning({ id: DbSchema.testDefinitions.id });
+    if (definition === undefined) {
+      throw new Error("seed: no definition inserted");
+    }
+    const runs = await db
+      .insert(DbSchema.testRuns)
+      .values(
+        jobs.map((_, index) => ({
+          name: `automation-list ${String(index)}`,
+          iso: "https://example.com/omarchy.iso",
+          serverUrl: SERVER,
+        })),
+      )
+      .returning({ id: DbSchema.testRuns.id });
+    const results = await db
+      .insert(DbSchema.testResults)
+      .values(
+        jobs.map((job, index) => {
+          const run = runs[index];
+          if (run === undefined) {
+            throw new Error("seed: no run inserted");
+          }
+          return {
+            runId: run.id,
+            definitionId: definition.id,
+            linearId: job.ticket,
+          };
+        }),
+      )
+      .returning({ id: DbSchema.testResults.id });
+    await db.insert(DbSchema.automationJobs).values(
+      jobs.map((job, index) => {
+        const result = results[index];
+        if (result === undefined) {
+          throw new Error("seed: no result inserted");
+        }
+        return {
+          resultId: result.id,
+          action: job.action,
+          status: job.status,
+          createdAt: secondsAgo(job.queuedSecondsAgo),
+          startedAt: job.startedSecondsAgo === undefined ? null : secondsAgo(job.startedSecondsAgo),
+          finishedAt:
+            job.finishedSecondsAgo === undefined ? null : secondsAgo(job.finishedSecondsAgo),
+        };
+      }),
+    );
+  } finally {
+    await client.end();
+  }
+};
+
 // ---------------------------------------------------------------------------
 // Without a database: parsing, environment order
 // ---------------------------------------------------------------------------
@@ -140,6 +219,7 @@ describe("./ctrl without a database", () => {
     expect(bare.code).toBe(0);
     expect(bare.stdout).toMatch(/test-results/);
     expect(bare.stdout).toMatch(/session/);
+    expect(bare.stdout).toMatch(/automation/);
 
     const unknown = await runCtrl(["reboot"], { DATABASE_URL: "" });
     expect(unknown.code).toBe(1);
@@ -153,6 +233,7 @@ describe("./ctrl without a database", () => {
       ["session", "--help"],
       ["test", "start", "--help"],
       ["diagnose", "--help"],
+      ["automation", "--help"],
     ]) {
       const result = await runCtrl(args, { DATABASE_URL: "" });
       expect(result.code).toBe(0);
@@ -253,6 +334,7 @@ describe("./ctrl without a database", () => {
         "--model",
         "m",
       ],
+      ["automation", "--list"],
     ]) {
       const result = await runCtrl(args, {
         DATABASE_URL: "",
@@ -442,6 +524,13 @@ describe("./ctrl without a database", () => {
         env,
       ],
       [["session", "list", "--count", "ten"], /Invalid value for flag --count: "ten"/, env],
+      [["automation"], /Missing required flag: --list/, env],
+      [
+        ["automation", "--list", "--count", "0"],
+        /Invalid value for flag --count: "0"[\s\S]*count must be at least 1/,
+        env,
+      ],
+      [["automation", "--list", "--count", "ten"], /Invalid value for flag --count: "ten"/, env],
       [["session", "list", "--session-id", randomUUID()], /Unrecognized flag: --session-id/, env],
       [
         ["session", "--session-id", randomUUID(), "--logs", "--active"],
@@ -666,6 +755,91 @@ Postgres.describeWithDatabase("./ctrl against the seeded database", () => {
         expect(pendingSeen).toBe(false);
       }
     }
+  });
+
+  it("automation --list prints running, then pending, then completed, from the database", async () => {
+    await seedAutomationJobs([
+      {
+        ticket: "CTL-101",
+        action: "drive",
+        status: "running",
+        queuedSecondsAgo: 300,
+        startedSecondsAgo: 5,
+      },
+      {
+        ticket: "CTL-102",
+        action: "diagnose",
+        status: "running",
+        queuedSecondsAgo: 100,
+        startedSecondsAgo: 2,
+      },
+      { ticket: "CTL-103", action: "drive", status: "pending", queuedSecondsAgo: 90 },
+      { ticket: "CTL-104", action: "diagnose", status: "pending", queuedSecondsAgo: 30 },
+      {
+        ticket: "CTL-105",
+        action: "drive",
+        status: "succeeded",
+        queuedSecondsAgo: 3_000,
+        startedSecondsAgo: 2_900,
+        finishedSecondsAgo: 600,
+      },
+      {
+        ticket: "CTL-106",
+        action: "drive",
+        status: "failed",
+        queuedSecondsAgo: 2_000,
+        startedSecondsAgo: 1_900,
+        finishedSecondsAgo: 60,
+      },
+    ]);
+    const result = await runCtrl(["automation", "--list"]);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    const printed = lines(result.stdout);
+    expect(printed[0]).toBe("running");
+    expect(printed[1]).toContain("CTL-102");
+    expect(printed[1]).toContain("diagnose");
+    expect(printed[1]).toContain("running");
+    expect(printed[2]).toContain("CTL-101");
+    expect(printed[2]).toContain("drive");
+    const pendingAt = printed.indexOf("pending");
+    expect(printed[pendingAt + 1]).toContain("CTL-104");
+    expect(printed[pendingAt + 2]).toContain("CTL-103");
+    const completedAt = printed.indexOf("completed");
+    expect(printed[completedAt + 1]).toContain("CTL-106");
+    expect(printed[completedAt + 1]).toContain("failed");
+    expect(printed[completedAt + 2]).toContain("CTL-105");
+    expect(printed[completedAt + 2]).toContain("succeeded");
+  });
+
+  it("automation --list --count bounds only the completed jobs", async () => {
+    await seedAutomationJobs([
+      { ticket: "CTL-201", action: "drive", status: "pending", queuedSecondsAgo: 10 },
+      {
+        ticket: "CTL-202",
+        action: "drive",
+        status: "succeeded",
+        queuedSecondsAgo: 200,
+        startedSecondsAgo: 180,
+        finishedSecondsAgo: 90,
+      },
+      {
+        ticket: "CTL-203",
+        action: "diagnose",
+        status: "failed",
+        queuedSecondsAgo: 300,
+        startedSecondsAgo: 280,
+        finishedSecondsAgo: 20,
+      },
+    ]);
+    const result = await runCtrl(["automation", "--list", "--count=1"]);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    const printed = lines(result.stdout);
+    expect(printed).toContain("pending");
+    expect(printed.some((line) => line.includes("CTL-201"))).toBe(true);
+    expect(printed.some((line) => line.includes("CTL-203"))).toBe(true);
+    expect(printed.some((line) => line.includes("CTL-202"))).toBe(false);
   });
 
   it("session --logs prints the bare JSON array and needs neither OLIGARCHY_TOKEN nor SERVER_URL", async () => {

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -1179,6 +1179,70 @@ Postgres.describeWithDatabase("database", () => {
     );
 
     scoped.effect(
+      "AutomationStore listJobs returns every running and pending job, diagnoses first, and the newest completed up to count",
+      () =>
+        Effect.gen(function* () {
+          const tests = yield* Tests.TestStore;
+          const automation = yield* Automation.AutomationStore;
+          const database = yield* Client.Database;
+          const definition = Option.getOrThrow(yield* tests.findTestDefinition("lock-screen"));
+          const created = yield* Effect.forEach([0, 1, 2, 3, 4, 5], () =>
+            tests.createRun({
+              iso: "https://example.com/omarchy.iso",
+              serverUrl: "http://127.0.0.1:42069",
+              definitions: [{ id: definition.id }],
+            }),
+          );
+          const resultIds = created.map((run) => run.results[0].id);
+          yield* tests.setLinearId(resultIds[0], "LST-101");
+          yield* tests.setLinearId(resultIds[1], "LST-102");
+          yield* tests.setLinearId(resultIds[2], "LST-103");
+          yield* tests.setLinearId(resultIds[3], "LST-104");
+          yield* tests.setLinearId(resultIds[4], "LST-105");
+          yield* tests.setLinearId(resultIds[5], "LST-106");
+          const completedDrive = yield* automation.enqueue({
+            resultId: resultIds[0],
+            action: "drive",
+          });
+          const completedDiagnose = yield* automation.enqueue({
+            resultId: resultIds[1],
+            action: "diagnose",
+          });
+          yield* automation.enqueue({ resultId: resultIds[2], action: "drive" });
+          yield* automation.enqueue({ resultId: resultIds[3], action: "diagnose" });
+          yield* automation.enqueue({ resultId: resultIds[4], action: "drive" });
+          yield* automation.enqueue({ resultId: resultIds[5], action: "diagnose" });
+          expect(Option.isSome(yield* automation.claim())).toBe(true);
+          expect(Option.isSome(yield* automation.claim())).toBe(true);
+          yield* automation.finish(completedDrive.id, "succeeded", null);
+          yield* automation.finish(completedDiagnose.id, "failed", "nope");
+          yield* database.run("stamp", (db) =>
+            db.execute(
+              sql`update automation_jobs set finished_at = now() - interval '2 minutes' where id = ${completedDrive.id}`,
+            ),
+          );
+          expect(Option.isSome(yield* automation.claim())).toBe(true);
+          expect(Option.isSome(yield* automation.claim())).toBe(true);
+          const listed = yield* automation.listJobs(1);
+          expect(listed.running.map((job) => [job.ticket, job.action, job.status])).toEqual([
+            ["LST-104", "diagnose", "running"],
+            ["LST-103", "drive", "running"],
+          ]);
+          expect(listed.pending.map((job) => [job.ticket, job.action, job.test])).toEqual([
+            ["LST-106", "diagnose", "lock-screen"],
+            ["LST-105", "drive", "lock-screen"],
+          ]);
+          expect(listed.completed.map((job) => [job.ticket, job.status])).toEqual([
+            ["LST-102", "failed"],
+          ]);
+          const more = yield* automation.listJobs(10);
+          expect(more.completed.map((job) => job.ticket)).toEqual(["LST-102", "LST-101"]);
+          expect(more.running).toHaveLength(2);
+          expect(more.pending).toHaveLength(2);
+        }),
+    );
+
+    scoped.effect(
       "ServerStore registers a url once as a qemu server, lists the qemu servers in registration order, forgets it",
       () =>
         Effect.gen(function* () {

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -20,6 +20,10 @@ type TestBasePromptRow = typeof DbSchema.testBasePrompts.$inferSelect;
 type TestRunRow = typeof DbSchema.testRuns.$inferSelect;
 type TestResultRow = typeof DbSchema.testResults.$inferSelect;
 type AutomationJobRow = typeof DbSchema.automationJobs.$inferSelect;
+type FakeAutomationJob = AutomationJobRow & {
+  readonly ticket?: string | null;
+  readonly test?: string;
+};
 
 const sameId = (left: string, right: string): boolean => left.toLowerCase() === right.toLowerCase();
 
@@ -514,7 +518,7 @@ export const fakeTestStore = (
 // ---------------------------------------------------------------------------
 
 export type FakeAutomationStore = {
-  readonly jobs: Array<AutomationJobRow>;
+  readonly jobs: Array<FakeAutomationJob>;
   readonly layer: Layer.Layer<Automation.AutomationStore>;
 };
 
@@ -522,7 +526,7 @@ export type FakeAutomationStore = {
 export const fakeAutomationStore = (
   overrides: Partial<typeof Automation.AutomationStore.Service> = {},
 ): FakeAutomationStore => {
-  const jobs: Array<AutomationJobRow> = [];
+  const jobs: Array<FakeAutomationJob> = [];
   let nextId = 1;
   const service = Automation.AutomationStore.of({
     enqueue: (input) =>
@@ -534,7 +538,7 @@ export const fakeAutomationStore = (
             conflict("enqueueAutomationJob", 'insert into "automation_jobs"'),
           );
         }
-        const row: AutomationJobRow = {
+        const row: FakeAutomationJob = {
           id: `00000000-0000-4000-8000-${String(nextId++).padStart(12, "0")}`,
           resultId: input.resultId,
           action: input.action,
@@ -576,6 +580,48 @@ export const fakeAutomationStore = (
           job.reason = reason;
         }
         return true;
+      }),
+    listJobs: (count) =>
+      Effect.sync(() => {
+        const listed = (job: FakeAutomationJob): Automation.AutomationJobListRow => ({
+          ticket: job.ticket ?? null,
+          test: job.test ?? "",
+          action: job.action,
+          status: job.status,
+          createdAt: job.createdAt,
+          startedAt: job.startedAt,
+          finishedAt: job.finishedAt,
+        });
+        const diagnoseFirst = (left: FakeAutomationJob, right: FakeAutomationJob) => {
+          if (left.action !== right.action) {
+            return left.action === "diagnose" ? -1 : 1;
+          }
+          const byTime = left.createdAt.getTime() - right.createdAt.getTime();
+          return byTime !== 0 ? byTime : left.id.localeCompare(right.id);
+        };
+        const running = jobs
+          .filter((job) => job.status === "running")
+          .sort(diagnoseFirst)
+          .map(listed);
+        const pending = jobs
+          .filter((job) => job.status === "pending")
+          .sort(diagnoseFirst)
+          .map(listed);
+        const completed = jobs
+          .filter(
+            (job) =>
+              job.status === "succeeded" ||
+              job.status === "failed" ||
+              job.status === "aborted" ||
+              job.status === "timed_out",
+          )
+          .sort((left, right) => {
+            const byTime = (right.finishedAt?.getTime() ?? 0) - (left.finishedAt?.getTime() ?? 0);
+            return byTime !== 0 ? byTime : right.id.localeCompare(left.id);
+          })
+          .slice(0, count)
+          .map(listed);
+        return { running, pending, completed };
       }),
     ...overrides,
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`./ctrl automation --list` prints the automation queue straight from the database: every running job, then every pending job, then the most recently completed jobs.

## Why

Operators need to see what the automation worker is doing without hitting an HTTP endpoint. `./ctrl` is already the record keeper; this is the same pattern as `session list`.

## Behavior

```
./ctrl automation --list [--count <n>]
```

- `--list` is required.
- Running and pending are printed in full (diagnoses first, then queue order).
- Completed is the last 10 by default; `--count` raises that.
- Each line is colored status, action, age, ticket (or `—`), and test name.
- Age is started-at for running, queued-at for pending, finished-at for completed.

No qemu server, no Linear, no automation-server HTTP. `DATABASE_URL` only.

## Testing

- `npm run check:fast` — lint, format, types, 948 unit tests green.
- Live `./ctrl automation --list` against the environment database: all running jobs, empty pending, last 10 completed.
- `--count 2` kept every running job and cut completed to two.
- Missing `--list` is a usage error; `--count 0` is refused.
- Database-backed integration tests were skipped here (no Docker); they are in the PR for CI.

[CLI output of automation --help, --list, --count 2, and missing --list](https://cursor.com/agents/bc-01a0912b-3b4c-733b-becc-1ffff480b16b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fctrl_automation_list.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0912b-3b4c-733b-becc-1ffff480b16b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0912b-3b4c-733b-becc-1ffff480b16b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

