### PR TITLE
Add automation-server POST /abort with ticket routing

### DIFF
--- a/drizzle/0011_busy_spectrum.sql
+++ b/drizzle/0011_busy_spectrum.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "automation_jobs" ADD COLUMN "client_url" text;

--- a/drizzle/0011_busy_spectrum.sql
+++ b/drizzle/0011_busy_spectrum.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "automation_jobs" ADD COLUMN "client_url" text;

--- a/drizzle/0011_volatile_sersi.sql
+++ b/drizzle/0011_volatile_sersi.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "automation_jobs" ADD COLUMN "server_id" uuid;--> statement-breakpoint
+ALTER TABLE "servers" ADD COLUMN "id" uuid DEFAULT gen_random_uuid() NOT NULL;--> statement-breakpoint
+ALTER TABLE "servers" ADD CONSTRAINT "servers_id_unique" UNIQUE("id");

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "9804ecb3-a9d2-4471-992b-ccdebde78ba1",
+  "id": "c08369c0-745e-43b2-8290-1dd24d29ece4",
   "prevId": "91b67423-9d71-414e-980c-33fe00b1af99",
   "version": "7",
   "dialect": "postgresql",
@@ -227,9 +227,9 @@
           "primaryKey": false,
           "notNull": false
         },
-        "client_url": {
-          "name": "client_url",
-          "type": "text",
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": false
         },
@@ -640,6 +640,13 @@
       "name": "servers",
       "schema": "",
       "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
         "url": {
           "name": "url",
           "type": "text",
@@ -684,7 +691,15 @@
       "indexes": {},
       "foreignKeys": {},
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
+      "uniqueConstraints": {
+        "servers_id_unique": {
+          "name": "servers_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1269 @@
+{
+  "id": "9804ecb3-a9d2-4471-992b-ccdebde78ba1",
+  "prevId": "91b67423-9d71-414e-980c-33fe00b1af99",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "actions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "action_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "actions_session_id_idx": {
+          "name": "actions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_session_id_sessions_id_fk": {
+          "name": "actions_session_id_sessions_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actions_agent_id_agent_runs_agent_id_fk": {
+          "name": "actions_agent_id_agent_runs_agent_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_runs_session_id_idx": {
+          "name": "agent_runs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_session_id_sessions_id_fk": {
+          "name": "agent_runs_session_id_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_jobs": {
+      "name": "automation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "automation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_url": {
+          "name": "client_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_jobs_result_action_idx": {
+          "name": "automation_jobs_result_action_idx",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_jobs_status_created_at_idx": {
+          "name": "automation_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_jobs_result_id_test_results_result_id_fk": {
+          "name": "automation_jobs_result_id_test_results_result_id_fk",
+          "tableFrom": "automation_jobs",
+          "tableTo": "test_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debug_logs_session_id_sessions_id_fk": {
+          "name": "debug_logs_session_id_sessions_id_fk",
+          "tableFrom": "debug_logs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "images_id_idx": {
+          "name": "images_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_action_id_actions_id_fk": {
+          "name": "images_action_id_actions_id_fk",
+          "tableFrom": "images",
+          "tableTo": "actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_location_idx": {
+          "name": "logs_location_idx",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_run_diagnosis": {
+      "name": "post_run_diagnosis",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "diagnosis_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_run_diagnosis_error_type_idx": {
+          "name": "post_run_diagnosis_error_type_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_run_diagnosis_session_id_sessions_id_fk": {
+          "name": "post_run_diagnosis_session_id_sessions_id_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_run_diagnosis_error_type_post_run_error_types_key_fk": {
+          "name": "post_run_diagnosis_error_type_post_run_error_types_key_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "post_run_error_types",
+          "columnsFrom": [
+            "error_type"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_run_diagnosis_verdict_error_type_check": {
+          "name": "post_run_diagnosis_verdict_error_type_check",
+          "value": "(\"post_run_diagnosis\".\"verdict\" = 'passed') = (\"post_run_diagnosis\".\"error_type\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_run_error_types": {
+      "name": "post_run_error_types",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servers": {
+      "name": "servers",
+      "schema": "",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "server_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'qemu'"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_servers": {
+      "name": "session_servers",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_servers_session_id_sessions_id_fk": {
+          "name": "session_servers_session_id_sessions_id_fk",
+          "tableFrom": "session_servers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_base_prompts": {
+      "name": "test_base_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_base_prompts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_base_prompts_name_idx": {
+          "name": "test_base_prompts_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_definitions": {
+      "name": "test_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_definitions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_definitions_name_idx": {
+          "name": "test_definitions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_results": {
+      "name": "test_results",
+      "schema": "",
+      "columns": {
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_id": {
+          "name": "linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "test_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_results_run_definition_idx": {
+          "name": "test_results_run_definition_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_session_id_idx": {
+          "name": "test_results_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_linear_id_idx": {
+          "name": "test_results_linear_id_idx",
+          "columns": [
+            {
+              "expression": "linear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_results_run_id_test_runs_id_fk": {
+          "name": "test_results_run_id_test_runs_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_definition_id_test_definitions_id_fk": {
+          "name": "test_results_definition_id_test_definitions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_session_id_sessions_id_fk": {
+          "name": "test_results_session_id_sessions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso": {
+          "name": "iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "test_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.action_state": {
+      "name": "action_state",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed"
+      ]
+    },
+    "public.automation_action": {
+      "name": "automation_action",
+      "schema": "public",
+      "values": [
+        "drive",
+        "diagnose"
+      ]
+    },
+    "public.automation_job_status": {
+      "name": "automation_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.diagnosis_verdict": {
+      "name": "diagnosis_verdict",
+      "schema": "public",
+      "values": [
+        "passed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.server_type": {
+      "name": "server_type",
+      "schema": "public",
+      "values": [
+        "qemu",
+        "automation-client"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_result_status": {
+      "name": "test_result_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_run_status": {
+      "name": "test_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1789074862043,
       "tag": "0010_sweet_taskmaster",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1789147828158,
+      "tag": "0011_busy_spectrum",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -75,8 +75,8 @@
     {
       "idx": 11,
       "version": "7",
-      "when": 1789147828158,
-      "tag": "0011_busy_spectrum",
+      "when": 1789151887921,
+      "tag": "0011_volatile_sersi",
       "breakpoints": true
     }
   ]

--- a/src/automation-server/client.ts
+++ b/src/automation-server/client.ts
@@ -24,6 +24,7 @@ const bodyDetail = (text: string): string | undefined =>
 
 const failed = (
   url: string,
+  path: "/run" | "/abort",
   status: number | undefined,
   text: string,
   cause: unknown,
@@ -34,8 +35,8 @@ const failed = (
       {
         message:
           detail === undefined
-            ? `automation client: POST ${url}/run failed`
-            : `automation client: POST ${url}/run failed: ${detail}`,
+            ? `automation client: POST ${url}${path} failed`
+            : `automation client: POST ${url}${path} failed: ${detail}`,
         cause,
       },
       status === undefined ? undefined : { status },
@@ -43,31 +44,55 @@ const failed = (
   );
 };
 
-// POST /run and wait for the client to finish. node:http has no ceiling of its own; a drive or
-// diagnose runs until the client answers, or until this fiber is interrupted.
-export const run = Effect.fn("run")(function* (url: string, prompt: string, ticket: string) {
+const makeClient = Effect.fn("makeClient")(function* (url: string) {
   const token = Redacted.value(yield* OligarchyToken);
   const bearer = HttpApiMiddleware.layerClient(Api.BearerAuth, ({ next, request }) =>
     next(HttpClientRequest.bearerToken(request, token)),
   );
   const middleware = yield* Effect.scoped(Layer.build(bearer));
-  const client = yield* HttpApiClient.make(Api.AutomationClientApi, {
+  return yield* HttpApiClient.make(Api.AutomationClientApi, {
     baseUrl: url,
     transformClient: HttpClient.filterStatusOk,
   }).pipe(Effect.provide(middleware));
+});
+
+// POST /run and wait for the client to finish. node:http has no ceiling of its own; a drive or
+// diagnose runs until the client answers, or until this fiber is interrupted.
+export const run = Effect.fn("run")(function* (url: string, prompt: string, ticket: string) {
+  const client = yield* makeClient(url);
   return yield* client.Runs.run({ payload: Contract.RunBody.make({ prompt, ticket }) }).pipe(
     Effect.catch((error) => {
       if (error._tag === "HttpClientError") {
         const response = error.response;
         if (response === undefined) {
-          return Effect.fail(failed(url, undefined, "", error));
+          return Effect.fail(failed(url, "/run", undefined, "", error));
         }
         return response.text.pipe(
           Effect.orElseSucceed(() => ""),
-          Effect.flatMap((text) => Effect.fail(failed(url, response.status, text, error))),
+          Effect.flatMap((text) => Effect.fail(failed(url, "/run", response.status, text, error))),
         );
       }
-      return Effect.fail(failed(url, undefined, "", error));
+      return Effect.fail(failed(url, "/run", undefined, "", error));
+    }),
+    Effect.asVoid,
+  );
+});
+
+export const abort = Effect.fn("abort")(function* (url: string, ticket: string) {
+  const client = yield* makeClient(url);
+  return yield* client.Runs.abort({ payload: Contract.AbortBody.make({ ticket }) }).pipe(
+    Effect.catch((error) => {
+      if (error._tag === "HttpClientError") {
+        const response = error.response;
+        if (response === undefined) {
+          return Effect.fail(failed(url, "/abort", undefined, "", error));
+        }
+        return response.text.pipe(
+          Effect.orElseSucceed(() => ""),
+          Effect.flatMap((text) => Effect.fail(failed(url, "/abort", response.status, text, error))),
+        );
+      }
+      return Effect.fail(failed(url, "/abort", undefined, "", error));
     }),
     Effect.asVoid,
   );

--- a/src/automation-server/client.ts
+++ b/src/automation-server/client.ts
@@ -89,7 +89,9 @@ export const abort = Effect.fn("abort")(function* (url: string, ticket: string) 
         }
         return response.text.pipe(
           Effect.orElseSucceed(() => ""),
-          Effect.flatMap((text) => Effect.fail(failed(url, "/abort", response.status, text, error))),
+          Effect.flatMap((text) =>
+            Effect.fail(failed(url, "/abort", response.status, text, error)),
+          ),
         );
       }
       return Effect.fail(failed(url, "/abort", undefined, "", error));

--- a/src/automation-server/command.ts
+++ b/src/automation-server/command.ts
@@ -64,6 +64,6 @@ export const makeAutomationServerCommand = <RServe>(server: AutomationServer<RSe
       }),
   ).pipe(
     Command.withDescription(
-      "The automation server: POST /linear verifies a signed Linear webhook and enqueues drive or diagnose jobs, then dispatches them to live automation clients",
+      "The automation server: POST /linear verifies a signed Linear webhook and enqueues drive or diagnose jobs, then dispatches them to live automation clients; POST /abort stops a running job",
     ),
   );

--- a/src/automation-server/handlers.ts
+++ b/src/automation-server/handlers.ts
@@ -10,6 +10,7 @@ import * as Middleware from "../qemu-server/middleware.ts";
 import * as Api from "../shared/api.ts";
 import * as Contract from "../shared/contract.ts";
 import * as Errors from "../shared/errors.ts";
+import * as AutomationClient from "./client.ts";
 import * as Signature from "./signature.ts";
 import * as Webhook from "./webhook.ts";
 
@@ -98,11 +99,76 @@ export const LinearLive = HttpApiBuilder.group(Api.AutomationServerApi, "Linear"
   ),
 );
 
-// The bearer is left off: Linear signs /linear.
+export const AbortLive = HttpApiBuilder.group(Api.AutomationServerApi, "Abort", (handlers) =>
+  handlers.handle("abort", ({ payload }) =>
+    Effect.gen(function* () {
+      const tests = yield* Tests.TestStore;
+      const automation = yield* Automation.AutomationStore;
+      const log = yield* Log.Log;
+      const result = yield* tests.findResultByLinearId(payload.ticket).pipe(
+        Effect.mapError((error) =>
+          Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+        ),
+      );
+      if (Option.isNone(result)) {
+        return yield* Errors.BadRequest.make({
+          message: `ticket "${payload.ticket}" is not running`,
+          agentId: payload.ticket,
+        });
+      }
+      const job = yield* automation.findRunning(result.value.id).pipe(
+        Effect.mapError((error) =>
+          Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+        ),
+      );
+      if (Option.isNone(job)) {
+        return yield* Errors.BadRequest.make({
+          message: `ticket "${payload.ticket}" is not running`,
+          agentId: payload.ticket,
+        });
+      }
+      const url = job.value.clientUrl;
+      if (url === null) {
+        return yield* Effect.die(new Error(`running job ${job.value.id} has no clientUrl`));
+      }
+      yield* AutomationClient.abort(url, payload.ticket).pipe(
+        Effect.catchTag("AutomationClientError", (error) =>
+          error.status === 404
+            ? Effect.fail(Errors.unknownSession(payload.ticket, payload.ticket))
+            : Effect.fail(
+                Errors.RunFailed.make(
+                  Object.assign(
+                    { message: error.message },
+                    error.cause === undefined ? undefined : { cause: error.cause },
+                  ),
+                ),
+              ),
+        ),
+      );
+      yield* log.info(`aborted ${job.value.action}; ${url}`, {
+        location: Log.Locations.automation,
+        agentId: payload.ticket,
+      });
+      yield* automation.finish(job.value.id, "aborted", "aborted").pipe(
+        Effect.mapError((error) =>
+          Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+        ),
+      );
+      return ok;
+    }),
+  ),
+);
+
+const BearerAuthLive = Layer.unwrap(
+  Effect.map(AutomationClient.OligarchyToken, Middleware.bearerAuth),
+);
+
+// Linear signs /linear. /abort takes the oligarchy bearer, from the same token POST /run uses.
 export const routes = Layer.mergeAll(
   HttpApiBuilder.layer(Api.AutomationServerApi).pipe(
     Layer.provide(LinearLive),
-    Layer.provide(Middleware.ApiBoundaryLive),
+    Layer.provide(AbortLive),
+    Layer.provide(Layer.mergeAll(BearerAuthLive, Middleware.ApiBoundaryLive)),
   ),
   QemuServerHandlers.NotFoundRoute,
 );

--- a/src/automation-server/handlers.ts
+++ b/src/automation-server/handlers.ts
@@ -99,69 +99,78 @@ export const LinearLive = HttpApiBuilder.group(Api.AutomationServerApi, "Linear"
   ),
 );
 
+// A disconnect must not leave the client killed and the row still running.
+const uninterruptible = { uninterruptible: true } as const;
+
 export const AbortLive = HttpApiBuilder.group(Api.AutomationServerApi, "Abort", (handlers) =>
-  handlers.handle("abort", ({ payload }) =>
-    Effect.gen(function* () {
-      const tests = yield* Tests.TestStore;
-      const automation = yield* Automation.AutomationStore;
-      const log = yield* Log.Log;
-      const result = yield* tests
-        .findResultByLinearId(payload.ticket)
-        .pipe(
-          Effect.mapError((error) =>
-            Errors.Internal.make({ cause: error, agentId: payload.ticket }),
-          ),
-        );
-      if (Option.isNone(result)) {
-        return yield* Errors.BadRequest.make({
-          message: `ticket "${payload.ticket}" is not running`,
-          agentId: payload.ticket,
-        });
-      }
-      const job = yield* automation
-        .findRunning(result.value.id)
-        .pipe(
-          Effect.mapError((error) =>
-            Errors.Internal.make({ cause: error, agentId: payload.ticket }),
-          ),
-        );
-      if (Option.isNone(job)) {
-        return yield* Errors.BadRequest.make({
-          message: `ticket "${payload.ticket}" is not running`,
-          agentId: payload.ticket,
-        });
-      }
-      const url = job.value.clientUrl;
-      if (url === null) {
-        return yield* Effect.die(new Error(`running job ${job.value.id} has no clientUrl`));
-      }
-      yield* AutomationClient.abort(url, payload.ticket).pipe(
-        Effect.catchTag("AutomationClientError", (error) =>
-          Effect.fail(
-            error.status === 404
-              ? Errors.unknownSession(payload.ticket, payload.ticket)
-              : Errors.RunFailed.make(
-                  Object.assign(
-                    { message: error.message },
-                    error.cause === undefined ? undefined : { cause: error.cause },
+  handlers.handle(
+    "abort",
+    ({ payload }) =>
+      Effect.gen(function* () {
+        const tests = yield* Tests.TestStore;
+        const automation = yield* Automation.AutomationStore;
+        const log = yield* Log.Log;
+        const result = yield* tests
+          .findResultByLinearId(payload.ticket)
+          .pipe(
+            Effect.mapError((error) =>
+              Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+            ),
+          );
+        if (Option.isNone(result)) {
+          return yield* Errors.BadRequest.make({
+            message: `ticket "${payload.ticket}" is not running`,
+            agentId: payload.ticket,
+          });
+        }
+        const job = yield* automation
+          .findRunning(result.value.id)
+          .pipe(
+            Effect.mapError((error) =>
+              Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+            ),
+          );
+        if (Option.isNone(job)) {
+          return yield* Errors.BadRequest.make({
+            message: `ticket "${payload.ticket}" is not running`,
+            agentId: payload.ticket,
+          });
+        }
+        const url = job.value.clientUrl;
+        if (url === null) {
+          return yield* Effect.die(new Error(`running job ${job.value.id} has no clientUrl`));
+        }
+        yield* AutomationClient.abort(url, payload.ticket).pipe(
+          Effect.catchTag("AutomationClientError", (error) =>
+            Effect.fail(
+              error.status === 404
+                ? Errors.unknownSession(payload.ticket, payload.ticket)
+                : Errors.RunFailed.make(
+                    Object.assign(
+                      { message: error.message },
+                      error.cause === undefined ? undefined : { cause: error.cause },
+                    ),
                   ),
-                ),
-          ),
-        ),
-      );
-      yield* log.info(`aborted ${job.value.action}; ${url}`, {
-        location: Log.Locations.automation,
-        agentId: payload.ticket,
-      });
-      yield* automation
-        .finish(job.value.id, "aborted", "aborted")
-        .pipe(
-          Effect.mapError((error) =>
-            Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+            ),
           ),
         );
-      return ok;
-    }),
+        const closed = yield* automation
+          .finish(job.value.id, "aborted", "aborted")
+          .pipe(
+            Effect.mapError((error) =>
+              Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+            ),
+          );
+        if (closed) {
+          yield* log.info(`aborted ${job.value.action}; ${url}`, {
+            location: Log.Locations.automation,
+            agentId: payload.ticket,
+          });
+        }
+        // The client already stopped; a lost finish race is another closer.
+        return ok;
+      }),
+    uninterruptible,
   ),
 );
 

--- a/src/automation-server/handlers.ts
+++ b/src/automation-server/handlers.ts
@@ -3,6 +3,7 @@ import { HttpServerRequest } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import * as Config from "../config.ts";
 import * as Automation from "../db/automation.ts";
+import * as Servers from "../db/servers.ts";
 import * as Tests from "../db/tests.ts";
 import * as Log from "../observability/log.ts";
 import * as QemuServerHandlers from "../qemu-server/handlers.ts";
@@ -109,6 +110,7 @@ export const AbortLive = HttpApiBuilder.group(Api.AutomationServerApi, "Abort", 
       Effect.gen(function* () {
         const tests = yield* Tests.TestStore;
         const automation = yield* Automation.AutomationStore;
+        const servers = yield* Servers.ServerStore;
         const log = yield* Log.Log;
         const result = yield* tests
           .findResultByLinearId(payload.ticket)
@@ -136,10 +138,22 @@ export const AbortLive = HttpApiBuilder.group(Api.AutomationServerApi, "Abort", 
             agentId: payload.ticket,
           });
         }
-        const url = job.value.clientUrl;
-        if (url === null) {
-          return yield* Effect.die(new Error(`running job ${job.value.id} has no clientUrl`));
+        if (job.value.serverId === null) {
+          return yield* Effect.die(new Error(`running job ${job.value.id} has no serverId`));
         }
+        const server = yield* servers
+          .findServer(job.value.serverId)
+          .pipe(
+            Effect.mapError((error) =>
+              Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+            ),
+          );
+        if (Option.isNone(server)) {
+          return yield* Errors.RunFailed.make({
+            message: `unknown server "${job.value.serverId}"`,
+          });
+        }
+        const url = server.value.url;
         yield* AutomationClient.abort(url, payload.ticket).pipe(
           Effect.catchTag("AutomationClientError", (error) =>
             Effect.fail(

--- a/src/automation-server/handlers.ts
+++ b/src/automation-server/handlers.ts
@@ -105,22 +105,26 @@ export const AbortLive = HttpApiBuilder.group(Api.AutomationServerApi, "Abort", 
       const tests = yield* Tests.TestStore;
       const automation = yield* Automation.AutomationStore;
       const log = yield* Log.Log;
-      const result = yield* tests.findResultByLinearId(payload.ticket).pipe(
-        Effect.mapError((error) =>
-          Errors.Internal.make({ cause: error, agentId: payload.ticket }),
-        ),
-      );
+      const result = yield* tests
+        .findResultByLinearId(payload.ticket)
+        .pipe(
+          Effect.mapError((error) =>
+            Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+          ),
+        );
       if (Option.isNone(result)) {
         return yield* Errors.BadRequest.make({
           message: `ticket "${payload.ticket}" is not running`,
           agentId: payload.ticket,
         });
       }
-      const job = yield* automation.findRunning(result.value.id).pipe(
-        Effect.mapError((error) =>
-          Errors.Internal.make({ cause: error, agentId: payload.ticket }),
-        ),
-      );
+      const job = yield* automation
+        .findRunning(result.value.id)
+        .pipe(
+          Effect.mapError((error) =>
+            Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+          ),
+        );
       if (Option.isNone(job)) {
         return yield* Errors.BadRequest.make({
           message: `ticket "${payload.ticket}" is not running`,
@@ -133,27 +137,29 @@ export const AbortLive = HttpApiBuilder.group(Api.AutomationServerApi, "Abort", 
       }
       yield* AutomationClient.abort(url, payload.ticket).pipe(
         Effect.catchTag("AutomationClientError", (error) =>
-          error.status === 404
-            ? Effect.fail(Errors.unknownSession(payload.ticket, payload.ticket))
-            : Effect.fail(
-                Errors.RunFailed.make(
+          Effect.fail(
+            error.status === 404
+              ? Errors.unknownSession(payload.ticket, payload.ticket)
+              : Errors.RunFailed.make(
                   Object.assign(
                     { message: error.message },
                     error.cause === undefined ? undefined : { cause: error.cause },
                   ),
                 ),
-              ),
+          ),
         ),
       );
       yield* log.info(`aborted ${job.value.action}; ${url}`, {
         location: Log.Locations.automation,
         agentId: payload.ticket,
       });
-      yield* automation.finish(job.value.id, "aborted", "aborted").pipe(
-        Effect.mapError((error) =>
-          Errors.Internal.make({ cause: error, agentId: payload.ticket }),
-        ),
-      );
+      yield* automation
+        .finish(job.value.id, "aborted", "aborted")
+        .pipe(
+          Effect.mapError((error) =>
+            Errors.Internal.make({ cause: error, agentId: payload.ticket }),
+          ),
+        );
       return ok;
     }),
   ),

--- a/src/automation-server/main.ts
+++ b/src/automation-server/main.ts
@@ -61,7 +61,8 @@ const ServerLive = (port: number) =>
 const DatabaseLive = Layer.unwrap(Effect.map(Config.databaseUrl, Client.Database.layer));
 
 // LINEAR_WEBHOOK_SECRET signs POST /linear; OLIGARCHY_TOKEN authenticates POST /run to a
-// client; DATABASE_URL holds the queue, the live-server list and the logs rows. Sentry sits
+// client and POST /abort from Cloudflare; DATABASE_URL holds the queue, the live-server
+// list and the logs rows. Sentry sits
 // beneath Log so Log captures the reporter. Lines land in logs with location/agentId
 // "automation"; durable jobs remain automation_jobs.
 const MainLive = Layer.mergeAll(

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -85,7 +85,7 @@ export const dispatch = Effect.fn("dispatch")(function* () {
       return;
     }
     yield* Effect.uninterruptibleMask((restore) =>
-      store.claim().pipe(
+      store.claim(url).pipe(
         Effect.flatMap((maybe) => {
           if (Option.isNone(maybe)) {
             return Effect.void;
@@ -100,9 +100,8 @@ export const dispatch = Effect.fn("dispatch")(function* () {
               Effect.gen(function* () {
                 const closed = yield* store.finish(job.id, outcome.status, outcome.reason);
                 if (!closed) {
-                  return yield* Effect.die(
-                    new Error(`finishAutomationJob: ${job.id} was not running`),
-                  );
+                  // abort may have closed the row first
+                  return;
                 }
                 return yield* logOutcome(job, outcome);
               }),

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -80,18 +80,18 @@ export const dispatch = Effect.fn("dispatch")(function* () {
 
   const tick = Effect.fn("tick")(function* () {
     const live = yield* servers.listLiveServers("automation-client");
-    const url = live[0];
-    if (url === undefined) {
+    const chosen = live[0];
+    if (chosen === undefined) {
       return;
     }
     yield* Effect.uninterruptibleMask((restore) =>
-      store.claim(url).pipe(
+      store.claim(chosen.id).pipe(
         Effect.flatMap((maybe) => {
           if (Option.isNone(maybe)) {
             return Effect.void;
           }
           const job = maybe.value;
-          return restore(execute(job, url)).pipe(
+          return restore(execute(job, chosen.url)).pipe(
             Effect.matchCause({
               onSuccess: (): Outcome => ({ status: "succeeded", reason: null }),
               onFailure: outcomeFrom,

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -99,11 +99,10 @@ export const dispatch = Effect.fn("dispatch")(function* () {
             Effect.flatMap((outcome) =>
               Effect.gen(function* () {
                 const closed = yield* store.finish(job.id, outcome.status, outcome.reason);
-                if (!closed) {
-                  // abort may have closed the row first
-                  return;
+                // abort may have closed the row first
+                if (closed) {
+                  yield* logOutcome(job, outcome);
                 }
-                return yield* logOutcome(job, outcome);
               }),
             ),
           );

--- a/src/db/automation.ts
+++ b/src/db/automation.ts
@@ -48,8 +48,9 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
       });
 
       // Oldest pending, locked for the transaction so a second claimer waits. Queue order is
-      // created_at; id breaks a tie. url is the client that took it: /abort reads it back.
-      const claim = Effect.fn("db.claimAutomationJob")(function* (url: string) {
+      // created_at; id breaks a tie. serverId is the client that took it: /abort looks that
+      // server up for its url.
+      const claim = Effect.fn("db.claimAutomationJob")(function* (serverId: string) {
         return yield* database.transaction("claimAutomationJob", (tx) =>
           Effect.gen(function* () {
             const pending = yield* Client.attempt("claimAutomationJob", () =>
@@ -68,7 +69,7 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
             const updated = yield* Client.attempt("claimAutomationJob", () =>
               tx
                 .update(DbSchema.automationJobs)
-                .set({ status: "running", startedAt: sql`now()`, clientUrl: url })
+                .set({ status: "running", startedAt: sql`now()`, serverId })
                 .where(eq(DbSchema.automationJobs.id, row.value.id))
                 .returning(),
             );

--- a/src/db/automation.ts
+++ b/src/db/automation.ts
@@ -48,8 +48,8 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
       });
 
       // Oldest pending, locked for the transaction so a second claimer waits. Queue order is
-      // created_at; id breaks a tie.
-      const claim = Effect.fn("db.claimAutomationJob")(function* () {
+      // created_at; id breaks a tie. url is the client that took it: /abort reads it back.
+      const claim = Effect.fn("db.claimAutomationJob")(function* (url: string) {
         return yield* database.transaction("claimAutomationJob", (tx) =>
           Effect.gen(function* () {
             const pending = yield* Client.attempt("claimAutomationJob", () =>
@@ -68,13 +68,29 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
             const updated = yield* Client.attempt("claimAutomationJob", () =>
               tx
                 .update(DbSchema.automationJobs)
-                .set({ status: "running", startedAt: sql`now()` })
+                .set({ status: "running", startedAt: sql`now()`, clientUrl: url })
                 .where(eq(DbSchema.automationJobs.id, row.value.id))
                 .returning(),
             );
             return Arr.head(updated);
           }),
         );
+      });
+
+      const findRunning = Effect.fn("db.findRunningAutomationJob")(function* (resultId: string) {
+        const rows = yield* database.run("findRunningAutomationJob", (db) =>
+          db
+            .select()
+            .from(DbSchema.automationJobs)
+            .where(
+              and(
+                eq(DbSchema.automationJobs.resultId, resultId),
+                eq(DbSchema.automationJobs.status, "running"),
+              ),
+            )
+            .limit(1),
+        );
+        return Arr.head(rows);
       });
 
       // Only a running row closes. reason is omitted when null so a previous value stays.
@@ -153,7 +169,7 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
         return { running, pending, completed };
       });
 
-      return { enqueue, claim, finish, listJobs };
+      return { enqueue, claim, findRunning, finish, listJobs };
     }),
   },
 ) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -205,8 +205,10 @@ export type ServerStats = {
 // claimed. type says what kind of server the row is, so a reverse proxy lists its own kind;
 // every writer names it, and the default is what the migration filled the rows that predate
 // the column with — qemu servers were the only kind there was. automation-client is the
-// other kind: same heartbeat, listed apart from the qemu fleet.
+// other kind: same heartbeat, listed apart from the qemu fleet. id is the stable handle a
+// job stores when it is claimed; url remains the key a heartbeat upserts on.
 export const servers = pgTable("servers", {
+  id: uuid("id").notNull().defaultRandom().unique(),
   url: text("url").primaryKey(),
   type: serverType("type").notNull().default("qemu"),
   stats: jsonb("stats").$type<ServerStats>(),
@@ -319,8 +321,9 @@ export const testResults = pgTable(
 // pending; a worker claims the oldest pending row, runs it, and closes with a terminal
 // status. (result_id, action) is unique — one drive and one diagnose per result for now.
 // Queue order is created_at among pending rows; capacity limits stay out of this table.
-// client_url is the automation-client that claimed the job, so /abort can find it after
-// a restart; null while the row is pending.
+// server_id is the servers.id that claimed the job, so /abort can find that client after
+// a restart; null while the row is pending. Attribution, not a relation: forgetting a
+// server must keep the job row.
 export const automationJobs = pgTable(
   "automation_jobs",
   {
@@ -331,7 +334,7 @@ export const automationJobs = pgTable(
     action: automationAction("action").notNull(),
     status: automationJobStatus("status").notNull().default("pending"),
     reason: text("reason"),
-    clientUrl: text("client_url"),
+    serverId: uuid("server_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     startedAt: timestamp("started_at", { withTimezone: true }),
     finishedAt: timestamp("finished_at", { withTimezone: true }),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -319,6 +319,8 @@ export const testResults = pgTable(
 // pending; a worker claims the oldest pending row, runs it, and closes with a terminal
 // status. (result_id, action) is unique — one drive and one diagnose per result for now.
 // Queue order is created_at among pending rows; capacity limits stay out of this table.
+// client_url is the automation-client that claimed the job, so /abort can find it after
+// a restart; null while the row is pending.
 export const automationJobs = pgTable(
   "automation_jobs",
   {
@@ -329,6 +331,7 @@ export const automationJobs = pgTable(
     action: automationAction("action").notNull(),
     status: automationJobStatus("status").notNull().default("pending"),
     reason: text("reason"),
+    clientUrl: text("client_url"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     startedAt: timestamp("started_at", { withTimezone: true }),
     finishedAt: timestamp("finished_at", { withTimezone: true }),

--- a/src/db/servers.ts
+++ b/src/db/servers.ts
@@ -6,6 +6,11 @@ import * as DbSchema from "./schema.ts";
 type ServerRow = typeof DbSchema.servers.$inferSelect;
 export type ServerType = ServerRow["type"];
 
+export type LiveServer = {
+  readonly id: string;
+  readonly url: string;
+};
+
 export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/ServerStore", {
   make: Effect.gen(function* () {
     const database = yield* Client.Database;
@@ -69,9 +74,9 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
     // Clients write every 30s; 45s is one missed beat plus a little. A null heartbeat is
     // an operator-added row no process has claimed, so it is not live.
     const listLiveServers = Effect.fn("db.listLiveServers")(function* (type: ServerType) {
-      const rows = yield* database.run("listLiveServers", (db) =>
+      return yield* database.run("listLiveServers", (db) =>
         db
-          .select({ url: DbSchema.servers.url })
+          .select({ id: DbSchema.servers.id, url: DbSchema.servers.url })
           .from(DbSchema.servers)
           .where(
             and(
@@ -81,7 +86,17 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
           )
           .orderBy(DbSchema.servers.createdAt, DbSchema.servers.url),
       );
-      return rows.map((row) => row.url);
+    });
+
+    const findServer = Effect.fn("db.findServer")(function* (id: string) {
+      const rows = yield* database.run("findServer", (db) =>
+        db
+          .select({ id: DbSchema.servers.id, url: DbSchema.servers.url })
+          .from(DbSchema.servers)
+          .where(eq(DbSchema.servers.id, id))
+          .limit(1),
+      );
+      return Arr.head(rows);
     });
 
     // A session is routed once; a second insert is the primary key's DatabaseError by design.
@@ -107,6 +122,7 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       removeServer,
       listServers,
       listLiveServers,
+      findServer,
       routeSession,
       serverForSession,
     };

--- a/src/qemu-server/middleware.ts
+++ b/src/qemu-server/middleware.ts
@@ -9,9 +9,11 @@ import * as Api from "../shared/api.ts";
 import * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 
-// Every qemu server and qemu reverse proxy route carries `Authorization: Bearer <OLIGARCHY_TOKEN>`; the
-// compare is exact, as it always was. The token comes in as a value: those servers read it from
-// ProxyConfig beside their database url. The automation server does not use this bearer.
+// Every qemu server, qemu reverse proxy, automation-client, and automation-server /abort
+// route carries `Authorization: Bearer <OLIGARCHY_TOKEN>`; the compare is exact, as it
+// always was. The token comes in as a value: qemu servers read it from ProxyConfig; the
+// automation server reads it from OligarchyToken. /linear does not use this bearer —
+// Linear signs the body.
 export const bearerAuth = (token: Redacted.Redacted): Layer.Layer<Api.BearerAuth> =>
   Layer.succeed(Api.BearerAuth)(
     Api.BearerAuth.of({

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -164,16 +164,14 @@ export class QemuReverseProxyApi extends HttpApi.make("OligarchyQemuReverseProxy
   .add(Servers) {}
 
 // The automation server: POST /linear is Linear's signed webhook. No oligarchy bearer —
-// Linear signs the body. The qemu server's own boundary suffices: this process neither forwards
-// nor places.
+// Linear signs the body. POST /abort is ours and takes the bearer. The qemu server's own
+// boundary suffices: this process neither forwards nor places.
 export const linear = HttpApiEndpoint.post("linear", "/linear", {
   success: Contract.Ok,
   error: Errors.UnauthorizedWire,
 });
 
 export class Linear extends HttpApiGroup.make("Linear").add(linear).middleware(ApiBoundary) {}
-
-export class AutomationServerApi extends HttpApi.make("OligarchyAutomationServer").add(Linear) {}
 
 export const run = HttpApiEndpoint.post("run", "/run", {
   payload: Contract.RunBody,
@@ -186,6 +184,15 @@ export const abort = HttpApiEndpoint.post("abort", "/abort", {
   success: Contract.Ok,
   error: [Errors.UnknownSessionWire, Errors.RunFailedWire],
 });
+
+export class Abort extends HttpApiGroup.make("Abort")
+  .add(abort)
+  .middleware(BearerAuth)
+  .middleware(ApiBoundary) {}
+
+export class AutomationServerApi extends HttpApi.make("OligarchyAutomationServer")
+  .add(Linear)
+  .add(Abort) {}
 
 export class Runs extends HttpApiGroup.make("Runs")
   .add(run)

--- a/test/automation-client/heartbeat.unit.test.ts
+++ b/test/automation-client/heartbeat.unit.test.ts
@@ -53,7 +53,7 @@ describe("automation-client heartbeat happy path", () => {
         const store = Stores.fakeServerStore();
         const { log } = yield* start(store);
         expect(store.heartbeats).toEqual([ANNOUNCED]);
-        expect(store.servers).toEqual([REGISTERED]);
+        expect(store.servers).toEqual([expect.objectContaining(REGISTERED)]);
         yield* TestClock.adjust("29 seconds");
         expect(store.heartbeats).toHaveLength(1);
         yield* TestClock.adjust("1 second");
@@ -82,10 +82,14 @@ describe("automation-client heartbeat happy path", () => {
   it.effect("deletes its own row when the scope closes, and leaves every other server", () =>
     Effect.gen(function* () {
       const store = Stores.fakeServerStore();
-      const other = { url: "http://127.0.0.1:1", type: "qemu" as const };
+      const other = {
+        id: crypto.randomUUID(),
+        url: "http://127.0.0.1:1",
+        type: "qemu" as const,
+      };
       store.servers.push(other);
       const { scope, log } = yield* start(store);
-      expect(store.servers).toEqual([other, REGISTERED]);
+      expect(store.servers).toEqual([other, expect.objectContaining(REGISTERED)]);
       yield* Scope.close(scope, Exit.void);
       expect(store.servers).toEqual([other]);
       expect(log.lines).toEqual([]);
@@ -198,9 +202,9 @@ describe("automation-client heartbeat unhappy path", () => {
           removeServer: () => Effect.fail(refusedDelete),
         });
         const { scope, log } = yield* start(store);
-        expect(store.servers).toEqual([REGISTERED]);
+        expect(store.servers).toEqual([expect.objectContaining(REGISTERED)]);
         yield* Scope.close(scope, Exit.void);
-        expect(store.servers).toEqual([REGISTERED]);
+        expect(store.servers).toEqual([expect.objectContaining(REGISTERED)]);
         expect(log.lines).toEqual([
           {
             level: "error",

--- a/test/automation-server/client.unit.test.ts
+++ b/test/automation-server/client.unit.test.ts
@@ -18,6 +18,9 @@ const token = Layer.succeed(AutomationClient.OligarchyToken)(
 const run = (http: Layer.Layer<HttpClient.HttpClient>) =>
   AutomationClient.run(URL, PROMPT, TICKET).pipe(Effect.provide(Layer.mergeAll(token, http)));
 
+const abort = (http: Layer.Layer<HttpClient.HttpClient>) =>
+  AutomationClient.abort(URL, TICKET).pipe(Effect.provide(Layer.mergeAll(token, http)));
+
 describe("automation client POST /run happy path", () => {
   it.effect("posts the prompt with the bearer token and succeeds on 200", () =>
     Effect.gen(function* () {
@@ -78,6 +81,55 @@ describe("automation client POST /run has no timeout", () => {
       const fiber = yield* Effect.forkChild(run(FakeHttp.never));
       yield* TestClock.adjust("2 hours");
       expect(fiber.pollUnsafe()).toBeUndefined();
+    }),
+  );
+});
+
+describe("automation client POST /abort happy path", () => {
+  it.effect("posts the ticket with the bearer token and succeeds on 200", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      yield* abort(recorder.layer);
+      expect(recorder.requests).toHaveLength(1);
+      expect(recorder.requests[0]?.method).toBe("POST");
+      expect(recorder.requests[0]?.url).toBe(`${URL}/abort`);
+      expect(recorder.requests[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+      expect(JSON.parse(recorder.requests[0]?.body ?? "")).toEqual({ ticket: TICKET });
+    }),
+  );
+});
+
+describe("automation client POST /abort unhappy path", () => {
+  it.effect("a 404 is AutomationClientError with the body's error and status 404", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(() =>
+        FakeHttp.json({ error: `unknown session "${TICKET}"` }, 404),
+      );
+      const error = yield* Effect.flip(abort(recorder.layer));
+      expect(error).toMatchObject({
+        _tag: "AutomationClientError",
+        status: 404,
+        message: `automation client: POST ${URL}/abort failed: unknown session "${TICKET}"`,
+      });
+    }),
+  );
+
+  it.effect("an unreachable client has no status and carries the cause", () =>
+    Effect.gen(function* () {
+      const layer = FakeHttp.respondWith((request) =>
+        Effect.fail(
+          new HttpClientError.HttpClientError({
+            reason: new HttpClientError.TransportError({
+              request,
+              cause: new Error("connect ECONNREFUSED 127.0.0.1:55333"),
+            }),
+          }),
+        ),
+      );
+      const error = yield* Effect.flip(abort(layer));
+      expect(error._tag).toBe("AutomationClientError");
+      expect(error.status).toBeUndefined();
+      expect(error.message).toBe(`automation client: POST ${URL}/abort failed`);
     }),
   );
 });

--- a/test/automation-server/http.unit.test.ts
+++ b/test/automation-server/http.unit.test.ts
@@ -101,11 +101,17 @@ const seedResult = (
   return resultId;
 };
 
+const seedServer = (fixed: Fixture, url: string) => {
+  const id = crypto.randomUUID();
+  fixed.stores.servers.servers.push({ id, url, type: "automation-client" });
+  return id;
+};
+
 const seedJob = (
   fixed: Fixture,
   resultId: string,
   status: "pending" | "running" | "succeeded" | "failed" | "aborted" = "pending",
-  clientUrl: string | null = null,
+  serverId: string | null = null,
 ) => {
   fixed.stores.automation.jobs.push({
     id: `00000000-0000-4000-8000-${String(fixed.stores.automation.jobs.length + 1).padStart(12, "0")}`,
@@ -113,7 +119,7 @@ const seedJob = (
     action: "drive",
     status,
     reason: null,
-    clientUrl,
+    serverId,
     createdAt: new Date(),
     startedAt: status === "pending" ? null : new Date(),
     finishedAt: status === "pending" || status === "running" ? null : new Date(),
@@ -340,7 +346,7 @@ describe("POST /abort", () => {
       const outbound = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
       const fixed = fixture();
       seedResult(fixed, TICKET, RESULT);
-      seedJob(fixed, RESULT, "running", CLIENT_URL);
+      seedJob(fixed, RESULT, "running", seedServer(fixed, CLIENT_URL));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
         const response = yield* abort(http);
@@ -369,9 +375,9 @@ describe("POST /abort", () => {
       const outbound = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
       const fixed = fixture();
       seedResult(fixed, TICKET, RESULT);
-      seedJob(fixed, RESULT, "running", CLIENT_URL);
+      seedJob(fixed, RESULT, "running", seedServer(fixed, CLIENT_URL));
       seedResult(fixed, OTHER_TICKET, OTHER_RESULT);
-      seedJob(fixed, OTHER_RESULT, "running", OTHER_URL);
+      seedJob(fixed, OTHER_RESULT, "running", seedServer(fixed, OTHER_URL));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
         const response = yield* abort(http, TICKET);
@@ -389,7 +395,7 @@ describe("POST /abort refusals", () => {
     Effect.gen(function* () {
       const fixed = fixture();
       seedResult(fixed, TICKET, RESULT);
-      seedJob(fixed, RESULT, "succeeded", CLIENT_URL);
+      seedJob(fixed, RESULT, "succeeded", seedServer(fixed, CLIENT_URL));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
         const response = yield* abort(http);
@@ -505,7 +511,7 @@ describe("POST /abort refusals", () => {
       );
       const fixed = fixture();
       seedResult(fixed, TICKET, RESULT);
-      seedJob(fixed, RESULT, "running", CLIENT_URL);
+      seedJob(fixed, RESULT, "running", seedServer(fixed, CLIENT_URL));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
         const response = yield* abort(http);
@@ -520,6 +526,24 @@ describe("POST /abort refusals", () => {
     }),
   );
 
+  it.effect("500 when the server that claimed the job is gone", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      seedResult(fixed, TICKET, RESULT);
+      seedJob(fixed, RESULT, "running", crypto.randomUUID());
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http);
+        expect(response.status).toBe(500);
+        const body = yield* response.json;
+        expect(body).toEqual(
+          expect.objectContaining({ error: expect.stringContaining("unknown server") }),
+        );
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.stores.automation.jobs[0]?.status).toBe("running");
+    }),
+  );
+
   it.effect("500 when the client fails, and the job stays running", () =>
     Effect.gen(function* () {
       const outbound = FakeHttp.recordRequests(() =>
@@ -527,7 +551,7 @@ describe("POST /abort refusals", () => {
       );
       const fixed = fixture();
       seedResult(fixed, TICKET, RESULT);
-      seedJob(fixed, RESULT, "running", CLIENT_URL);
+      seedJob(fixed, RESULT, "running", seedServer(fixed, CLIENT_URL));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
         const response = yield* abort(http);

--- a/test/automation-server/http.unit.test.ts
+++ b/test/automation-server/http.unit.test.ts
@@ -4,13 +4,22 @@ import { it } from "@effect/vitest";
 import { Effect, Layer, Redacted } from "effect";
 import { HttpBody, HttpClient, HttpRouter } from "effect/unstable/http";
 import { NodeHttpServer } from "@effect/platform-node";
+import * as AutomationClient from "../../src/automation-server/client.ts";
 import * as Handlers from "../../src/automation-server/handlers.ts";
 import * as Log from "../../src/observability/log.ts";
+import * as FakeHttp from "../support/fake-http.ts";
 import * as FakeLog from "../support/log.ts";
 import * as Reporter from "../support/reporter.ts";
 import * as Stores from "../support/stores.ts";
 
 const WEBHOOK_SECRET = "whsec_test";
+const TOKEN = "test-token";
+const CLIENT_URL = "http://127.0.0.1:55333";
+const OTHER_URL = "http://127.0.0.1:55334";
+const TICKET = "OLI-42";
+const OTHER_TICKET = "OLI-99";
+const RESULT = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+const OTHER_RESULT = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff";
 
 const SecretLive = Layer.succeed(Handlers.LinearWebhookSecret)(
   Handlers.LinearWebhookSecret.of(Redacted.make(WEBHOOK_SECRET)),
@@ -28,13 +37,43 @@ const fixture = (): Fixture => ({
   reporter: Reporter.collect(),
 });
 
-const serve = (fixed: Fixture) =>
+const TokenLive = Layer.succeed(AutomationClient.OligarchyToken)(
+  AutomationClient.OligarchyToken.of(Redacted.make(TOKEN)),
+);
+
+const serve = (
+  fixed: Fixture,
+  outbound: Layer.Layer<HttpClient.HttpClient> = FakeHttp.die,
+) =>
   HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
-    Layer.provide(Layer.mergeAll(fixed.stores.layer, fixed.log.layer, SecretLive)),
+    Layer.provide(
+      Layer.mergeAll(
+        fixed.stores.layer,
+        fixed.log.layer,
+        SecretLive,
+        TokenLive,
+        outbound,
+      ),
+    ),
     Layer.provide(Layer.succeed(Log.ProcessAttribution)(Log.AutomationProcessAttribution)),
     Layer.provideMerge(NodeHttpServer.layerTest),
     Layer.provideMerge(fixed.reporter.layer),
   );
+
+const abortHeaders = {
+  authorization: `Bearer ${TOKEN}`,
+  "content-type": "application/json",
+};
+
+const abort = (
+  http: HttpClient.HttpClient,
+  ticket = TICKET,
+  headers: Record<string, string> = abortHeaders,
+) =>
+  http.post("/abort", {
+    headers,
+    body: HttpBody.text(JSON.stringify({ ticket }), "application/json"),
+  });
 
 const sign = (payload: string | Uint8Array): string =>
   createHmac("sha256", WEBHOOK_SECRET).update(payload).digest("hex");
@@ -69,6 +108,25 @@ const seedResult = (
     finishedAt: null,
   });
   return resultId;
+};
+
+const seedJob = (
+  fixed: Fixture,
+  resultId: string,
+  status: "pending" | "running" | "succeeded" | "failed" | "aborted" = "pending",
+  clientUrl: string | null = null,
+) => {
+  fixed.stores.automation.jobs.push({
+    id: `00000000-0000-4000-8000-${String(fixed.stores.automation.jobs.length + 1).padStart(12, "0")}`,
+    resultId,
+    action: "drive",
+    status,
+    reason: null,
+    clientUrl,
+    createdAt: new Date(),
+    startedAt: status === "pending" ? null : new Date(),
+    finishedAt: status === "pending" || status === "running" ? null : new Date(),
+  });
 };
 
 const issueBody = (state: string, extras: Record<string, unknown> = {}) =>
@@ -282,5 +340,212 @@ describe("POST /linear refusals", () => {
         expect(fixed.stores.automation.jobs).toEqual([]);
         expect(fixed.log.lines).toEqual([]);
       }),
+  );
+});
+
+describe("POST /abort", () => {
+  it.effect("aborts a running job at the client that claimed it", () =>
+    Effect.gen(function* () {
+      const outbound = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      const fixed = fixture();
+      seedResult(fixed, TICKET, RESULT);
+      seedJob(fixed, RESULT, "running", CLIENT_URL);
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http);
+        expect(response.status).toBe(200);
+        expect(yield* response.json).toEqual({ ok: "true" });
+      }).pipe(Effect.provide(serve(fixed, outbound.layer)));
+      expect(outbound.requests).toEqual([
+        expect.objectContaining({
+          method: "POST",
+          url: `${CLIENT_URL}/abort`,
+        }),
+      ]);
+      expect(JSON.parse(outbound.requests[0]?.body ?? "")).toEqual({ ticket: TICKET });
+      expect(fixed.stores.automation.jobs[0]).toMatchObject({
+        status: "aborted",
+        reason: "aborted",
+        finishedAt: expect.any(Date),
+      });
+      expect(FakeLog.texts(fixed.log)).toEqual([`aborted drive; ${CLIENT_URL}`]);
+      expect(fixed.log.lines[0]?.agentId).toBe(TICKET);
+    }),
+  );
+
+  it.effect("routes abort to the client that claimed that ticket", () =>
+    Effect.gen(function* () {
+      const outbound = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      const fixed = fixture();
+      seedResult(fixed, TICKET, RESULT);
+      seedJob(fixed, RESULT, "running", CLIENT_URL);
+      seedResult(fixed, OTHER_TICKET, OTHER_RESULT);
+      seedJob(fixed, OTHER_RESULT, "running", OTHER_URL);
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http, TICKET);
+        expect(response.status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed, outbound.layer)));
+      expect(outbound.requests.map((request) => request.url)).toEqual([`${CLIENT_URL}/abort`]);
+      expect(fixed.stores.automation.jobs[0]?.status).toBe("aborted");
+      expect(fixed.stores.automation.jobs[1]?.status).toBe("running");
+    }),
+  );
+});
+
+describe("POST /abort refusals", () => {
+  it.effect("400 when the ticket already finished, and the client is not called", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      seedResult(fixed, TICKET, RESULT);
+      seedJob(fixed, RESULT, "succeeded", CLIENT_URL);
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http);
+        expect(response.status).toBe(400);
+        expect(yield* response.json).toEqual({
+          error: `ticket "${TICKET}" is not running`,
+        });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.stores.automation.jobs[0]?.status).toBe("succeeded");
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: `POST /abort failed: ticket "${TICKET}" is not running`,
+          location: "automation",
+          agentId: TICKET,
+          skipSentry: true,
+          cause: undefined,
+        },
+      ]);
+    }),
+  );
+
+  it.effect("400 when the ticket is still pending, and the client is not called", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      seedResult(fixed, TICKET, RESULT);
+      seedJob(fixed, RESULT, "pending", null);
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http);
+        expect(response.status).toBe(400);
+        expect(yield* response.json).toEqual({
+          error: `ticket "${TICKET}" is not running`,
+        });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.stores.automation.jobs[0]?.status).toBe("pending");
+    }),
+  );
+
+  it.effect("400 when the ticket is unknown, and the client is not called", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http);
+        expect(response.status).toBe(400);
+        expect(yield* response.json).toEqual({
+          error: `ticket "${TICKET}" is not running`,
+        });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.stores.automation.jobs).toEqual([]);
+    }),
+  );
+
+  it.effect("refuses a missing bearer with 401 and one error line", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http, TICKET, { "content-type": "application/json" });
+        expect(response.status).toBe(401);
+        expect(yield* response.json).toEqual({ error: "unauthorized" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /abort failed: unauthorized",
+          location: "automation",
+          agentId: "automation",
+          skipSentry: true,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
+  it.effect("a wrong bearer is 401 too", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http, TICKET, {
+          authorization: "Bearer wrong",
+          "content-type": "application/json",
+        });
+        expect(response.status).toBe(401);
+        expect(yield* response.json).toEqual({ error: "unauthorized" });
+      }).pipe(Effect.provide(serve(fixed)));
+    }),
+  );
+
+  it.effect("a body without ticket is 400", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* http.post("/abort", {
+          headers: abortHeaders,
+          body: HttpBody.text("{}", "application/json"),
+        });
+        expect(response.status).toBe(400);
+        const body = yield* response.json;
+        expect(body).toEqual(expect.objectContaining({ error: expect.stringContaining("ticket") }));
+      }).pipe(Effect.provide(serve(fixed)));
+    }),
+  );
+
+  it.effect("404 when the client does not know the session, and the job stays running", () =>
+    Effect.gen(function* () {
+      const outbound = FakeHttp.recordRequests(() =>
+        FakeHttp.json({ error: `unknown session "${TICKET}"` }, 404),
+      );
+      const fixed = fixture();
+      seedResult(fixed, TICKET, RESULT);
+      seedJob(fixed, RESULT, "running", CLIENT_URL);
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http);
+        expect(response.status).toBe(404);
+        expect(yield* response.json).toEqual({
+          error: `unknown session "${TICKET}"`,
+        });
+      }).pipe(Effect.provide(serve(fixed, outbound.layer)));
+      expect(outbound.requests).toHaveLength(1);
+      expect(fixed.stores.automation.jobs[0]?.status).toBe("running");
+      expect(fixed.stores.automation.jobs[0]?.finishedAt).toBeNull();
+    }),
+  );
+
+  it.effect("500 when the client fails, and the job stays running", () =>
+    Effect.gen(function* () {
+      const outbound = FakeHttp.recordRequests(() =>
+        FakeHttp.json({ error: "opencode exited 1" }, 500),
+      );
+      const fixed = fixture();
+      seedResult(fixed, TICKET, RESULT);
+      seedJob(fixed, RESULT, "running", CLIENT_URL);
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* abort(http);
+        expect(response.status).toBe(500);
+        expect(yield* response.json).toEqual({
+          error: `automation client: POST ${CLIENT_URL}/abort failed: opencode exited 1`,
+        });
+      }).pipe(Effect.provide(serve(fixed, outbound.layer)));
+      expect(fixed.stores.automation.jobs[0]?.status).toBe("running");
+    }),
   );
 });

--- a/test/automation-server/http.unit.test.ts
+++ b/test/automation-server/http.unit.test.ts
@@ -41,19 +41,10 @@ const TokenLive = Layer.succeed(AutomationClient.OligarchyToken)(
   AutomationClient.OligarchyToken.of(Redacted.make(TOKEN)),
 );
 
-const serve = (
-  fixed: Fixture,
-  outbound: Layer.Layer<HttpClient.HttpClient> = FakeHttp.die,
-) =>
+const serve = (fixed: Fixture, outbound: Layer.Layer<HttpClient.HttpClient> = FakeHttp.die) =>
   HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
     Layer.provide(
-      Layer.mergeAll(
-        fixed.stores.layer,
-        fixed.log.layer,
-        SecretLive,
-        TokenLive,
-        outbound,
-      ),
+      Layer.mergeAll(fixed.stores.layer, fixed.log.layer, SecretLive, TokenLive, outbound),
     ),
     Layer.provide(Layer.succeed(Log.ProcessAttribution)(Log.AutomationProcessAttribution)),
     Layer.provideMerge(NodeHttpServer.layerTest),

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -68,7 +68,7 @@ const seedJob = (
     action,
     status: "pending",
     reason: null,
-    clientUrl: null,
+    serverId: null,
     createdAt: new Date(),
     startedAt: null,
     finishedAt: null,
@@ -76,8 +76,10 @@ const seedJob = (
 };
 
 const seedLiveClient = (servers: Stores.FakeServerStore, url = URL) => {
-  servers.servers.push({ url, type: "automation-client" });
+  const id = crypto.randomUUID();
+  servers.servers.push({ id, url, type: "automation-client" });
   servers.heartbeats.push({ url, type: "automation-client", stats: STATS });
+  return id;
 };
 
 type Harness = {
@@ -136,7 +138,7 @@ describe("dispatch happy path", () => {
       const fixed = harness();
       seedResult(fixed.tests);
       seedJob(fixed.automation);
-      seedLiveClient(fixed.servers);
+      const clientId = seedLiveClient(fixed.servers);
       const started = yield* Deferred.make<void>();
       const release = yield* Deferred.make<void>();
       const http = FakeHttp.recordRequests(() =>
@@ -149,7 +151,7 @@ describe("dispatch happy path", () => {
       yield* start(fixed, http.layer);
       yield* Deferred.await(started);
       expect(fixed.automation.jobs[0]?.status).toBe("running");
-      expect(fixed.automation.jobs[0]?.clientUrl).toBe(URL);
+      expect(fixed.automation.jobs[0]?.serverId).toBe(clientId);
       expect(http.requests).toHaveLength(1);
       yield* Deferred.succeed(release, undefined);
       yield* settle(fixed.automation.jobs, "succeeded");
@@ -311,7 +313,7 @@ describe("dispatch unhappy path", () => {
       const fixed = harness();
       seedResult(fixed.tests);
       seedJob(fixed.automation);
-      fixed.servers.servers.push({ url: URL, type: "qemu" });
+      fixed.servers.servers.push({ id: crypto.randomUUID(), url: URL, type: "qemu" });
       fixed.servers.heartbeats.push({ url: URL, type: "qemu", stats: STATS });
       yield* start(fixed, FakeHttp.die);
       yield* Effect.yieldNow;
@@ -406,7 +408,7 @@ describe("dispatch unhappy path", () => {
       yield* Deferred.await(started);
       const job = fixed.automation.jobs[0];
       expect(job?.status).toBe("running");
-      expect(job?.clientUrl).toBe(URL);
+      expect(job?.serverId).not.toBeNull();
       if (job !== undefined) {
         job.status = "aborted";
         job.reason = "aborted";

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -68,6 +68,7 @@ const seedJob = (
     action,
     status: "pending",
     reason: null,
+    clientUrl: null,
     createdAt: new Date(),
     startedAt: null,
     finishedAt: null,
@@ -148,6 +149,7 @@ describe("dispatch happy path", () => {
       yield* start(fixed, http.layer);
       yield* Deferred.await(started);
       expect(fixed.automation.jobs[0]?.status).toBe("running");
+      expect(fixed.automation.jobs[0]?.clientUrl).toBe(URL);
       expect(http.requests).toHaveLength(1);
       yield* Deferred.succeed(release, undefined);
       yield* settle(fixed.automation.jobs, "succeeded");
@@ -382,6 +384,43 @@ describe("dispatch unhappy path", () => {
         reason: "no Linear ticket",
       });
       expect(FakeLog.texts(fixed.log)).toEqual(["drive failed; no Linear ticket"]);
+    }),
+  );
+
+  it.effect("a job already closed by abort does not die when dispatch finishes", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      seedLiveClient(fixed.servers);
+      const started = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      const http = FakeHttp.recordRequests(() =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(started, undefined);
+          yield* Deferred.await(release);
+          return FakeHttp.json({ ok: "true" });
+        }),
+      );
+      yield* start(fixed, http.layer);
+      yield* Deferred.await(started);
+      const job = fixed.automation.jobs[0];
+      expect(job?.status).toBe("running");
+      expect(job?.clientUrl).toBe(URL);
+      if (job !== undefined) {
+        job.status = "aborted";
+        job.reason = "aborted";
+        job.finishedAt = new Date();
+      }
+      yield* Deferred.succeed(release, undefined);
+      for (let i = 0; i < 100; i++) {
+        yield* Effect.yieldNow;
+      }
+      expect(fixed.automation.jobs[0]?.status).toBe("aborted");
+      expect(fixed.automation.jobs[0]?.reason).toBe("aborted");
+      expect(FakeLog.texts(fixed.log).some((text) => text.includes("dispatch tick failed"))).toBe(
+        false,
+      );
     }),
   );
 });

--- a/test/ctrl/command.unit.test.ts
+++ b/test/ctrl/command.unit.test.ts
@@ -1251,6 +1251,7 @@ const listedJob = (
   action: fields.action,
   status: fields.status,
   reason: fields.reason ?? null,
+  clientUrl: fields.clientUrl ?? null,
   createdAt: fields.createdAt ?? ago(90),
   startedAt: fields.startedAt ?? (fields.status === "pending" ? null : ago(5)),
   finishedAt:

--- a/test/ctrl/command.unit.test.ts
+++ b/test/ctrl/command.unit.test.ts
@@ -1251,7 +1251,7 @@ const listedJob = (
   action: fields.action,
   status: fields.status,
   reason: fields.reason ?? null,
-  clientUrl: fields.clientUrl ?? null,
+  serverId: fields.serverId ?? null,
   createdAt: fields.createdAt ?? ago(90),
   startedAt: fields.startedAt ?? (fields.status === "pending" ? null : ago(5)),
   finishedAt:

--- a/test/integration/automation-server.integration.test.ts
+++ b/test/integration/automation-server.integration.test.ts
@@ -605,3 +605,136 @@ describeServing("automation server dispatch", () => {
     }),
   );
 });
+
+describeServing("automation server abort", () => {
+  it.live("aborts a running job at the client that claimed it", () =>
+    Effect.promise(async () => {
+      const seen: Array<string> = [];
+      const client = await serveClient((req, res) => {
+        seen.push(`${req.method} ${req.url ?? ""}`);
+        if (req.url === "/abort") {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ ok: "true" }));
+          return;
+        }
+      });
+      const linearId = `OLI-${randomUUID().slice(0, 8)}`;
+      const resultId = await seedResult(linearId);
+      await seedJob(resultId, "drive");
+      await seedLiveClient(client.url);
+      const port = await freePort();
+      const process = spawnAutomationServer(["--port", String(port)]);
+      try {
+        await process.waitFor(/automation server listening/);
+        await waitForJob(resultId, "running");
+        const response = await request(
+          port,
+          "POST",
+          "/abort",
+          { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
+          JSON.stringify({ ticket: linearId }),
+        );
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({ ok: "true" });
+        const job = await waitForJob(resultId, "aborted");
+        expect(job).toMatchObject({
+          status: "aborted",
+          reason: "aborted",
+          clientUrl: client.url,
+        });
+        expect(seen).toContain("POST /abort");
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+        await removeServer(client.url);
+        await client.close();
+      }
+    }),
+  );
+
+  it.live("400 when the ticket is not running", () =>
+    Effect.promise(async () => {
+      const port = await freePort();
+      const process = spawnAutomationServer(["--port", String(port)]);
+      try {
+        await process.waitFor(/automation server listening/);
+        const response = await request(
+          port,
+          "POST",
+          "/abort",
+          { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
+          JSON.stringify({ ticket: "OLI-missing" }),
+        );
+        expect(response.status).toBe(400);
+        expect(await response.json()).toEqual({
+          error: 'ticket "OLI-missing" is not running',
+        });
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+      }
+    }),
+  );
+
+  it.live("404 when the client does not know the session, and the job stays running", () =>
+    Effect.promise(async () => {
+      const client = await serveClient((req, res) => {
+        if (req.url === "/abort") {
+          res.writeHead(404, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: 'unknown session "OLI-x"' }));
+          return;
+        }
+      });
+      const linearId = `OLI-${randomUUID().slice(0, 8)}`;
+      const resultId = await seedResult(linearId);
+      await seedJob(resultId, "drive");
+      await seedLiveClient(client.url);
+      const port = await freePort();
+      const process = spawnAutomationServer(["--port", String(port)]);
+      try {
+        await process.waitFor(/automation server listening/);
+        await waitForJob(resultId, "running");
+        const response = await request(
+          port,
+          "POST",
+          "/abort",
+          { "content-type": "application/json", authorization: `Bearer ${TOKEN}` },
+          JSON.stringify({ ticket: linearId }),
+        );
+        expect(response.status).toBe(404);
+        expect(await response.json()).toEqual({
+          error: `unknown session "${linearId}"`,
+        });
+        const jobs = await jobsFor(resultId);
+        expect(jobs).toEqual([expect.objectContaining({ status: "running" })]);
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+        await removeServer(client.url);
+        await client.close();
+      }
+    }),
+  );
+
+  it.live("401 without a bearer", () =>
+    Effect.promise(async () => {
+      const port = await freePort();
+      const process = spawnAutomationServer(["--port", String(port)]);
+      try {
+        await process.waitFor(/automation server listening/);
+        const response = await request(
+          port,
+          "POST",
+          "/abort",
+          { "content-type": "application/json" },
+          JSON.stringify({ ticket: "OLI-1" }),
+        );
+        expect(response.status).toBe(401);
+        expect(await response.json()).toEqual({ error: "unauthorized" });
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+      }
+    }),
+  );
+});

--- a/test/integration/automation-server.integration.test.ts
+++ b/test/integration/automation-server.integration.test.ts
@@ -640,8 +640,8 @@ describeServing("automation server abort", () => {
         expect(job).toMatchObject({
           status: "aborted",
           reason: "aborted",
-          clientUrl: client.url,
         });
+        expect(job.serverId).toEqual(expect.any(String));
         expect(seen).toContain("POST /abort");
       } finally {
         process.child.kill("SIGTERM");

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -1123,21 +1123,26 @@ Postgres.describeWithDatabase("database", () => {
           resultId: second.results[0].id,
           action: "drive",
         });
-        const claimed = yield* automation.claim();
+        const firstUrl = "http://127.0.0.1:55333";
+        const secondUrl = "http://127.0.0.1:55334";
+        expect(yield* automation.findRunning(older.resultId)).toEqual(Option.none());
+        const claimed = yield* automation.claim(firstUrl);
         expect(Option.isSome(claimed)).toBe(true);
         if (Option.isSome(claimed)) {
           expect(claimed.value).toMatchObject({
             id: older.id,
             status: "running",
+            clientUrl: firstUrl,
           });
           expect(claimed.value.startedAt).toBeInstanceOf(Date);
         }
-        const next = yield* automation.claim();
+        expect(yield* automation.findRunning(older.resultId)).toEqual(claimed);
+        const next = yield* automation.claim(secondUrl);
         expect(Option.isSome(next)).toBe(true);
         if (Option.isSome(next)) {
-          expect(next.value.id).toBe(newer.id);
+          expect(next.value).toMatchObject({ id: newer.id, clientUrl: secondUrl });
         }
-        expect(yield* automation.claim()).toEqual(Option.none());
+        expect(yield* automation.claim("http://127.0.0.1:9")).toEqual(Option.none());
       }),
     );
 
@@ -1156,9 +1161,11 @@ Postgres.describeWithDatabase("database", () => {
           resultId: created.results[0].id,
           action: "drive",
         });
-        const claimed = yield* automation.claim();
+        const claimed = yield* automation.claim("http://127.0.0.1:55333");
         expect(Option.isSome(claimed)).toBe(true);
+        expect(yield* automation.findRunning(created.results[0].id)).toEqual(claimed);
         expect(yield* automation.finish(enqueued.id, "succeeded", null)).toBe(true);
+        expect(yield* automation.findRunning(created.results[0].id)).toEqual(Option.none());
         const [row] = yield* database.run("select", (db) =>
           db
             .select()

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -1219,8 +1219,8 @@ Postgres.describeWithDatabase("database", () => {
           yield* automation.enqueue({ resultId: resultIds[3], action: "diagnose" });
           yield* automation.enqueue({ resultId: resultIds[4], action: "drive" });
           yield* automation.enqueue({ resultId: resultIds[5], action: "diagnose" });
-          expect(Option.isSome(yield* automation.claim())).toBe(true);
-          expect(Option.isSome(yield* automation.claim())).toBe(true);
+          expect(Option.isSome(yield* automation.claim("http://127.0.0.1:55333"))).toBe(true);
+          expect(Option.isSome(yield* automation.claim("http://127.0.0.1:55334"))).toBe(true);
           yield* automation.finish(completedDrive.id, "succeeded", null);
           yield* automation.finish(completedDiagnose.id, "failed", "nope");
           yield* database.run("stamp", (db) =>
@@ -1228,8 +1228,8 @@ Postgres.describeWithDatabase("database", () => {
               sql`update automation_jobs set finished_at = now() - interval '2 minutes' where id = ${completedDrive.id}`,
             ),
           );
-          expect(Option.isSome(yield* automation.claim())).toBe(true);
-          expect(Option.isSome(yield* automation.claim())).toBe(true);
+          expect(Option.isSome(yield* automation.claim("http://127.0.0.1:55335"))).toBe(true);
+          expect(Option.isSome(yield* automation.claim("http://127.0.0.1:55336"))).toBe(true);
           const listed = yield* automation.listJobs(1);
           expect(listed.running.map((job) => [job.ticket, job.action, job.status])).toEqual([
             ["LST-104", "diagnose", "running"],

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -1123,26 +1123,26 @@ Postgres.describeWithDatabase("database", () => {
           resultId: second.results[0].id,
           action: "drive",
         });
-        const firstUrl = "http://127.0.0.1:55333";
-        const secondUrl = "http://127.0.0.1:55334";
+        const firstServer = crypto.randomUUID();
+        const secondServer = crypto.randomUUID();
         expect(yield* automation.findRunning(older.resultId)).toEqual(Option.none());
-        const claimed = yield* automation.claim(firstUrl);
+        const claimed = yield* automation.claim(firstServer);
         expect(Option.isSome(claimed)).toBe(true);
         if (Option.isSome(claimed)) {
           expect(claimed.value).toMatchObject({
             id: older.id,
             status: "running",
-            clientUrl: firstUrl,
+            serverId: firstServer,
           });
           expect(claimed.value.startedAt).toBeInstanceOf(Date);
         }
         expect(yield* automation.findRunning(older.resultId)).toEqual(claimed);
-        const next = yield* automation.claim(secondUrl);
+        const next = yield* automation.claim(secondServer);
         expect(Option.isSome(next)).toBe(true);
         if (Option.isSome(next)) {
-          expect(next.value).toMatchObject({ id: newer.id, clientUrl: secondUrl });
+          expect(next.value).toMatchObject({ id: newer.id, serverId: secondServer });
         }
-        expect(yield* automation.claim("http://127.0.0.1:9")).toEqual(Option.none());
+        expect(yield* automation.claim(crypto.randomUUID())).toEqual(Option.none());
       }),
     );
 
@@ -1161,7 +1161,7 @@ Postgres.describeWithDatabase("database", () => {
           resultId: created.results[0].id,
           action: "drive",
         });
-        const claimed = yield* automation.claim("http://127.0.0.1:55333");
+        const claimed = yield* automation.claim(crypto.randomUUID());
         expect(Option.isSome(claimed)).toBe(true);
         expect(yield* automation.findRunning(created.results[0].id)).toEqual(claimed);
         expect(yield* automation.finish(enqueued.id, "succeeded", null)).toBe(true);
@@ -1219,8 +1219,8 @@ Postgres.describeWithDatabase("database", () => {
           yield* automation.enqueue({ resultId: resultIds[3], action: "diagnose" });
           yield* automation.enqueue({ resultId: resultIds[4], action: "drive" });
           yield* automation.enqueue({ resultId: resultIds[5], action: "diagnose" });
-          expect(Option.isSome(yield* automation.claim("http://127.0.0.1:55333"))).toBe(true);
-          expect(Option.isSome(yield* automation.claim("http://127.0.0.1:55334"))).toBe(true);
+          expect(Option.isSome(yield* automation.claim(crypto.randomUUID()))).toBe(true);
+          expect(Option.isSome(yield* automation.claim(crypto.randomUUID()))).toBe(true);
           yield* automation.finish(completedDrive.id, "succeeded", null);
           yield* automation.finish(completedDiagnose.id, "failed", "nope");
           yield* database.run("stamp", (db) =>
@@ -1228,8 +1228,8 @@ Postgres.describeWithDatabase("database", () => {
               sql`update automation_jobs set finished_at = now() - interval '2 minutes' where id = ${completedDrive.id}`,
             ),
           );
-          expect(Option.isSome(yield* automation.claim("http://127.0.0.1:55335"))).toBe(true);
-          expect(Option.isSome(yield* automation.claim("http://127.0.0.1:55336"))).toBe(true);
+          expect(Option.isSome(yield* automation.claim(crypto.randomUUID()))).toBe(true);
+          expect(Option.isSome(yield* automation.claim(crypto.randomUUID()))).toBe(true);
           const listed = yield* automation.listJobs(1);
           expect(listed.running.map((job) => [job.ticket, job.action, job.status])).toEqual([
             ["LST-104", "diagnose", "running"],
@@ -1471,10 +1471,10 @@ Postgres.describeWithDatabase("database", () => {
               .where(eq(DbSchema.servers.url, stale)),
           );
           const live = yield* store.listLiveServers("automation-client");
-          expect(live).toContain(fresh);
-          expect(live).not.toContain(stale);
-          expect(live).not.toContain(qemu);
-          expect(live).not.toContain(silent);
+          expect(live.map((server) => server.url)).toEqual([fresh]);
+          expect(live[0]?.id).toEqual(expect.any(String));
+          expect(yield* store.findServer(live[0]?.id ?? "")).toEqual(Option.some(live[0]));
+          expect(yield* store.findServer(crypto.randomUUID())).toEqual(Option.none());
           expect(yield* store.listServers("automation-client")).toEqual(
             expect.arrayContaining([fresh, stale, silent]),
           );

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -118,7 +118,7 @@ const decoder = new TextDecoder();
 const serverBody = (url: string) => Contract.ServerBody.make({ url });
 
 // A registered qemu server, as the fake store's rows carry it: what this reverse proxy fronts.
-const qemu = (url: string) => ({ url, type: "qemu" as const });
+const qemu = (url: string) => ({ id: crypto.randomUUID(), url, type: "qemu" as const });
 
 const upstreamCalls = (fixed: Fixture) =>
   fixed.upstream.requests.map((request) => `${request.method} ${request.url}`);
@@ -142,7 +142,9 @@ describe("server registration", () => {
             body: "",
           },
         ]);
-        expect(fixed.store.servers).toEqual([{ url: SERVER_A, type: "qemu" }]);
+        expect(fixed.store.servers).toEqual([
+          expect.objectContaining({ url: SERVER_A, type: "qemu" }),
+        ]);
         expect(fixed.log.lines).toEqual([
           {
             level: "info",
@@ -164,7 +166,9 @@ describe("server registration", () => {
         yield* api.Servers.register({ payload: serverBody(`${SERVER_A}/`) });
       }).pipe(Effect.provide(serve(fixed)));
       expect(upstreamCalls(fixed)).toEqual([`GET ${SERVER_A}/stats`]);
-      expect(fixed.store.servers).toEqual([qemu(`${SERVER_A}/`)]);
+      expect(fixed.store.servers).toEqual([
+        expect.objectContaining({ url: `${SERVER_A}/`, type: "qemu" }),
+      ]);
     }),
   );
 
@@ -177,7 +181,9 @@ describe("server registration", () => {
         yield* api.Servers.register({ payload: serverBody(SERVER_A) });
       }).pipe(Effect.provide(serve(fixed)));
       expect(upstreamCalls(fixed)).toEqual([`GET ${SERVER_A}/stats`, `GET ${SERVER_A}/stats`]);
-      expect(fixed.store.servers).toEqual([qemu(SERVER_A)]);
+      expect(fixed.store.servers).toEqual([
+        expect.objectContaining({ url: SERVER_A, type: "qemu" }),
+      ]);
       expect(FakeLog.texts(fixed.log)).toEqual([
         `server registered; ${SERVER_A}`,
         `server registered; ${SERVER_A}`,
@@ -194,7 +200,9 @@ describe("server registration", () => {
         const ok = yield* api.Servers.unregister({ payload: serverBody(SERVER_A) });
         expect(ok.ok).toBe("true");
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.store.servers).toEqual([qemu(SERVER_B)]);
+      expect(fixed.store.servers).toEqual([
+        expect.objectContaining({ url: SERVER_B, type: "qemu" }),
+      ]);
       expect(fixed.upstream.requests).toEqual([]);
       expect(fixed.log.lines).toEqual([
         {

--- a/test/qemu-server/heartbeat.unit.test.ts
+++ b/test/qemu-server/heartbeat.unit.test.ts
@@ -50,7 +50,7 @@ describe("heartbeat happy path", () => {
         const store = Stores.fakeServerStore();
         const { log } = yield* start(store);
         expect(store.heartbeats).toEqual([ANNOUNCED]);
-        expect(store.servers).toEqual([REGISTERED]);
+        expect(store.servers).toEqual([expect.objectContaining(REGISTERED)]);
         yield* TestClock.adjust("29 seconds");
         expect(store.heartbeats).toHaveLength(1);
         yield* TestClock.adjust("1 second");
@@ -79,10 +79,10 @@ describe("heartbeat happy path", () => {
   it.effect("deletes its own row when the scope closes, and leaves every other server", () =>
     Effect.gen(function* () {
       const store = Stores.fakeServerStore();
-      const other = { url: "http://127.0.0.1:1", type: "qemu" as const };
+      const other = { id: crypto.randomUUID(), url: "http://127.0.0.1:1", type: "qemu" as const };
       store.servers.push(other);
       const { scope, log } = yield* start(store);
-      expect(store.servers).toEqual([other, REGISTERED]);
+      expect(store.servers).toEqual([other, expect.objectContaining(REGISTERED)]);
       yield* Scope.close(scope, Exit.void);
       expect(store.servers).toEqual([other]);
       expect(log.lines).toEqual([]);
@@ -193,9 +193,9 @@ describe("heartbeat unhappy path", () => {
           removeServer: () => Effect.fail(refusedDelete),
         });
         const { scope, log } = yield* start(store);
-        expect(store.servers).toEqual([REGISTERED]);
+        expect(store.servers).toEqual([expect.objectContaining(REGISTERED)]);
         yield* Scope.close(scope, Exit.void);
-        expect(store.servers).toEqual([REGISTERED]);
+        expect(store.servers).toEqual([expect.objectContaining(REGISTERED)]);
         expect(log.lines).toEqual([
           {
             level: "error",

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -235,20 +235,25 @@ describe("QemuReverseProxyApi", () => {
 describe("AutomationServerApi", () => {
   const automation = Api.AutomationServerApi;
 
-  it("declares POST /linear and nothing else", () => {
+  it("declares POST /linear and POST /abort", () => {
     const table = routes(automation).map(({ method, path }) => `${method} ${path}`);
-    expect(table).toEqual(["POST /linear"]);
+    expect(table.sort()).toEqual(["POST /abort", "POST /linear"]);
     expect(HttpApiClient.urlBuilder(automation).Linear.linear()).toBe("/linear");
+    expect(HttpApiClient.urlBuilder(automation).Abort.abort()).toBe("/abort");
   });
 
-  it("applies ApiBoundary and no bearer", () => {
+  it("keeps /linear unsigned and requires the bearer on /abort", () => {
     const spec = OpenApi.fromApi(automation);
-    expect(spec.components.securitySchemes).toEqual({});
     const linear = byIdentifier(automation, "linear");
     expect(linear.group).toBe("Linear");
     expect(linear.middleware).toEqual([Api.ApiBoundary.key]);
     expect(spec.paths["/linear"]?.post?.security).toEqual([]);
     expect(linear.errors).toEqual([400, 401, 500]);
+    const abort = byIdentifier(automation, "abort");
+    expect(abort.group).toBe("Abort");
+    expect(abort.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);
+    expect(spec.paths["/abort"]?.post?.security).toEqual([{ bearer: [] }]);
+    expect(abort.errors).toEqual([400, 401, 404, 500]);
   });
 
   it("is its own api: neither the qemu server nor the qemu reverse proxy answers /linear", () => {
@@ -281,11 +286,12 @@ describe("AutomationClientApi", () => {
     expect(abort.errors).toEqual([400, 401, 404, 500]);
   });
 
-  it("is its own api: no other process answers /run or /abort", () => {
-    for (const path of ["/run", "/abort"]) {
-      expect(routes(Api.QemuServerApi).map(({ path: route }) => route)).not.toContain(path);
-      expect(routes(Api.QemuReverseProxyApi).map(({ path: route }) => route)).not.toContain(path);
-      expect(routes(Api.AutomationServerApi).map(({ path: route }) => route)).not.toContain(path);
-    }
+  it("is its own api: no other process answers /run; /abort is the client and the automation server", () => {
+    expect(routes(Api.QemuServerApi).map(({ path }) => path)).not.toContain("/run");
+    expect(routes(Api.QemuReverseProxyApi).map(({ path }) => path)).not.toContain("/run");
+    expect(routes(Api.AutomationServerApi).map(({ path }) => path)).not.toContain("/run");
+    expect(routes(Api.QemuServerApi).map(({ path }) => path)).not.toContain("/abort");
+    expect(routes(Api.QemuReverseProxyApi).map(({ path }) => path)).not.toContain("/abort");
+    expect(routes(Api.AutomationServerApi).map(({ path }) => path)).toContain("/abort");
   });
 });

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -544,6 +544,7 @@ export const fakeAutomationStore = (
           action: input.action,
           status: "pending",
           reason: null,
+          clientUrl: null,
           createdAt: new Date(),
           startedAt: null,
           finishedAt: null,
@@ -551,7 +552,7 @@ export const fakeAutomationStore = (
         jobs.push(row);
         return row;
       }),
-    claim: () =>
+    claim: (url) =>
       Effect.sync(() => {
         const pending = jobs
           .filter((job) => job.status === "pending")
@@ -566,8 +567,15 @@ export const fakeAutomationStore = (
         }
         job.status = "running";
         job.startedAt = new Date();
+        job.clientUrl = url;
         return Option.some(job);
       }),
+    findRunning: (resultId) =>
+      Effect.sync(() =>
+        Option.fromUndefinedOr(
+          jobs.find((job) => sameId(job.resultId, resultId) && job.status === "running"),
+        ),
+      ),
     finish: (id, status, reason) =>
       Effect.sync(() => {
         const job = jobs.find((row) => row.id === id && row.status === "running");

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -544,7 +544,7 @@ export const fakeAutomationStore = (
           action: input.action,
           status: "pending",
           reason: null,
-          clientUrl: null,
+          serverId: null,
           createdAt: new Date(),
           startedAt: null,
           finishedAt: null,
@@ -552,7 +552,7 @@ export const fakeAutomationStore = (
         jobs.push(row);
         return row;
       }),
-    claim: (url) =>
+    claim: (serverId) =>
       Effect.sync(() => {
         const pending = jobs
           .filter((job) => job.status === "pending")
@@ -567,7 +567,7 @@ export const fakeAutomationStore = (
         }
         job.status = "running";
         job.startedAt = new Date();
-        job.clientUrl = url;
+        job.serverId = serverId;
         return Option.some(job);
       }),
     findRunning: (resultId) =>
@@ -640,7 +640,11 @@ export const fakeAutomationStore = (
 // ServerStore
 // ---------------------------------------------------------------------------
 
-type RegisteredServer = { readonly url: string; readonly type: Servers.ServerType };
+type RegisteredServer = {
+  readonly id: string;
+  readonly url: string;
+  readonly type: Servers.ServerType;
+};
 type Heartbeat = {
   readonly url: string;
   readonly type: Servers.ServerType;
@@ -671,16 +675,19 @@ export const fakeServerStore = (
     addServer: (url, type) =>
       Effect.sync(() => {
         if (indexOf(url) === -1) {
-          servers.push({ url, type });
+          servers.push({ id: crypto.randomUUID(), url, type });
         }
       }),
     heartbeat: (url, type, stats) =>
       Effect.sync(() => {
         const index = indexOf(url);
         if (index === -1) {
-          servers.push({ url, type });
+          servers.push({ id: crypto.randomUUID(), url, type });
         } else {
-          servers[index] = { url, type };
+          const existing = servers[index];
+          if (existing !== undefined) {
+            servers[index] = { id: existing.id, url, type };
+          }
         }
         heartbeats.push({ url, type, stats });
       }),
@@ -704,7 +711,14 @@ export const fakeServerStore = (
           .filter(
             (server) => server.type === type && heartbeats.some((beat) => beat.url === server.url),
           )
-          .map((server) => server.url),
+          .map((server) => ({ id: server.id, url: server.url })),
+      ),
+    findServer: (id) =>
+      Effect.sync(() =>
+        Option.map(
+          Option.fromUndefinedOr(servers.find((server) => server.id === id)),
+          (server) => ({ id: server.id, url: server.url }),
+        ),
       ),
     routeSession: (sessionId, url) =>
       routes.has(sessionId)
@@ -728,6 +742,7 @@ export const fakeStores = () => {
   const automation = fakeAutomationStore();
   const debugLogs = fakeDebugLogStore();
   const diagnosis = fakeDiagnosisStore();
+  const servers = fakeServerStore();
   return {
     sessions,
     actions,
@@ -736,6 +751,7 @@ export const fakeStores = () => {
     automation,
     debugLogs,
     diagnosis,
+    servers,
     layer: Layer.mergeAll(
       sessions.layer,
       actions.layer,
@@ -744,6 +760,7 @@ export const fakeStores = () => {
       automation.layer,
       debugLogs.layer,
       diagnosis.layer,
+      servers.layer,
     ),
   };
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Automation server `POST /abort` with the same interface as the client: `{ ticket }`, oligarchy bearer.

- Looks the ticket up in the database (`test_results.linear_id` → running `automation_jobs` row)
- `400` if the ticket is unknown, still pending, or already closed — the client is not called
- Routes via `servers.id`: claim writes that id on the job; abort looks the server up for its current url
- Client `200` → finish the row as `aborted`
- Client `404` → pass through as `404 { error: "unknown session \"…\"" }` and leave the row running
- Client down, or the server row is gone → `500`, row stays running

If abort closes the row first, dispatch does not die when its later `finish` returns false. The handler is uninterruptible so a disconnect after the client kill still persists the row.

## Out of scope

- Cloudflare `/abort`, Wrangler oligarchy-token secret, fallback mark-aborted + Sentry
- Servers-page X button

## Tests

- Unit: abort routes to the claiming client
- Unit: 400 when not running, 401, 400 decode, 404 pass-through, 500 client/server failure
- Unit: claim stores `server_id`; finish-false after abort does not die
- Integration: abort a running dispatched job (needs Docker / DB; CI)
- `npm run check:fast` — lint, format, types, 981 unit tests pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0911f-e3af-799f-8976-6b6c48abb91f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0911f-e3af-799f-8976-6b6c48abb91f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

