### PR TITLE
Add an abort button on running automation jobs

### DIFF
--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -898,6 +898,10 @@ app.post("/servers/delete", async (context) => {
 // that server is the close. A 4xx or 5xx, or no answer at all, closes a running row here
 // so the queue does not stay stuck; Sentry records "Cloudflare aborted job" only when
 // that write lands. This route always answers 200: the operator's click is done either way.
+// OpenCode's force-kill is 5s; ten seconds is that wait plus the round trip. A hung
+// server must not hold the operator's 200.
+const ABORT_TIMEOUT_MS = 10_000;
+
 app.post("/abort", async (context) => {
   try {
     const body: unknown = await context.req.json();
@@ -920,6 +924,7 @@ app.post("/abort", async (context) => {
           "content-type": "application/json",
         },
         body: JSON.stringify({ ticket }),
+        signal: AbortSignal.timeout(ABORT_TIMEOUT_MS),
       });
       if (response.status === 200) {
         return context.json({ ok: "true" });

--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -903,51 +903,77 @@ app.post("/servers/delete", async (context) => {
 const ABORT_TIMEOUT_MS = 10_000;
 
 app.post("/abort", async (context) => {
-  try {
-    const body: unknown = await context.req.json();
-    const ticket =
-      typeof body === "object" &&
-      body !== null &&
-      "ticket" in body &&
-      typeof body.ticket === "string" &&
-      body.ticket !== ""
-        ? body.ticket
-        : undefined;
-    if (ticket === undefined) {
+  const wantsQueue = context.req.header("hx-request") === "true";
+  const isJson = (context.req.header("content-type") ?? "").includes("application/json");
+  const reply = async () => {
+    if (wantsQueue) {
+      try {
+        const queue = await listAutomationQueue(context.env.HYPERDRIVE.connectionString);
+        return context.html(<Queue queue={queue} />);
+      } catch (error) {
+        Sentry.captureException(error);
+        console.error("dashboard: aborting a job:", errorMessage(error));
+        return context.html(<p>error: internal error</p>);
+      }
+    }
+    if (isJson) {
       return context.json({ ok: "true" });
     }
-    try {
-      const response = await fetch(new URL("/abort", context.env.AUTOMATION_SERVER_URL), {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${context.env.OLIGARCHY_TOKEN}`,
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({ ticket }),
-        signal: AbortSignal.timeout(ABORT_TIMEOUT_MS),
-      });
-      if (response.status === 200) {
-        return context.json({ ok: "true" });
-      }
-      console.error(
-        `dashboard: aborting a job: automation server returned ${String(response.status)}`,
-      );
-    } catch (error) {
-      console.error("dashboard: aborting a job:", errorMessage(error));
+    return context.redirect("/servers", 303);
+  };
+  try {
+    let ticket: string | undefined;
+    if (isJson) {
+      const body: unknown = await context.req.json();
+      ticket =
+        typeof body === "object" &&
+        body !== null &&
+        "ticket" in body &&
+        typeof body.ticket === "string" &&
+        body.ticket !== ""
+          ? body.ticket
+          : undefined;
+    } else {
+      const body = await context.req.parseBody();
+      ticket = typeof body.ticket === "string" && body.ticket !== "" ? body.ticket : undefined;
     }
-    try {
-      if (await abortAutomationJob(context.env.HYPERDRIVE.connectionString, ticket)) {
-        Sentry.captureException(new Error("Cloudflare aborted job"));
+    if (ticket !== undefined) {
+      let closedByServer = false;
+      try {
+        const response = await fetch(new URL("/abort", context.env.AUTOMATION_SERVER_URL), {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${context.env.OLIGARCHY_TOKEN}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ ticket }),
+          signal: AbortSignal.timeout(ABORT_TIMEOUT_MS),
+        });
+        closedByServer = response.status === 200;
+        if (!closedByServer) {
+          console.error(
+            `dashboard: aborting a job: automation server returned ${String(response.status)}`,
+          );
+        }
+      } catch (error) {
+        console.error("dashboard: aborting a job:", errorMessage(error));
       }
-    } catch (error) {
-      Sentry.captureException(error);
-      console.error("dashboard: aborting a job:", errorMessage(error));
+      if (!closedByServer) {
+        try {
+          if (await abortAutomationJob(context.env.HYPERDRIVE.connectionString, ticket)) {
+            Sentry.captureException(new Error("Cloudflare aborted job"));
+          }
+        } catch (error) {
+          Sentry.captureException(error);
+          console.error("dashboard: aborting a job:", errorMessage(error));
+        }
+      }
     }
   } catch (error) {
     Sentry.captureException(error);
     console.error("dashboard: aborting a job:", errorMessage(error));
   }
-  return context.json({ ok: "true" });
+  return reply();
 });
 
 export default Sentry.withSentry(

--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -895,9 +895,9 @@ app.post("/servers/delete", async (context) => {
 });
 
 // POST /abort asks the automation server to stop the running job for a ticket. A 200 from
-// that server is the close; any other answer (or no answer) closes the running row here so
-// the queue does not stay stuck, and Sentry records "Cloudflare aborted job". This route
-// always answers 200: the operator's click is done either way.
+// that server is the close. A 4xx or 5xx, or no answer at all, closes a running row here
+// so the queue does not stay stuck; Sentry records "Cloudflare aborted job" only when
+// that write lands. This route always answers 200: the operator's click is done either way.
 app.post("/abort", async (context) => {
   try {
     const body: unknown = await context.req.json();
@@ -912,7 +912,6 @@ app.post("/abort", async (context) => {
     if (ticket === undefined) {
       return context.json({ ok: "true" });
     }
-    let closedByServer = false;
     try {
       const response = await fetch(new URL("/abort", context.env.AUTOMATION_SERVER_URL), {
         method: "POST",
@@ -922,23 +921,22 @@ app.post("/abort", async (context) => {
         },
         body: JSON.stringify({ ticket }),
       });
-      closedByServer = response.status === 200;
-      if (!closedByServer) {
-        console.error(
-          `dashboard: aborting a job: automation server returned ${String(response.status)}`,
-        );
+      if (response.status === 200) {
+        return context.json({ ok: "true" });
       }
+      console.error(
+        `dashboard: aborting a job: automation server returned ${String(response.status)}`,
+      );
     } catch (error) {
       console.error("dashboard: aborting a job:", errorMessage(error));
     }
-    if (!closedByServer) {
-      try {
-        await abortAutomationJob(context.env.HYPERDRIVE.connectionString, ticket);
-      } catch (error) {
-        Sentry.captureException(error);
-        console.error("dashboard: aborting a job:", errorMessage(error));
+    try {
+      if (await abortAutomationJob(context.env.HYPERDRIVE.connectionString, ticket)) {
+        Sentry.captureException(new Error("Cloudflare aborted job"));
       }
-      Sentry.captureException(new Error("Cloudflare aborted job"));
+    } catch (error) {
+      Sentry.captureException(error);
+      console.error("dashboard: aborting a job:", errorMessage(error));
     }
   } catch (error) {
     Sentry.captureException(error);

--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -4,6 +4,7 @@ import { html } from "hono/html";
 import type { FC, PropsWithChildren } from "hono/jsx";
 import { jsxRenderer } from "hono/jsx-renderer";
 import {
+  abortAutomationJob,
   addServer,
   definitionStats,
   getImage,
@@ -37,6 +38,10 @@ type Bindings = {
   HYPERDRIVE: {
     connectionString: string;
   };
+  // wrangler secret; the same token POST /abort on the automation server checks.
+  OLIGARCHY_TOKEN: string;
+  // The automation server's base url, set as a Cloudflare var.
+  AUTOMATION_SERVER_URL: string;
 };
 
 type SessionListProps = {
@@ -887,6 +892,59 @@ app.post("/servers/delete", async (context) => {
     console.error("dashboard: removing a server:", errorMessage(error));
     return serversPage(context, 500, undefined, "internal error");
   }
+});
+
+// POST /abort asks the automation server to stop the running job for a ticket. A 200 from
+// that server is the close; any other answer (or no answer) closes the running row here so
+// the queue does not stay stuck, and Sentry records "Cloudflare aborted job". This route
+// always answers 200: the operator's click is done either way.
+app.post("/abort", async (context) => {
+  try {
+    const body: unknown = await context.req.json();
+    const ticket =
+      typeof body === "object" &&
+      body !== null &&
+      "ticket" in body &&
+      typeof body.ticket === "string" &&
+      body.ticket !== ""
+        ? body.ticket
+        : undefined;
+    if (ticket === undefined) {
+      return context.json({ ok: "true" });
+    }
+    let closedByServer = false;
+    try {
+      const response = await fetch(new URL("/abort", context.env.AUTOMATION_SERVER_URL), {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${context.env.OLIGARCHY_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ ticket }),
+      });
+      closedByServer = response.status === 200;
+      if (!closedByServer) {
+        console.error(
+          `dashboard: aborting a job: automation server returned ${String(response.status)}`,
+        );
+      }
+    } catch (error) {
+      console.error("dashboard: aborting a job:", errorMessage(error));
+    }
+    if (!closedByServer) {
+      try {
+        await abortAutomationJob(context.env.HYPERDRIVE.connectionString, ticket);
+      } catch (error) {
+        Sentry.captureException(error);
+        console.error("dashboard: aborting a job:", errorMessage(error));
+      }
+      Sentry.captureException(new Error("Cloudflare aborted job"));
+    }
+  } catch (error) {
+    Sentry.captureException(error);
+    console.error("dashboard: aborting a job:", errorMessage(error));
+  }
+  return context.json({ ok: "true" });
 });
 
 export default Sentry.withSentry(

--- a/src/dashboard/query.ts
+++ b/src/dashboard/query.ts
@@ -1,4 +1,4 @@
-import { desc, eq, getTableColumns, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, getTableColumns, inArray, sql } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 import {
@@ -418,6 +418,31 @@ export function listAutomationQueue(connectionString: string): Promise<Automatio
       .orderBy(desc(automationJobs.finishedAt))
       .limit(QUEUE_LIMIT);
     return { running, pending, completed };
+  });
+}
+
+// Only a running row closes, the same rule as the automation server's finish: a pending or
+// finished ticket is left as it is. reason and finished_at are written with the status so the
+// queue shows the close.
+export function abortAutomationJob(connectionString: string, ticket: string): Promise<boolean> {
+  return withDatabase(connectionString, async (db) => {
+    const rows = await db
+      .update(automationJobs)
+      .set({ status: "aborted", reason: "aborted", finishedAt: sql`now()` })
+      .where(
+        and(
+          eq(automationJobs.status, "running"),
+          inArray(
+            automationJobs.resultId,
+            db
+              .select({ id: testResults.id })
+              .from(testResults)
+              .where(eq(testResults.linearId, ticket)),
+          ),
+        ),
+      )
+      .returning({ id: automationJobs.id });
+    return rows.length > 0;
   });
 }
 

--- a/src/dashboard/servers.tsx
+++ b/src/dashboard/servers.tsx
@@ -136,11 +136,22 @@ const Jobs: FC<{ jobs: ReadonlyArray<AutomationJob> }> = ({ jobs }) =>
                 method="post"
                 action="/abort"
                 hx-post="/abort"
+                hx-confirm="are you sure?"
                 hx-target="#queue"
                 hx-swap="innerHTML"
               >
                 <input type="hidden" name="ticket" value={job.ticket} />
-                <button>abort</button>
+                <button type="submit" class="abort" aria-label="abort">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="12"
+                    height="12"
+                    viewBox="0 0 12 12"
+                    aria-hidden="true"
+                  >
+                    <path d="M2 2l8 8M10 2L2 10" stroke="red" stroke-width="2" fill="none" />
+                  </svg>
+                </button>
               </form>
             ) : null}
           </td>
@@ -182,7 +193,7 @@ export const ServersPage: FC<{
       <title>oligarchy servers</title>
       <style>
         {
-          ".halves { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: start; }"
+          ".halves { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: start; } .abort { background: none; border: none; padding: 0; cursor: pointer; line-height: 0; vertical-align: middle; }"
         }
       </style>
       <script src={HTMX_URL} integrity={HTMX_INTEGRITY} crossorigin="anonymous"></script>

--- a/src/dashboard/servers.tsx
+++ b/src/dashboard/servers.tsx
@@ -118,6 +118,7 @@ const Jobs: FC<{ jobs: ReadonlyArray<AutomationJob> }> = ({ jobs }) =>
         <th>started</th>
         <th>finished</th>
         <th>reason</th>
+        <th></th>
       </tr>
       {jobs.map((job) => (
         <tr>
@@ -129,6 +130,20 @@ const Jobs: FC<{ jobs: ReadonlyArray<AutomationJob> }> = ({ jobs }) =>
           <td>{since(job.startedAt, job.queriedAt)}</td>
           <td>{since(job.finishedAt, job.queriedAt)}</td>
           <td>{job.reason}</td>
+          <td>
+            {job.status === "running" && job.ticket !== null ? (
+              <form
+                method="post"
+                action="/abort"
+                hx-post="/abort"
+                hx-target="#queue"
+                hx-swap="innerHTML"
+              >
+                <input type="hidden" name="ticket" value={job.ticket} />
+                <button>abort</button>
+              </form>
+            ) : null}
+          </td>
         </tr>
       ))}
     </table>

--- a/test/dashboard/dashboard.unit.test.ts
+++ b/test/dashboard/dashboard.unit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { app } from "../../src/dashboard/dashboard.tsx";
+
+const env = {
+  HYPERDRIVE: { connectionString: "postgres://user:x@127.0.0.1:1/oligarchy" },
+  OLIGARCHY_TOKEN: "t",
+  AUTOMATION_SERVER_URL: "http://automation.test",
+};
+
+const abort = (body: string | Record<string, unknown>) =>
+  app.request(
+    "/abort",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    },
+    env,
+  );
+
+describe("POST /abort happy path", () => {
+  it("answers 200 with ok for a well-formed body that names no ticket", async () => {
+    const response = await abort({});
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: "true" });
+  });
+});
+
+describe("POST /abort unhappy path", () => {
+  it("answers 200 with ok when the ticket is empty", async () => {
+    const response = await abort({ ticket: "" });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: "true" });
+  });
+
+  it("answers 200 with ok when the body is not JSON", async () => {
+    const response = await abort("not-json");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: "true" });
+  });
+});

--- a/test/dashboard/dashboard.unit.test.ts
+++ b/test/dashboard/dashboard.unit.test.ts
@@ -38,4 +38,18 @@ describe("POST /abort unhappy path", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ ok: "true" });
   });
+
+  it("sends a form post without a ticket back to the servers page", async () => {
+    const response = await app.request(
+      "/abort",
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: "",
+      },
+      env,
+    );
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe("/servers");
+  });
 });

--- a/test/dashboard/servers.unit.test.ts
+++ b/test/dashboard/servers.unit.test.ts
@@ -79,7 +79,10 @@ const QUEUE: AutomationQueue = { running: [running], pending: [pending], complet
 const EMPTY_QUEUE: AutomationQueue = { running: [], pending: [], completed: [] };
 
 const JOB_COLUMNS =
-  "<tr><th>ticket</th><th>test</th><th>action</th><th>status</th><th>queued</th><th>started</th><th>finished</th><th>reason</th></tr>";
+  "<tr><th>ticket</th><th>test</th><th>action</th><th>status</th><th>queued</th><th>started</th><th>finished</th><th>reason</th><th></th></tr>";
+
+const abortForm = (ticket: string): string =>
+  `<form method="post" action="/abort" hx-post="/abort" hx-target="#queue" hx-swap="innerHTML"><input type="hidden" name="ticket" value="${ticket}"/><button>abort</button></form>`;
 
 // The components are functions of their props; the string they render, through the same html
 // helper the routes serve them with, is the page. The helper hands back a String object, hence
@@ -172,21 +175,26 @@ describe("Queue happy path", () => {
   it("shows a running job's ticket, test, action and status, how long ago it was queued and started, and no finish yet", async () => {
     const page = await render(Queue({ queue: { ...EMPTY_QUEUE, running: [running] } }));
     expect(page).toContain(
-      "<tr><td>OLI-61</td><td>lock-screen</td><td>diagnose</td><td>running</td><td>3 min ago</td><td>45 s ago</td><td>—</td><td></td></tr>",
+      `<tr><td>OLI-61</td><td>lock-screen</td><td>diagnose</td><td>running</td><td>3 min ago</td><td>45 s ago</td><td>—</td><td></td><td>${abortForm("OLI-61")}</td></tr>`,
     );
+  });
+
+  it("puts an abort form on a running job that has a ticket", async () => {
+    const page = await render(Queue({ queue: { ...EMPTY_QUEUE, running: [running] } }));
+    expect(page).toContain(abortForm("OLI-61"));
   });
 
   it("shows a pending job as queued and not yet started or finished", async () => {
     const page = await render(Queue({ queue: { ...EMPTY_QUEUE, pending: [pending] } }));
     expect(page).toContain(
-      "<tr><td>OLI-62</td><td>install</td><td>drive</td><td>pending</td><td>7 s ago</td><td>—</td><td>—</td><td></td></tr>",
+      "<tr><td>OLI-62</td><td>install</td><td>drive</td><td>pending</td><td>7 s ago</td><td>—</td><td>—</td><td></td><td></td></tr>",
     );
   });
 
   it("shows a completed job's terminal status, when it finished, and the reason it closed with", async () => {
     const page = await render(Queue({ queue: { ...EMPTY_QUEUE, completed: [failed] } }));
     expect(page).toContain(
-      "<tr><td>OLI-60</td><td>wifi</td><td>drive</td><td>failed</td><td>1 h ago</td><td>1 h ago</td><td>10 min ago</td><td>session timed out</td></tr>",
+      "<tr><td>OLI-60</td><td>wifi</td><td>drive</td><td>failed</td><td>1 h ago</td><td>1 h ago</td><td>10 min ago</td><td>session timed out</td><td></td></tr>",
     );
   });
 
@@ -212,6 +220,20 @@ describe("Queue unhappy path", () => {
     expect(page).toContain("<tr><td>—</td><td>install</td><td>drive</td><td>pending</td>");
   });
 
+  it("offers no abort on pending, completed, or a running job with no ticket", async () => {
+    const page = await render(
+      Queue({
+        queue: {
+          running: [{ ...running, ticket: null }],
+          pending: [pending],
+          completed: [failed],
+        },
+      }),
+    );
+    expect(page).not.toContain('action="/abort"');
+    expect(page).not.toContain(">abort</button>");
+  });
+
   it("escapes a ticket, a test name and a reason", async () => {
     const hostile: AutomationJob = {
       ...failed,
@@ -222,6 +244,11 @@ describe("Queue unhappy path", () => {
     const page = await render(Queue({ queue: { ...EMPTY_QUEUE, completed: [hostile] } }));
     expect(page).toContain("<td>OLI-&lt;1&quot;&gt;</td><td>&lt;b&gt;wifi&lt;/b&gt;</td>");
     expect(page).toContain("<td>&lt;script&gt;alert(1)&lt;/script&gt;</td>");
+    const runningHostile = await render(
+      Queue({ queue: { ...EMPTY_QUEUE, running: [{ ...running, ticket: 'OLI-<1">' }] } }),
+    );
+    expect(runningHostile).toContain('value="OLI-&lt;1&quot;&gt;"');
+    expect(runningHostile).not.toContain('value="OLI-<1">');
     expect(page).not.toContain("<script>alert");
     expect(page).not.toContain("<b>wifi");
   });

--- a/test/dashboard/servers.unit.test.ts
+++ b/test/dashboard/servers.unit.test.ts
@@ -81,8 +81,11 @@ const EMPTY_QUEUE: AutomationQueue = { running: [], pending: [], completed: [] }
 const JOB_COLUMNS =
   "<tr><th>ticket</th><th>test</th><th>action</th><th>status</th><th>queued</th><th>started</th><th>finished</th><th>reason</th><th></th></tr>";
 
+const ABORT_X =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" aria-hidden="true"><path d="M2 2l8 8M10 2L2 10" stroke="red" stroke-width="2" fill="none"></path></svg>';
+
 const abortForm = (ticket: string): string =>
-  `<form method="post" action="/abort" hx-post="/abort" hx-target="#queue" hx-swap="innerHTML"><input type="hidden" name="ticket" value="${ticket}"/><button>abort</button></form>`;
+  `<form method="post" action="/abort" hx-post="/abort" hx-confirm="are you sure?" hx-target="#queue" hx-swap="innerHTML"><input type="hidden" name="ticket" value="${ticket}"/><button type="submit" class="abort" aria-label="abort">${ABORT_X}</button></form>`;
 
 // The components are functions of their props; the string they render, through the same html
 // helper the routes serve them with, is the page. The helper hands back a String object, hence
@@ -179,9 +182,12 @@ describe("Queue happy path", () => {
     );
   });
 
-  it("puts an abort form on a running job that has a ticket", async () => {
+  it("puts a red X on a running job that has a ticket, and asks are you sure before it posts", async () => {
     const page = await render(Queue({ queue: { ...EMPTY_QUEUE, running: [running] } }));
     expect(page).toContain(abortForm("OLI-61"));
+    expect(page).toContain('hx-confirm="are you sure?"');
+    expect(page).toContain('stroke="red"');
+    expect(page).not.toContain(">abort</button>");
   });
 
   it("shows a pending job as queued and not yet started or finished", async () => {
@@ -231,7 +237,9 @@ describe("Queue unhappy path", () => {
       }),
     );
     expect(page).not.toContain('action="/abort"');
-    expect(page).not.toContain(">abort</button>");
+    expect(page).not.toContain('hx-confirm="are you sure?"');
+    expect(page).not.toContain('aria-label="abort"');
+    expect(page).not.toContain("<svg");
   });
 
   it("escapes a ticket, a test name and a reason", async () => {
@@ -262,6 +270,7 @@ describe("ServersPage happy path", () => {
     expect(page).toContain("<title>oligarchy servers</title>");
     expect(page).toContain('<script src="https://cdn.jsdelivr.net/npm/htmx.org@4.0.0"');
     expect(page).toMatch(/<style>[^<]*\.halves\s*\{[^}]*grid-template-columns:\s*1fr 1fr/);
+    expect(page).toMatch(/<style>[^<]*\.abort\s*\{[^}]*background:\s*none/);
     expect(page).toContain("<h1>oligarchy servers</h1>");
     expect(page).toContain(
       '<div class="halves"><section><h2>automation</h2><div id="queue" hx-get="/servers/queue" hx-trigger="every 30s"><h3>running</h3>',

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createServer as createHttpServer } from "node:http";
 import { fileURLToPath } from "node:url";
 import { eq, sql } from "drizzle-orm";
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
@@ -1335,6 +1336,29 @@ describe("dashboard POST /abort unhappy path: always 200", () => {
     const response = await postAbort("ABT-DOWN", REFUSED_URL, "http://127.0.0.1:1");
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ ok: "true" });
+  });
+
+  it("answers 200 when the automation server accepts the request and never answers", async () => {
+    const server = createHttpServer(() => {});
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    try {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        throw new Error("hanging abort server: no tcp address");
+      }
+      const response = await postAbort(
+        "ABT-HANG",
+        REFUSED_URL,
+        `http://127.0.0.1:${String(address.port)}`,
+      );
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+    } finally {
+      await new Promise<void>((done) => server.close(() => done()));
+    }
   });
 });
 

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -13,6 +13,7 @@ import {
   testResults,
   testRuns,
 } from "../../src/db/schema.ts";
+import * as StubProxy from "../support/stub-proxy.ts";
 
 const QUERY = fileURLToPath(new URL("../../src/dashboard/query.ts", import.meta.url));
 const SCHEMA = fileURLToPath(new URL("../../src/db/schema.ts", import.meta.url));
@@ -1121,5 +1122,314 @@ describe("dashboard/servers page unhappy path: unreachable database", () => {
     expect(deleted.status).toBe(500);
     expect(deleted.text).toContain("<p>error: internal error</p>");
     expect(deleted.text).not.toContain(SENTINEL_PASSWORD);
+  });
+});
+
+const TOKEN = "test-token";
+
+const postAbort = async (
+  ticket: string,
+  databaseUrl: string,
+  automationUrl: string,
+): Promise<{ readonly status: number; readonly body: unknown }> => {
+  const response = await app.request(
+    "/abort",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ticket }),
+    },
+    {
+      HYPERDRIVE: { connectionString: databaseUrl },
+      OLIGARCHY_TOKEN: TOKEN,
+      AUTOMATION_SERVER_URL: automationUrl,
+    },
+  );
+  return { status: response.status, body: await response.json() };
+};
+
+const jobByTicket = async (
+  databaseUrl: string,
+  ticket: string,
+): Promise<{
+  readonly status: string;
+  readonly reason: string | null;
+  readonly finishedAt: Date | null;
+}> => {
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    const [row] = await drizzle(client)
+      .select({
+        status: automationJobs.status,
+        reason: automationJobs.reason,
+        finishedAt: automationJobs.finishedAt,
+      })
+      .from(automationJobs)
+      .innerJoin(testResults, eq(testResults.id, automationJobs.resultId))
+      .where(eq(testResults.linearId, ticket));
+    if (row === undefined) {
+      throw new Error(`no job for ${ticket}`);
+    }
+    return row;
+  } finally {
+    await client.end();
+  }
+};
+
+describe.skipIf(dbUrl === "")("dashboard/query abortAutomationJob happy path", () => {
+  it("closes a running job for the ticket and ends the connection", async () => {
+    await seed(dbUrl, (db) =>
+      seedQueue(db, "abort-query-running", [
+        {
+          ticket: "ABT-Q-1",
+          action: "drive",
+          status: "running",
+          queuedSecondsAgo: 10,
+          startedSecondsAgo: 5,
+        },
+      ]),
+    );
+    const result = await runQuery(
+      'const closed = await query.abortAutomationJob(url, "ABT-Q-1");\nconsole.log(String(closed));',
+      dbUrl,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("true\n");
+    const job = await jobByTicket(dbUrl, "ABT-Q-1");
+    expect(job.status).toBe("aborted");
+    expect(job.reason).toBe("aborted");
+    expect(job.finishedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe.skipIf(dbUrl === "")("dashboard/query abortAutomationJob unhappy path", () => {
+  it("leaves a pending job pending and ends the connection", async () => {
+    await seed(dbUrl, (db) =>
+      seedQueue(db, "abort-query-pending", [
+        { ticket: "ABT-Q-2", action: "drive", status: "pending", queuedSecondsAgo: 10 },
+      ]),
+    );
+    const result = await runQuery(
+      'const closed = await query.abortAutomationJob(url, "ABT-Q-2");\nconsole.log(String(closed));',
+      dbUrl,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("false\n");
+    expect(await jobByTicket(dbUrl, "ABT-Q-2")).toMatchObject({
+      status: "pending",
+      reason: null,
+      finishedAt: null,
+    });
+  });
+
+  it("leaves a finished job finished and ends the connection", async () => {
+    await seed(dbUrl, (db) =>
+      seedQueue(db, "abort-query-done", [
+        {
+          ticket: "ABT-Q-3",
+          action: "drive",
+          status: "succeeded",
+          queuedSecondsAgo: 30,
+          startedSecondsAgo: 20,
+          finishedSecondsAgo: 5,
+        },
+      ]),
+    );
+    const result = await runQuery(
+      'const closed = await query.abortAutomationJob(url, "ABT-Q-3");\nconsole.log(String(closed));',
+      dbUrl,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("false\n");
+    expect((await jobByTicket(dbUrl, "ABT-Q-3")).status).toBe("succeeded");
+  });
+
+  it("returns false for an unknown ticket and ends the connection", async () => {
+    const result = await runQuery(
+      'const closed = await query.abortAutomationJob(url, "ABT-missing");\nconsole.log(String(closed));',
+      dbUrl,
+    );
+    expect(result.hung, "process did not exit: the pg client was not ended").toBe(false);
+    expect(result.stderr).toBe("");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe("false\n");
+  });
+});
+
+describe("dashboard POST /abort happy path: the outbound call", () => {
+  it("posts the ticket with the bearer and answers 200 when the automation server does", async () => {
+    const proxy = await StubProxy.startStubProxy(() => StubProxy.OK);
+    try {
+      const response = await postAbort("ABT-200", REFUSED_URL, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      expect(proxy.requests).toEqual([
+        {
+          method: "POST",
+          url: "/abort",
+          authorization: `Bearer ${TOKEN}`,
+          body: { ticket: "ABT-200" },
+        },
+      ]);
+    } finally {
+      await proxy.close();
+    }
+  });
+});
+
+describe.skipIf(dbUrl === "")("dashboard POST /abort happy path", () => {
+  it("leaves a running job running when the automation server answers 200", async () => {
+    const proxy = await StubProxy.startStubProxy(() => StubProxy.OK);
+    try {
+      await seed(dbUrl, (db) =>
+        seedQueue(db, "abort-http-200", [
+          {
+            ticket: "ABT-200",
+            action: "drive",
+            status: "running",
+            queuedSecondsAgo: 10,
+            startedSecondsAgo: 5,
+          },
+        ]),
+      );
+      const response = await postAbort("ABT-200", dbUrl, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      expect(proxy.requests).toEqual([
+        {
+          method: "POST",
+          url: "/abort",
+          authorization: `Bearer ${TOKEN}`,
+          body: { ticket: "ABT-200" },
+        },
+      ]);
+      expect((await jobByTicket(dbUrl, "ABT-200")).status).toBe("running");
+    } finally {
+      await proxy.close();
+    }
+  });
+});
+
+describe("dashboard POST /abort unhappy path: always 200", () => {
+  it("answers 200 when the automation server returns 400 and the database is unreachable", async () => {
+    const proxy = await StubProxy.startStubProxy(() =>
+      StubProxy.refusal(400, 'ticket "ABT-400" is not running'),
+    );
+    try {
+      const response = await postAbort("ABT-400", REFUSED_URL, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it("answers 200 when the automation server is unreachable and the database is too", async () => {
+    const response = await postAbort("ABT-DOWN", REFUSED_URL, "http://127.0.0.1:1");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: "true" });
+  });
+});
+
+describe.skipIf(dbUrl === "")("dashboard POST /abort unhappy path", () => {
+  it("answers 200 and marks a running job aborted when the automation server returns 400", async () => {
+    const proxy = await StubProxy.startStubProxy(() =>
+      StubProxy.refusal(400, 'ticket "ABT-400" is not running'),
+    );
+    try {
+      await seed(dbUrl, (db) =>
+        seedQueue(db, "abort-http-400", [
+          {
+            ticket: "ABT-400",
+            action: "drive",
+            status: "running",
+            queuedSecondsAgo: 10,
+            startedSecondsAgo: 5,
+          },
+        ]),
+      );
+      const response = await postAbort("ABT-400", dbUrl, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      const job = await jobByTicket(dbUrl, "ABT-400");
+      expect(job.status).toBe("aborted");
+      expect(job.reason).toBe("aborted");
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it("answers 200 and marks a running job aborted when the automation server returns 500", async () => {
+    const proxy = await StubProxy.startStubProxy(() => StubProxy.refusal(500, "opencode exited 1"));
+    try {
+      await seed(dbUrl, (db) =>
+        seedQueue(db, "abort-http-500", [
+          {
+            ticket: "ABT-500",
+            action: "drive",
+            status: "running",
+            queuedSecondsAgo: 10,
+            startedSecondsAgo: 5,
+          },
+        ]),
+      );
+      const response = await postAbort("ABT-500", dbUrl, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      expect((await jobByTicket(dbUrl, "ABT-500")).status).toBe("aborted");
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it("answers 200 and marks a running job aborted when the automation server is unreachable", async () => {
+    await seed(dbUrl, (db) =>
+      seedQueue(db, "abort-http-down", [
+        {
+          ticket: "ABT-DOWN",
+          action: "drive",
+          status: "running",
+          queuedSecondsAgo: 10,
+          startedSecondsAgo: 5,
+        },
+      ]),
+    );
+    const response = await postAbort("ABT-DOWN", dbUrl, "http://127.0.0.1:1");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: "true" });
+    expect((await jobByTicket(dbUrl, "ABT-DOWN")).status).toBe("aborted");
+  });
+
+  it("answers 200 and leaves a finished job finished when the automation server returns 400", async () => {
+    const proxy = await StubProxy.startStubProxy(() =>
+      StubProxy.refusal(400, 'ticket "ABT-DONE" is not running'),
+    );
+    try {
+      await seed(dbUrl, (db) =>
+        seedQueue(db, "abort-http-done", [
+          {
+            ticket: "ABT-DONE",
+            action: "drive",
+            status: "succeeded",
+            queuedSecondsAgo: 30,
+            startedSecondsAgo: 20,
+            finishedSecondsAgo: 5,
+          },
+        ]),
+      );
+      const response = await postAbort("ABT-DONE", dbUrl, proxy.url);
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: "true" });
+      expect((await jobByTicket(dbUrl, "ABT-DONE")).status).toBe("succeeded");
+    } finally {
+      await proxy.close();
+    }
   });
 });

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -1017,13 +1017,13 @@ console.log([failed.test, failed.action, failed.reason, failed.createdAt instanc
     );
     // The ages are read against the database's clock: a minute has margin, seconds are counted.
     expect(html).toMatch(
-      /<tr><td>QUE-102<\/td><td>queue-order<\/td><td>diagnose<\/td><td>running<\/td><td>1 min ago<\/td><td>\d+ s ago<\/td><td>—<\/td><td><\/td><td><form method="post" action="\/abort" hx-post="\/abort" hx-target="#queue" hx-swap="innerHTML"><input type="hidden" name="ticket" value="QUE-102"\/><button>abort<\/button><\/form><\/td><\/tr><tr><td>QUE-101<\/td><td>queue-order<\/td><td>drive<\/td><td>running<\/td><td>5 min ago<\/td><td>3 min ago<\/td><td>—<\/td><td><\/td><td><form method="post" action="\/abort"/,
+      /<tr><td>QUE-102<\/td><td>queue-order<\/td><td>diagnose<\/td><td>running<\/td><td>1 min ago<\/td><td>\d+ s ago<\/td><td>—<\/td><td><\/td><td><form method="post" action="\/abort" hx-post="\/abort" hx-confirm="are you sure\?" hx-target="#queue" hx-swap="innerHTML"><input type="hidden" name="ticket" value="QUE-102"\/><button type="submit" class="abort" aria-label="abort"><svg/,
     );
     expect(html).toMatch(
-      /<h3>pending<\/h3><table>.*?<tr><td>QUE-104<\/td><td>queue-order<\/td><td>diagnose<\/td><td>pending<\/td><td>\d+ s ago<\/td><td>—<\/td><td>—<\/td><td><\/td><\/tr><tr><td>QUE-103<\/td>.*?<tr><td>QUE-105<\/td>.*?<tr><td>—<\/td><td>queue-order<\/td><td>drive<\/td><td>pending<\/td>.*?<h3>completed<\/h3>/s,
+      /<h3>pending<\/h3><table>.*?<tr><td>QUE-104<\/td><td>queue-order<\/td><td>diagnose<\/td><td>pending<\/td><td>\d+ s ago<\/td><td>—<\/td><td>—<\/td><td><\/td><td><\/td><\/tr><tr><td>QUE-103<\/td>.*?<tr><td>QUE-105<\/td>.*?<tr><td>—<\/td><td>queue-order<\/td><td>drive<\/td><td>pending<\/td>.*?<h3>completed<\/h3>/s,
     );
     expect(html).toMatch(
-      /<h3>completed<\/h3><table>.*?<tr><td>QUE-107<\/td><td>queue-order<\/td><td>drive<\/td><td>failed<\/td><td>\d+ min ago<\/td><td>\d+ min ago<\/td><td>1 min ago<\/td><td>session timed out<\/td><\/tr><tr><td>QUE-108<\/td>.*?<tr><td>QUE-106<\/td>.*?<tr><td>QUE-109<\/td>/s,
+      /<h3>completed<\/h3><table>.*?<tr><td>QUE-107<\/td><td>queue-order<\/td><td>drive<\/td><td>failed<\/td><td>\d+ min ago<\/td><td>\d+ min ago<\/td><td>1 min ago<\/td><td>session timed out<\/td><td><\/td><\/tr><tr><td>QUE-108<\/td>.*?<tr><td>QUE-106<\/td>.*?<tr><td>QUE-109<\/td>/s,
     );
     expect(html.indexOf("<h2>automation</h2>")).toBeLessThan(html.indexOf("<h2>qemu servers</h2>"));
     expect(html).toContain('<div id="fleet" hx-get="/servers/fleet" hx-trigger="every 30s">');

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -1017,7 +1017,7 @@ console.log([failed.test, failed.action, failed.reason, failed.createdAt instanc
     );
     // The ages are read against the database's clock: a minute has margin, seconds are counted.
     expect(html).toMatch(
-      /<tr><td>QUE-102<\/td><td>queue-order<\/td><td>diagnose<\/td><td>running<\/td><td>1 min ago<\/td><td>\d+ s ago<\/td><td>—<\/td><td><\/td><\/tr><tr><td>QUE-101<\/td><td>queue-order<\/td><td>drive<\/td><td>running<\/td><td>5 min ago<\/td><td>3 min ago<\/td><td>—<\/td><td><\/td><\/tr><\/table><h3>pending<\/h3>/,
+      /<tr><td>QUE-102<\/td><td>queue-order<\/td><td>diagnose<\/td><td>running<\/td><td>1 min ago<\/td><td>\d+ s ago<\/td><td>—<\/td><td><\/td><td><form method="post" action="\/abort" hx-post="\/abort" hx-target="#queue" hx-swap="innerHTML"><input type="hidden" name="ticket" value="QUE-102"\/><button>abort<\/button><\/form><\/td><\/tr><tr><td>QUE-101<\/td><td>queue-order<\/td><td>drive<\/td><td>running<\/td><td>5 min ago<\/td><td>3 min ago<\/td><td>—<\/td><td><\/td><td><form method="post" action="\/abort"/,
     );
     expect(html).toMatch(
       /<h3>pending<\/h3><table>.*?<tr><td>QUE-104<\/td><td>queue-order<\/td><td>diagnose<\/td><td>pending<\/td><td>\d+ s ago<\/td><td>—<\/td><td>—<\/td><td><\/td><\/tr><tr><td>QUE-103<\/td>.*?<tr><td>QUE-105<\/td>.*?<tr><td>—<\/td><td>queue-order<\/td><td>drive<\/td><td>pending<\/td>.*?<h3>completed<\/h3>/s,
@@ -1265,6 +1265,37 @@ describe.skipIf(dbUrl === "")("dashboard/query abortAutomationJob unhappy path",
 });
 
 describe("dashboard POST /abort happy path: the outbound call", () => {
+  it("posts a form ticket the same way the servers page abort button does", async () => {
+    const proxy = await StubProxy.startStubProxy(() => StubProxy.OK);
+    try {
+      const response = await app.request(
+        "/abort",
+        {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({ ticket: "ABT-FORM" }).toString(),
+        },
+        {
+          HYPERDRIVE: { connectionString: REFUSED_URL },
+          OLIGARCHY_TOKEN: TOKEN,
+          AUTOMATION_SERVER_URL: proxy.url,
+        },
+      );
+      expect(response.status).toBe(303);
+      expect(response.headers.get("location")).toBe("/servers");
+      expect(proxy.requests).toEqual([
+        {
+          method: "POST",
+          url: "/abort",
+          authorization: `Bearer ${TOKEN}`,
+          body: { ticket: "ABT-FORM" },
+        },
+      ]);
+    } finally {
+      await proxy.close();
+    }
+  });
+
   it("posts the ticket with the bearer and answers 200 when the automation server does", async () => {
     const proxy = await StubProxy.startStubProxy(() => StubProxy.OK);
     try {
@@ -1330,6 +1361,27 @@ describe("dashboard POST /abort unhappy path: always 200", () => {
     } finally {
       await proxy.close();
     }
+  });
+
+  it("answers the queue error fragment when htmx asks and the database is unreachable", async () => {
+    const response = await app.request(
+      "/abort",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "hx-request": "true",
+        },
+        body: "",
+      },
+      {
+        HYPERDRIVE: { connectionString: REFUSED_URL },
+        OLIGARCHY_TOKEN: TOKEN,
+        AUTOMATION_SERVER_URL: "http://127.0.0.1:1",
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("<p>error: internal error</p>");
   });
 
   it("answers 200 when the automation server is unreachable and the database is too", async () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,5 +21,8 @@
   ],
   "placement": {
     "region": "aws:us-east-1"
+  },
+  "vars": {
+    "AUTOMATION_SERVER_URL": "https://oligarchy-automation.trm.sh"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cloudflare `/abort` plus an abort control on the servers-page queue. Rebased onto latest `master` (definition duration charts from #120; JSON `/abort` from #119). Conflicts in the abort route were resolved by keeping the form/htmx path the red X uses.

## What
- `POST /abort` accepts JSON `{ ticket }` or a form `ticket` field.
- Worker calls the automation server `/abort` with the oligarchy bearer. On 200, done.
- On 4xx/5xx, hang past 10s, or unreachable, `abortAutomationJob` closes the running row (`status=aborted`, `reason=aborted`).
- JSON clients always get 200 `{ ok: "true" }`. Form posts without htmx 303 to `/servers`. htmx swaps `#queue`.
- Running ticketed jobs on `/servers` show a small red SVG X. Clicking it asks **are you sure?** (`hx-confirm`) before posting `/abort`. Pending, completed, and running-without-ticket rows stay button-less.

## Bindings
- `OLIGARCHY_TOKEN` — wrangler secret
- `AUTOMATION_SERVER_URL` — `https://oligarchy-automation.trm.sh`

## Test plan
- `npm run check:fast`
- Unit: missing ticket, Queue abort only on running+ticketed, red X + confirm text, hostile ticket escaped
- Integration: automation 200/400/500/unreachable/hang, finished row unchanged, form POST outbound, htmx fragment

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0911f-e3af-799f-8976-6b6c48abb91f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0911f-e3af-799f-8976-6b6c48abb91f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

