### PR TITLE
Add dashboard POST /abort that always answers 200

### DIFF
--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -898,6 +898,10 @@ app.post("/servers/delete", async (context) => {
 // that server is the close. A 4xx or 5xx, or no answer at all, closes a running row here
 // so the queue does not stay stuck; Sentry records "Cloudflare aborted job" only when
 // that write lands. This route always answers 200: the operator's click is done either way.
+// OpenCode's force-kill is 5s; ten seconds is that wait plus the round trip. A hung
+// server must not hold the operator's 200.
+const ABORT_TIMEOUT_MS = 10_000;
+
 app.post("/abort", async (context) => {
   try {
     const body: unknown = await context.req.json();
@@ -920,6 +924,7 @@ app.post("/abort", async (context) => {
           "content-type": "application/json",
         },
         body: JSON.stringify({ ticket }),
+        signal: AbortSignal.timeout(ABORT_TIMEOUT_MS),
       });
       if (response.status === 200) {
         return context.json({ ok: "true" });

--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -895,9 +895,9 @@ app.post("/servers/delete", async (context) => {
 });
 
 // POST /abort asks the automation server to stop the running job for a ticket. A 200 from
-// that server is the close; any other answer (or no answer) closes the running row here so
-// the queue does not stay stuck, and Sentry records "Cloudflare aborted job". This route
-// always answers 200: the operator's click is done either way.
+// that server is the close. A 4xx or 5xx, or no answer at all, closes a running row here
+// so the queue does not stay stuck; Sentry records "Cloudflare aborted job" only when
+// that write lands. This route always answers 200: the operator's click is done either way.
 app.post("/abort", async (context) => {
   try {
     const body: unknown = await context.req.json();
@@ -912,7 +912,6 @@ app.post("/abort", async (context) => {
     if (ticket === undefined) {
       return context.json({ ok: "true" });
     }
-    let closedByServer = false;
     try {
       const response = await fetch(new URL("/abort", context.env.AUTOMATION_SERVER_URL), {
         method: "POST",
@@ -922,23 +921,22 @@ app.post("/abort", async (context) => {
         },
         body: JSON.stringify({ ticket }),
       });
-      closedByServer = response.status === 200;
-      if (!closedByServer) {
-        console.error(
-          `dashboard: aborting a job: automation server returned ${String(response.status)}`,
-        );
+      if (response.status === 200) {
+        return context.json({ ok: "true" });
       }
+      console.error(
+        `dashboard: aborting a job: automation server returned ${String(response.status)}`,
+      );
     } catch (error) {
       console.error("dashboard: aborting a job:", errorMessage(error));
     }
-    if (!closedByServer) {
-      try {
-        await abortAutomationJob(context.env.HYPERDRIVE.connectionString, ticket);
-      } catch (error) {
-        Sentry.captureException(error);
-        console.error("dashboard: aborting a job:", errorMessage(error));
+    try {
+      if (await abortAutomationJob(context.env.HYPERDRIVE.connectionString, ticket)) {
+        Sentry.captureException(new Error("Cloudflare aborted job"));
       }
-      Sentry.captureException(new Error("Cloudflare aborted job"));
+    } catch (error) {
+      Sentry.captureException(error);
+      console.error("dashboard: aborting a job:", errorMessage(error));
     }
   } catch (error) {
     Sentry.captureException(error);

--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -4,6 +4,7 @@ import { html } from "hono/html";
 import type { FC, PropsWithChildren } from "hono/jsx";
 import { jsxRenderer } from "hono/jsx-renderer";
 import {
+  abortAutomationJob,
   addServer,
   definitionStats,
   getImage,
@@ -37,6 +38,10 @@ type Bindings = {
   HYPERDRIVE: {
     connectionString: string;
   };
+  // wrangler secret; the same token POST /abort on the automation server checks.
+  OLIGARCHY_TOKEN: string;
+  // The automation server's base url, set as a Cloudflare var.
+  AUTOMATION_SERVER_URL: string;
 };
 
 type SessionListProps = {
@@ -887,6 +892,59 @@ app.post("/servers/delete", async (context) => {
     console.error("dashboard: removing a server:", errorMessage(error));
     return serversPage(context, 500, undefined, "internal error");
   }
+});
+
+// POST /abort asks the automation server to stop the running job for a ticket. A 200 from
+// that server is the close; any other answer (or no answer) closes the running row here so
+// the queue does not stay stuck, and Sentry records "Cloudflare aborted job". This route
+// always answers 200: the operator's click is done either way.
+app.post("/abort", async (context) => {
+  try {
+    const body: unknown = await context.req.json();
+    const ticket =
+      typeof body === "object" &&
+      body !== null &&
+      "ticket" in body &&
+      typeof body.ticket === "string" &&
+      body.ticket !== ""
+        ? body.ticket
+        : undefined;
+    if (ticket === undefined) {
+      return context.json({ ok: "true" });
+    }
+    let closedByServer = false;
+    try {
+      const response = await fetch(new URL("/abort", context.env.AUTOMATION_SERVER_URL), {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${context.env.OLIGARCHY_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ ticket }),
+      });
+      closedByServer = response.status === 200;
+      if (!closedByServer) {
+        console.error(
+          `dashboard: aborting a job: automation server returned ${String(response.status)}`,
+        );
+      }
+    } catch (error) {
+      console.error("dashboard: aborting a job:", errorMessage(error));
+    }
+    if (!closedByServer) {
+      try {
+        await abortAutomationJob(context.env.HYPERDRIVE.connectionString, ticket);
+      } catch (error) {
+        Sentry.captureException(error);
+        console.error("dashboard: aborting a job:", errorMessage(error));
+      }
+      Sentry.captureException(new Error("Cloudflare aborted job"));
+    }
+  } catch (error) {
+    Sentry.captureException(error);
+    console.error("dashboard: aborting a job:", errorMessage(error));
+  }
+  return context.json({ ok: "true" });
 });
 
 export default Sentry.withSentry(

--- a/src/dashboard/query.ts
+++ b/src/dashboard/query.ts
@@ -1,4 +1,4 @@
-import { desc, eq, getTableColumns, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, getTableColumns, inArray, sql } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import {
@@ -418,6 +418,31 @@ export function listAutomationQueue(connectionString: string): Promise<Automatio
       .orderBy(desc(automationJobs.finishedAt))
       .limit(QUEUE_LIMIT);
     return { running, pending, completed };
+  });
+}
+
+// Only a running row closes, the same rule as the automation server's finish: a pending or
+// finished ticket is left as it is. reason and finished_at are written with the status so the
+// queue shows the close.
+export function abortAutomationJob(connectionString: string, ticket: string): Promise<boolean> {
+  return withDatabase(connectionString, async (db) => {
+    const rows = await db
+      .update(automationJobs)
+      .set({ status: "aborted", reason: "aborted", finishedAt: sql`now()` })
+      .where(
+        and(
+          eq(automationJobs.status, "running"),
+          inArray(
+            automationJobs.resultId,
+            db
+              .select({ id: testResults.id })
+              .from(testResults)
+              .where(eq(testResults.linearId, ticket)),
+          ),
+        ),
+      )
+      .returning({ id: automationJobs.id });
+    return rows.length > 0;
   });
 }
 

--- a/test/dashboard/dashboard.unit.test.ts
+++ b/test/dashboard/dashboard.unit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../../src/dashboard/dashboard.tsx";
+
+const env = {
+  HYPERDRIVE: { connectionString: "postgres://user:x@127.0.0.1:1/oligarchy" },
+  OLIGARCHY_TOKEN: "t",
+  AUTOMATION_SERVER_URL: "http://automation.test",
+};
+
+const abort = (body: string | Record<string, unknown>) =>
+  app.request(
+    "/abort",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    },
+    env,
+  );
+
+describe("POST /abort happy path", () => {
+  it("answers 200 with ok for a well-formed body that names no ticket", async () => {
+    const response = await abort({});
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: "true" });
+  });
+});
+
+describe("POST /abort unhappy path", () => {
+  it("answers 200 with ok when the ticket is empty", async () => {
+    const response = await abort({ ticket: "" });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: "true" });
+  });
+
+  it("answers 200 with ok when the body is not JSON", async () => {
+    const response = await abort("not-json");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: "true" });
+  });
+});

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createServer as createHttpServer } from "node:http";
 import { fileURLToPath } from "node:url";
 import { eq, sql } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
@@ -1335,6 +1336,29 @@ describe("dashboard POST /abort unhappy path: always 200", () => {
     const response = await postAbort("ABT-DOWN", REFUSED_URL, "http://127.0.0.1:1");
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ ok: "true" });
+  });
+
+  it("answers 200 when the automation server accepts the request and never answers", async () => {
+    const server = createHttpServer(() => {});
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    try {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        throw new Error("hanging abort server: no tcp address");
+      }
+      const response = await postAbort(
+        "ABT-HANG",
+        REFUSED_URL,
+        `http://127.0.0.1:${String(address.port)}`,
+      );
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+    } finally {
+      await new Promise<void>((done) => server.close(() => done()));
+    }
   });
 });
 

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -13,6 +13,7 @@ import {
   testResults,
   testRuns,
 } from "../../src/db/schema.ts";
+import * as StubProxy from "../support/stub-proxy.ts";
 
 const QUERY = fileURLToPath(new URL("../../src/dashboard/query.ts", import.meta.url));
 const SCHEMA = fileURLToPath(new URL("../../src/db/schema.ts", import.meta.url));
@@ -1121,5 +1122,314 @@ describe("dashboard/servers page unhappy path: unreachable database", () => {
     expect(deleted.status).toBe(500);
     expect(deleted.text).toContain("<p>error: internal error</p>");
     expect(deleted.text).not.toContain(SENTINEL_PASSWORD);
+  });
+});
+
+const TOKEN = "test-token";
+
+const postAbort = async (
+  ticket: string,
+  databaseUrl: string,
+  automationUrl: string,
+): Promise<{ readonly status: number; readonly body: unknown }> => {
+  const response = await app.request(
+    "/abort",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ticket }),
+    },
+    {
+      HYPERDRIVE: { connectionString: databaseUrl },
+      OLIGARCHY_TOKEN: TOKEN,
+      AUTOMATION_SERVER_URL: automationUrl,
+    },
+  );
+  return { status: response.status, body: await response.json() };
+};
+
+const jobByTicket = async (
+  databaseUrl: string,
+  ticket: string,
+): Promise<{
+  readonly status: string;
+  readonly reason: string | null;
+  readonly finishedAt: Date | null;
+}> => {
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    const [row] = await drizzle(client)
+      .select({
+        status: automationJobs.status,
+        reason: automationJobs.reason,
+        finishedAt: automationJobs.finishedAt,
+      })
+      .from(automationJobs)
+      .innerJoin(testResults, eq(testResults.id, automationJobs.resultId))
+      .where(eq(testResults.linearId, ticket));
+    if (row === undefined) {
+      throw new Error(`no job for ${ticket}`);
+    }
+    return row;
+  } finally {
+    await client.end();
+  }
+};
+
+describe.skipIf(dbUrl === "")("dashboard/query abortAutomationJob happy path", () => {
+  it("closes a running job for the ticket and ends the connection", async () => {
+    await seed(dbUrl, (db) =>
+      seedQueue(db, "abort-query-running", [
+        {
+          ticket: "ABT-Q-1",
+          action: "drive",
+          status: "running",
+          queuedSecondsAgo: 10,
+          startedSecondsAgo: 5,
+        },
+      ]),
+    );
+    const result = await runQuery(
+      'const closed = await query.abortAutomationJob(url, "ABT-Q-1");\nconsole.log(String(closed));',
+      dbUrl,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("true\n");
+    const job = await jobByTicket(dbUrl, "ABT-Q-1");
+    expect(job.status).toBe("aborted");
+    expect(job.reason).toBe("aborted");
+    expect(job.finishedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe.skipIf(dbUrl === "")("dashboard/query abortAutomationJob unhappy path", () => {
+  it("leaves a pending job pending and ends the connection", async () => {
+    await seed(dbUrl, (db) =>
+      seedQueue(db, "abort-query-pending", [
+        { ticket: "ABT-Q-2", action: "drive", status: "pending", queuedSecondsAgo: 10 },
+      ]),
+    );
+    const result = await runQuery(
+      'const closed = await query.abortAutomationJob(url, "ABT-Q-2");\nconsole.log(String(closed));',
+      dbUrl,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("false\n");
+    expect(await jobByTicket(dbUrl, "ABT-Q-2")).toMatchObject({
+      status: "pending",
+      reason: null,
+      finishedAt: null,
+    });
+  });
+
+  it("leaves a finished job finished and ends the connection", async () => {
+    await seed(dbUrl, (db) =>
+      seedQueue(db, "abort-query-done", [
+        {
+          ticket: "ABT-Q-3",
+          action: "drive",
+          status: "succeeded",
+          queuedSecondsAgo: 30,
+          startedSecondsAgo: 20,
+          finishedSecondsAgo: 5,
+        },
+      ]),
+    );
+    const result = await runQuery(
+      'const closed = await query.abortAutomationJob(url, "ABT-Q-3");\nconsole.log(String(closed));',
+      dbUrl,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("false\n");
+    expect((await jobByTicket(dbUrl, "ABT-Q-3")).status).toBe("succeeded");
+  });
+
+  it("returns false for an unknown ticket and ends the connection", async () => {
+    const result = await runQuery(
+      'const closed = await query.abortAutomationJob(url, "ABT-missing");\nconsole.log(String(closed));',
+      dbUrl,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("false\n");
+  });
+});
+
+describe("dashboard POST /abort happy path: the outbound call", () => {
+  it("posts the ticket with the bearer and answers 200 when the automation server does", async () => {
+    const proxy = await StubProxy.startStubProxy(() => StubProxy.OK);
+    try {
+      const response = await postAbort("ABT-200", REFUSED_URL, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      expect(proxy.requests).toEqual([
+        {
+          method: "POST",
+          url: "/abort",
+          authorization: `Bearer ${TOKEN}`,
+          body: { ticket: "ABT-200" },
+        },
+      ]);
+    } finally {
+      await proxy.close();
+    }
+  });
+});
+
+describe.skipIf(dbUrl === "")("dashboard POST /abort happy path", () => {
+  it("leaves a running job running when the automation server answers 200", async () => {
+    const proxy = await StubProxy.startStubProxy(() => StubProxy.OK);
+    try {
+      await seed(dbUrl, (db) =>
+        seedQueue(db, "abort-http-200", [
+          {
+            ticket: "ABT-200",
+            action: "drive",
+            status: "running",
+            queuedSecondsAgo: 10,
+            startedSecondsAgo: 5,
+          },
+        ]),
+      );
+      const response = await postAbort("ABT-200", dbUrl, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      expect(proxy.requests).toEqual([
+        {
+          method: "POST",
+          url: "/abort",
+          authorization: `Bearer ${TOKEN}`,
+          body: { ticket: "ABT-200" },
+        },
+      ]);
+      expect((await jobByTicket(dbUrl, "ABT-200")).status).toBe("running");
+    } finally {
+      await proxy.close();
+    }
+  });
+});
+
+describe("dashboard POST /abort unhappy path: always 200", () => {
+  it("answers 200 when the automation server returns 400 and the database is unreachable", async () => {
+    const proxy = await StubProxy.startStubProxy(() =>
+      StubProxy.refusal(400, 'ticket "ABT-400" is not running'),
+    );
+    try {
+      const response = await postAbort("ABT-400", REFUSED_URL, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it("answers 200 when the automation server is unreachable and the database is too", async () => {
+    const response = await postAbort("ABT-DOWN", REFUSED_URL, "http://127.0.0.1:1");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: "true" });
+  });
+});
+
+describe.skipIf(dbUrl === "")("dashboard POST /abort unhappy path", () => {
+  it("answers 200 and marks a running job aborted when the automation server returns 400", async () => {
+    const proxy = await StubProxy.startStubProxy(() =>
+      StubProxy.refusal(400, 'ticket "ABT-400" is not running'),
+    );
+    try {
+      await seed(dbUrl, (db) =>
+        seedQueue(db, "abort-http-400", [
+          {
+            ticket: "ABT-400",
+            action: "drive",
+            status: "running",
+            queuedSecondsAgo: 10,
+            startedSecondsAgo: 5,
+          },
+        ]),
+      );
+      const response = await postAbort("ABT-400", dbUrl, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      const job = await jobByTicket(dbUrl, "ABT-400");
+      expect(job.status).toBe("aborted");
+      expect(job.reason).toBe("aborted");
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it("answers 200 and marks a running job aborted when the automation server returns 500", async () => {
+    const proxy = await StubProxy.startStubProxy(() => StubProxy.refusal(500, "opencode exited 1"));
+    try {
+      await seed(dbUrl, (db) =>
+        seedQueue(db, "abort-http-500", [
+          {
+            ticket: "ABT-500",
+            action: "drive",
+            status: "running",
+            queuedSecondsAgo: 10,
+            startedSecondsAgo: 5,
+          },
+        ]),
+      );
+      const response = await postAbort("ABT-500", dbUrl, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      expect((await jobByTicket(dbUrl, "ABT-500")).status).toBe("aborted");
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it("answers 200 and marks a running job aborted when the automation server is unreachable", async () => {
+    await seed(dbUrl, (db) =>
+      seedQueue(db, "abort-http-down", [
+        {
+          ticket: "ABT-DOWN",
+          action: "drive",
+          status: "running",
+          queuedSecondsAgo: 10,
+          startedSecondsAgo: 5,
+        },
+      ]),
+    );
+    const response = await postAbort("ABT-DOWN", dbUrl, "http://127.0.0.1:1");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: "true" });
+    expect((await jobByTicket(dbUrl, "ABT-DOWN")).status).toBe("aborted");
+  });
+
+  it("answers 200 and leaves a finished job finished when the automation server returns 400", async () => {
+    const proxy = await StubProxy.startStubProxy(() =>
+      StubProxy.refusal(400, 'ticket "ABT-DONE" is not running'),
+    );
+    try {
+      await seed(dbUrl, (db) =>
+        seedQueue(db, "abort-http-done", [
+          {
+            ticket: "ABT-DONE",
+            action: "drive",
+            status: "succeeded",
+            queuedSecondsAgo: 30,
+            startedSecondsAgo: 20,
+            finishedSecondsAgo: 5,
+          },
+        ]),
+      );
+      const response = await postAbort("ABT-DONE", dbUrl, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      expect((await jobByTicket(dbUrl, "ABT-DONE")).status).toBe("succeeded");
+    } finally {
+      await proxy.close();
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Cloudflare dashboard is the abort wrapper around the automation server.

**Behavior**
- `POST /abort` with `{ ticket }` calls the automation server `POST /abort` with the oligarchy bearer.
- Automation server **200**: done. The server already closed the row. Dashboard does not write.
- Automation server **4xx / 5xx** or no answer (including a hang past 10s): dashboard closes any **running** job for that ticket (`status=aborted`, `reason=aborted`). Sentry `"Cloudflare aborted job"` only when that write lands.
- Dashboard **always answers 200** `{ ok: "true" }`, including missing/empty/invalid bodies.

**Server 400 when not running**
Already shipped in #118. `POST /abort` on the automation server returns 400 `ticket "<id>" is not running` when the ticket is unknown, pending, or already finished. The client is not called.

**Bindings to set in Cloudflare**
- `OLIGARCHY_TOKEN` — wrangler secret (same token the automation server checks)
- `AUTOMATION_SERVER_URL` — worker var, the automation server base URL

**Tests**
- Unit: always 200 on missing/empty/invalid ticket (no I/O)
- Integration: outbound bearer+ticket on 200; fallback mark-aborted on 400/500/unreachable; hang times out at 10s and still answers 200; finished and pending rows are left alone; `abortAutomationJob` ends the pg client
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0911f-e3af-799f-8976-6b6c48abb91f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0911f-e3af-799f-8976-6b6c48abb91f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

