### PR TITLE
Refuse work when qemu-server or automation-client is at capacity

### DIFF
--- a/drizzle/0012_adorable_deathbird.sql
+++ b/drizzle/0012_adorable_deathbird.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "servers" ADD COLUMN "jobs" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "servers" ADD COLUMN "max_jobs" integer DEFAULT 1 NOT NULL;

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1298 @@
+{
+  "id": "a2ae0206-7e6b-410c-9d63-14bdd81302d5",
+  "prevId": "c08369c0-745e-43b2-8290-1dd24d29ece4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "actions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "action_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "actions_session_id_idx": {
+          "name": "actions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_session_id_sessions_id_fk": {
+          "name": "actions_session_id_sessions_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actions_agent_id_agent_runs_agent_id_fk": {
+          "name": "actions_agent_id_agent_runs_agent_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_runs_session_id_idx": {
+          "name": "agent_runs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_session_id_sessions_id_fk": {
+          "name": "agent_runs_session_id_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_jobs": {
+      "name": "automation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "automation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_jobs_result_action_idx": {
+          "name": "automation_jobs_result_action_idx",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_jobs_status_created_at_idx": {
+          "name": "automation_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_jobs_result_id_test_results_result_id_fk": {
+          "name": "automation_jobs_result_id_test_results_result_id_fk",
+          "tableFrom": "automation_jobs",
+          "tableTo": "test_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debug_logs_session_id_sessions_id_fk": {
+          "name": "debug_logs_session_id_sessions_id_fk",
+          "tableFrom": "debug_logs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "images_id_idx": {
+          "name": "images_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_action_id_actions_id_fk": {
+          "name": "images_action_id_actions_id_fk",
+          "tableFrom": "images",
+          "tableTo": "actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_location_idx": {
+          "name": "logs_location_idx",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_run_diagnosis": {
+      "name": "post_run_diagnosis",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "diagnosis_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_run_diagnosis_error_type_idx": {
+          "name": "post_run_diagnosis_error_type_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_run_diagnosis_session_id_sessions_id_fk": {
+          "name": "post_run_diagnosis_session_id_sessions_id_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_run_diagnosis_error_type_post_run_error_types_key_fk": {
+          "name": "post_run_diagnosis_error_type_post_run_error_types_key_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "post_run_error_types",
+          "columnsFrom": [
+            "error_type"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_run_diagnosis_verdict_error_type_check": {
+          "name": "post_run_diagnosis_verdict_error_type_check",
+          "value": "(\"post_run_diagnosis\".\"verdict\" = 'passed') = (\"post_run_diagnosis\".\"error_type\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_run_error_types": {
+      "name": "post_run_error_types",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servers": {
+      "name": "servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "server_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'qemu'"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jobs": {
+          "name": "jobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_jobs": {
+          "name": "max_jobs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "servers_id_unique": {
+          "name": "servers_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_servers": {
+      "name": "session_servers",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_servers_session_id_sessions_id_fk": {
+          "name": "session_servers_session_id_sessions_id_fk",
+          "tableFrom": "session_servers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_base_prompts": {
+      "name": "test_base_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_base_prompts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_base_prompts_name_idx": {
+          "name": "test_base_prompts_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_definitions": {
+      "name": "test_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_definitions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_definitions_name_idx": {
+          "name": "test_definitions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_results": {
+      "name": "test_results",
+      "schema": "",
+      "columns": {
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_id": {
+          "name": "linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "test_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_results_run_definition_idx": {
+          "name": "test_results_run_definition_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_session_id_idx": {
+          "name": "test_results_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_linear_id_idx": {
+          "name": "test_results_linear_id_idx",
+          "columns": [
+            {
+              "expression": "linear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_results_run_id_test_runs_id_fk": {
+          "name": "test_results_run_id_test_runs_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_definition_id_test_definitions_id_fk": {
+          "name": "test_results_definition_id_test_definitions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_session_id_sessions_id_fk": {
+          "name": "test_results_session_id_sessions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso": {
+          "name": "iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "test_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.action_state": {
+      "name": "action_state",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed"
+      ]
+    },
+    "public.automation_action": {
+      "name": "automation_action",
+      "schema": "public",
+      "values": [
+        "drive",
+        "diagnose"
+      ]
+    },
+    "public.automation_job_status": {
+      "name": "automation_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.diagnosis_verdict": {
+      "name": "diagnosis_verdict",
+      "schema": "public",
+      "values": [
+        "passed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.server_type": {
+      "name": "server_type",
+      "schema": "public",
+      "values": [
+        "qemu",
+        "automation-client"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_result_status": {
+      "name": "test_result_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_run_status": {
+      "name": "test_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1789151887921,
       "tag": "0011_volatile_sersi",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1789162235354,
+      "tag": "0012_adorable_deathbird",
+      "breakpoints": true
     }
   ]
 }

--- a/src/automation-client/command.ts
+++ b/src/automation-client/command.ts
@@ -10,13 +10,13 @@ import * as Errors from "../shared/errors.ts";
 
 // One above the automation server's, so both run on one host in development.
 const DEFAULT_PORT = 54322;
-const DEFAULT_JOBS = 1;
+const DEFAULT_MAX_JOBS = 1;
 
 export type AutomationClient<RServe> = {
   readonly serve: (
     port: number,
     url: Option.Option<string>,
-    jobs: number,
+    maxJobs: number,
   ) => Layer.Layer<never, HttpServerError.ServeError, RServe>;
   readonly serverFailed: Deferred.Deferred<never, HttpServerError.ServeError>;
 };
@@ -44,13 +44,13 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
           "Announce this client to the fleet under this url, every 30 seconds, and delete the row on shutdown",
         ),
       ),
-      jobs: Flag.integer("jobs").pipe(
-        Flag.withSchema(Domain.Jobs),
-        Flag.withDefault(DEFAULT_JOBS),
+      maxJobs: Flag.integer("max-jobs").pipe(
+        Flag.withSchema(Domain.MaxJobs),
+        Flag.withDefault(DEFAULT_MAX_JOBS),
         Flag.withDescription("How many jobs this process can run at once"),
       ),
     },
-    ({ port, url, jobs }) =>
+    ({ port, url, maxJobs }) =>
       Effect.gen(function* () {
         const log = yield* Log.Log;
         const database = yield* Client.Database;
@@ -65,7 +65,7 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
             ),
           );
           return yield* Effect.raceFirst(
-            Layer.launch(server.serve(port, url, jobs)),
+            Layer.launch(server.serve(port, url, maxJobs)),
             Deferred.await(server.serverFailed),
           );
         });

--- a/src/automation-client/command.ts
+++ b/src/automation-client/command.ts
@@ -10,11 +10,13 @@ import * as Errors from "../shared/errors.ts";
 
 // One above the automation server's, so both run on one host in development.
 const DEFAULT_PORT = 54322;
+const DEFAULT_JOBS = 1;
 
 export type AutomationClient<RServe> = {
   readonly serve: (
     port: number,
     url: Option.Option<string>,
+    jobs: number,
   ) => Layer.Layer<never, HttpServerError.ServeError, RServe>;
   readonly serverFailed: Deferred.Deferred<never, HttpServerError.ServeError>;
 };
@@ -42,8 +44,13 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
           "Announce this client to the fleet under this url, every 30 seconds, and delete the row on shutdown",
         ),
       ),
+      jobs: Flag.integer("jobs").pipe(
+        Flag.withSchema(Domain.Jobs),
+        Flag.withDefault(DEFAULT_JOBS),
+        Flag.withDescription("How many jobs this process can run at once"),
+      ),
     },
-    ({ port, url }) =>
+    ({ port, url, jobs }) =>
       Effect.gen(function* () {
         const log = yield* Log.Log;
         const database = yield* Client.Database;
@@ -58,7 +65,7 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
             ),
           );
           return yield* Effect.raceFirst(
-            Layer.launch(server.serve(port, url)),
+            Layer.launch(server.serve(port, url, jobs)),
             Deferred.await(server.serverFailed),
           );
         });

--- a/src/automation-client/heartbeat.ts
+++ b/src/automation-client/heartbeat.ts
@@ -28,6 +28,7 @@ const detail = (error: unknown): string =>
 // the process still exits.
 export const announce = (
   url: string,
+  maxJobs: number,
 ): Effect.Effect<void, never, Scope.Scope | Stats.Stats | Servers.ServerStore | Log.Log> =>
   Effect.gen(function* () {
     const stats = yield* Stats.Stats;
@@ -36,18 +37,24 @@ export const announce = (
     const tick = stats.collect(0).pipe(
       Effect.flatMap((collected) =>
         Effect.uninterruptible(
-          store.heartbeat(url, "automation-client", {
-            qemus: collected.qemus,
-            memory: {
-              totalBytes: collected.memory.totalBytes,
-              usedBytes: collected.memory.usedBytes,
+          store.heartbeat(
+            url,
+            "automation-client",
+            {
+              qemus: collected.qemus,
+              memory: {
+                totalBytes: collected.memory.totalBytes,
+                usedBytes: collected.memory.usedBytes,
+              },
+              cpu: {
+                mean1m: collected.cpu.mean1m,
+                mean2m: collected.cpu.mean2m,
+                mean3m: collected.cpu.mean3m,
+              },
             },
-            cpu: {
-              mean1m: collected.cpu.mean1m,
-              mean2m: collected.cpu.mean2m,
-              mean3m: collected.cpu.mean3m,
-            },
-          }),
+            collected.qemus,
+            maxJobs,
+          ),
         ),
       ),
       Effect.catchCause((cause) => {

--- a/src/automation-client/heartbeat.ts
+++ b/src/automation-client/heartbeat.ts
@@ -21,7 +21,7 @@ const detail = (error: unknown): string =>
 
 // Announces this process under `url`: its `servers` row is written now and every thirty seconds
 // as an automation-client, with the host's stats and qemus 0 — this process boots no guests —
-// jobs the size of the running map, and max_jobs the --jobs it was started with. The row's
+// jobs the size of the running map, and max_jobs the --max-jobs it was started with. The row's
 // generation counts the writes, so a number that stops moving is a client that stopped without
 // a chance to leave. A tick that fails is one error line; the next tick runs. The row is this
 // process's word on itself, so a shutdown deletes it: registered before the loop so the fiber

--- a/src/automation-client/heartbeat.ts
+++ b/src/automation-client/heartbeat.ts
@@ -21,7 +21,7 @@ const detail = (error: unknown): string =>
 
 // Announces this process under `url`: its `servers` row is written now and every thirty seconds
 // as an automation-client, with the host's stats and qemus 0 — this process boots no guests —
-// jobs the size of the running map, and max_jobs the --max-jobs it was started with. The row's
+// jobs the running count, and max_jobs the --max-jobs it was started with. The row's
 // generation counts the writes, so a number that stops moving is a client that stopped without
 // a chance to leave. A tick that fails is one error line; the next tick runs. The row is this
 // process's word on itself, so a shutdown deletes it: registered before the loop so the fiber

--- a/src/automation-client/heartbeat.ts
+++ b/src/automation-client/heartbeat.ts
@@ -5,6 +5,7 @@ import * as Log from "../observability/log.ts";
 import * as Render from "../observability/render.ts";
 import * as Stats from "../qemu/stats.ts";
 import * as Errors from "../shared/errors.ts";
+import * as Sessions from "./sessions.ts";
 
 // Every thirty seconds, and the dashboard polls as often: a client's row is never more than one
 // poll behind, and three missed writes are what the page calls silent.
@@ -20,43 +21,49 @@ const detail = (error: unknown): string =>
 
 // Announces this process under `url`: its `servers` row is written now and every thirty seconds
 // as an automation-client, with the host's stats and qemus 0 — this process boots no guests —
-// and the row's generation counts the writes, so a number that stops moving is a client that
-// stopped without a chance to leave. A tick that fails is one error line; the next tick runs.
-// The row is this process's word on itself, so a shutdown deletes it: registered before the
-// loop so the fiber is interrupted first, a write in flight finishes (the write is
-// uninterruptible), then the row goes. A delete that fails is one `unannounce failed` line;
-// the process still exits.
+// jobs the size of the running map, and max_jobs the --jobs it was started with. The row's
+// generation counts the writes, so a number that stops moving is a client that stopped without
+// a chance to leave. A tick that fails is one error line; the next tick runs. The row is this
+// process's word on itself, so a shutdown deletes it: registered before the loop so the fiber
+// is interrupted first, a write in flight finishes (the write is uninterruptible), then the
+// row goes. A delete that fails is one `unannounce failed` line; the process still exits.
 export const announce = (
   url: string,
   maxJobs: number,
-): Effect.Effect<void, never, Scope.Scope | Stats.Stats | Servers.ServerStore | Log.Log> =>
+): Effect.Effect<
+  void,
+  never,
+  Scope.Scope | Stats.Stats | Sessions.Sessions | Servers.ServerStore | Log.Log
+> =>
   Effect.gen(function* () {
     const stats = yield* Stats.Stats;
+    const sessions = yield* Sessions.Sessions;
     const store = yield* Servers.ServerStore;
     const log = yield* Log.Log;
-    const tick = stats.collect(0).pipe(
-      Effect.flatMap((collected) =>
-        Effect.uninterruptible(
-          store.heartbeat(
-            url,
-            "automation-client",
-            {
-              qemus: collected.qemus,
-              memory: {
-                totalBytes: collected.memory.totalBytes,
-                usedBytes: collected.memory.usedBytes,
-              },
-              cpu: {
-                mean1m: collected.cpu.mean1m,
-                mean2m: collected.cpu.mean2m,
-                mean3m: collected.cpu.mean3m,
-              },
+    const tick = Effect.gen(function* () {
+      const collected = yield* stats.collect(0);
+      const jobs = yield* sessions.jobs;
+      yield* Effect.uninterruptible(
+        store.heartbeat(
+          url,
+          "automation-client",
+          {
+            qemus: collected.qemus,
+            memory: {
+              totalBytes: collected.memory.totalBytes,
+              usedBytes: collected.memory.usedBytes,
             },
-            collected.qemus,
-            maxJobs,
-          ),
+            cpu: {
+              mean1m: collected.cpu.mean1m,
+              mean2m: collected.cpu.mean2m,
+              mean3m: collected.cpu.mean3m,
+            },
+          },
+          jobs,
+          maxJobs,
         ),
-      ),
+      );
+    }).pipe(
       Effect.catchCause((cause) => {
         const error = Cause.squash(cause);
         return log.error(`heartbeat failed: ${detail(error)}`, {

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -36,7 +36,7 @@ server.on("error", (cause) => {
 
 // The heartbeat starts once the listener is up, in the same scope: a port refusal announces
 // nothing, and a shutdown deletes the row it wrote.
-const ServerLive = (port: number, url: Option.Option<string>, jobs: number) =>
+const ServerLive = (port: number, url: Option.Option<string>, maxJobs: number) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const log = yield* Log.Log;
@@ -47,7 +47,7 @@ const ServerLive = (port: number, url: Option.Option<string>, jobs: number) =>
       );
       yield* Option.match(url, {
         onNone: () => Effect.void,
-        onSome: (announced) => Heartbeat.announce(announced, jobs),
+        onSome: (announced) => Heartbeat.announce(announced, maxJobs),
       });
     }),
   ).pipe(

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -58,6 +58,7 @@ const ServerLive = (port: number, url: Option.Option<string>, maxJobs: number) =
       }).pipe(Layer.provide(NodeHttpServer.layer(() => server, { host: HOST, port }))),
     ),
     Layer.provide(Sessions.Sessions.layer),
+    Layer.provide(Layer.succeed(Sessions.MaxJobs)(maxJobs)),
     Layer.provide(Stats.Stats.layer),
     Layer.provide(Layer.succeed(HttpMiddleware.TracerDisabledWhen)(() => true)),
   );

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -36,7 +36,7 @@ server.on("error", (cause) => {
 
 // The heartbeat starts once the listener is up, in the same scope: a port refusal announces
 // nothing, and a shutdown deletes the row it wrote.
-const ServerLive = (port: number, url: Option.Option<string>) =>
+const ServerLive = (port: number, url: Option.Option<string>, jobs: number) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const log = yield* Log.Log;
@@ -45,7 +45,10 @@ const ServerLive = (port: number, url: Option.Option<string>) =>
         `automation client listening on ${HOST}:${String(port)}${Option.match(url, { onNone: () => "", onSome: (announced) => `; announcing ${announced}` })}`,
         automationClientAttr,
       );
-      yield* Option.match(url, { onNone: () => Effect.void, onSome: Heartbeat.announce });
+      yield* Option.match(url, {
+        onNone: () => Effect.void,
+        onSome: (announced) => Heartbeat.announce(announced, jobs),
+      });
     }),
   ).pipe(
     Layer.provide(

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -4,6 +4,10 @@ import * as Cli from "../cli.ts";
 import * as Errors from "../shared/errors.ts";
 import * as OpenCode from "./opencode.ts";
 
+export const MaxJobs = Context.Reference<number>("@oligarchy/automation-client/sessions/MaxJobs", {
+  defaultValue: () => 1,
+});
+
 const mapWith = <V>(map: ReadonlyMap<string, V>, key: string, value: V): ReadonlyMap<string, V> =>
   new Map([...map, [key, value]]);
 
@@ -18,18 +22,37 @@ const make = Effect.gen(function* () {
     new Map(),
   );
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const maxJobs = yield* MaxJobs;
 
   const run = Effect.fn("Sessions.run")(function* (ticket: string, prompt: string) {
     return yield* Effect.scoped(
       Effect.gen(function* () {
+        const current = yield* Ref.get(running);
+        if (!current.has(ticket) && current.size >= maxJobs) {
+          return yield* Errors.AtCapacity.make({});
+        }
         const handle = yield* Cli.spawn(OpenCode.BIN, OpenCode.args(prompt));
-        const claimed = yield* Ref.modify(running, (map) =>
-          map.has(ticket)
-            ? ([false, map] as const)
-            : ([true, mapWith(map, ticket, handle)] as const),
-        );
-        if (!claimed) {
+        const claimed = yield* Ref.modify(running, (map) => {
+          if (map.has(ticket)) {
+            return ["duplicate", map] as const;
+          }
+          if (map.size >= maxJobs) {
+            return ["full", map] as const;
+          }
+          return ["ok", mapWith(map, ticket, handle)] as const;
+        });
+        if (claimed === "duplicate") {
           return yield* Effect.die(`ticket "${ticket}" is already running`);
+        }
+        if (claimed === "full") {
+          // The slot was never taken; a child already gone is fine.
+          yield* handle
+            .kill({
+              killSignal: "SIGTERM",
+              forceKillAfter: Cli.FORCE_KILL_AFTER,
+            })
+            .pipe(Effect.catch(() => Effect.void));
+          return yield* Errors.AtCapacity.make({});
         }
         yield* Effect.addFinalizer(() =>
           Ref.update(running, (map) =>
@@ -39,7 +62,11 @@ const make = Effect.gen(function* () {
         return yield* Cli.awaitExit(OpenCode.BIN, handle);
       }),
     ).pipe(
-      Effect.mapError((error) => Errors.RunFailed.make({ message: error.message, cause: error })),
+      Effect.catch((error) =>
+        error._tag === "AtCapacity"
+          ? Effect.fail(error)
+          : Effect.fail(Errors.RunFailed.make({ message: error.message, cause: error })),
+      ),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
     );
   });

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -25,12 +25,12 @@ const make = Effect.gen(function* () {
   const maxJobs = yield* MaxJobs;
 
   const run = Effect.fn("Sessions.run")(function* (ticket: string, prompt: string) {
-    return yield* Effect.scoped(
+    const current = yield* Ref.get(running);
+    if (!current.has(ticket) && current.size >= maxJobs) {
+      return yield* Errors.AtCapacity.make({});
+    }
+    const outcome = yield* Effect.scoped(
       Effect.gen(function* () {
-        const current = yield* Ref.get(running);
-        if (!current.has(ticket) && current.size >= maxJobs) {
-          return yield* Errors.AtCapacity.make({});
-        }
         const handle = yield* Cli.spawn(OpenCode.BIN, OpenCode.args(prompt));
         const claimed = yield* Ref.modify(running, (map) => {
           if (map.has(ticket)) {
@@ -51,24 +51,25 @@ const make = Effect.gen(function* () {
               killSignal: "SIGTERM",
               forceKillAfter: Cli.FORCE_KILL_AFTER,
             })
-            .pipe(Effect.catch(() => Effect.void));
-          return yield* Errors.AtCapacity.make({});
+            .pipe(Effect.orElseSucceed(() => undefined));
+          return "full" as const;
         }
         yield* Effect.addFinalizer(() =>
           Ref.update(running, (map) =>
             map.get(ticket) === handle ? mapWithout(map, ticket) : map,
           ),
         );
-        return yield* Cli.awaitExit(OpenCode.BIN, handle);
+        yield* Cli.awaitExit(OpenCode.BIN, handle);
+        return "ok" as const;
       }),
     ).pipe(
-      Effect.catch((error) =>
-        error._tag === "AtCapacity"
-          ? Effect.fail(error)
-          : Effect.fail(Errors.RunFailed.make({ message: error.message, cause: error })),
-      ),
+      Effect.mapError((error) => Errors.RunFailed.make({ message: error.message, cause: error })),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
     );
+    if (outcome === "full") {
+      return yield* Errors.AtCapacity.make({});
+    }
+    return yield* Effect.void;
   });
 
   const abort = Effect.fn("Sessions.abort")(function* (ticket: string) {

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -17,66 +17,78 @@ const mapWithout = <V>(map: ReadonlyMap<string, V>, key: string): ReadonlyMap<st
   return next;
 };
 
+type Entry = ChildProcessSpawner.ChildProcessHandle | "starting";
+
 const make = Effect.gen(function* () {
-  const running = yield* Ref.make<ReadonlyMap<string, ChildProcessSpawner.ChildProcessHandle>>(
-    new Map(),
-  );
+  const running = yield* Ref.make<ReadonlyMap<string, Entry>>(new Map());
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const maxJobs = yield* MaxJobs;
 
   const run = Effect.fn("Sessions.run")(function* (ticket: string, prompt: string) {
-    const current = yield* Ref.get(running);
-    if (!current.has(ticket) && current.size >= maxJobs) {
+    const reserved = yield* Ref.modify(running, (map) => {
+      if (map.has(ticket)) {
+        return ["duplicate", map] as const;
+      }
+      if (map.size >= maxJobs) {
+        return ["full", map] as const;
+      }
+      return ["ok", mapWith(map, ticket, "starting")] as const;
+    });
+    if (reserved === "full") {
       return yield* Errors.AtCapacity.make({});
     }
-    const outcome = yield* Effect.scoped(
+    if (reserved === "duplicate") {
+      return yield* Effect.die(`ticket "${ticket}" is already running`);
+    }
+    return yield* Effect.scoped(
       Effect.gen(function* () {
         const handle = yield* Cli.spawn(OpenCode.BIN, OpenCode.args(prompt));
-        const claimed = yield* Ref.modify(running, (map) => {
-          if (map.has(ticket)) {
-            return ["duplicate", map] as const;
-          }
-          if (map.size >= maxJobs) {
-            return ["full", map] as const;
-          }
-          return ["ok", mapWith(map, ticket, handle)] as const;
-        });
-        if (claimed === "duplicate") {
-          return yield* Effect.die(`ticket "${ticket}" is already running`);
-        }
-        if (claimed === "full") {
-          // The slot was never taken; a child already gone is fine.
+        const claimed = yield* Ref.modify(running, (map) =>
+          map.get(ticket) === "starting"
+            ? ([true, mapWith(map, ticket, handle)] as const)
+            : ([false, map] as const),
+        );
+        if (!claimed) {
+          // Aborted while starting; the slot is already gone.
           yield* handle
             .kill({
               killSignal: "SIGTERM",
               forceKillAfter: Cli.FORCE_KILL_AFTER,
             })
             .pipe(Effect.orElseSucceed(() => undefined));
-          return "full" as const;
+          return yield* Effect.void;
         }
         yield* Effect.addFinalizer(() =>
           Ref.update(running, (map) =>
             map.get(ticket) === handle ? mapWithout(map, ticket) : map,
           ),
         );
-        yield* Cli.awaitExit(OpenCode.BIN, handle);
-        return "ok" as const;
+        return yield* Cli.awaitExit(OpenCode.BIN, handle);
       }),
     ).pipe(
       Effect.mapError((error) => Errors.RunFailed.make({ message: error.message, cause: error })),
+      // A spawn that failed still holds "starting"; drop it so the slot can be reused.
+      Effect.ensuring(
+        Ref.update(running, (map) =>
+          map.get(ticket) === "starting" ? mapWithout(map, ticket) : map,
+        ),
+      ),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
     );
-    if (outcome === "full") {
-      return yield* Errors.AtCapacity.make({});
-    }
-    return yield* Effect.void;
   });
 
   const abort = Effect.fn("Sessions.abort")(function* (ticket: string) {
-    const handle = (yield* Ref.get(running)).get(ticket);
-    if (handle === undefined) {
+    const entry = (yield* Ref.get(running)).get(ticket);
+    if (entry === undefined) {
       return yield* Errors.unknownSession(ticket, ticket);
     }
+    if (entry === "starting") {
+      yield* Ref.update(running, (map) =>
+        map.get(ticket) === "starting" ? mapWithout(map, ticket) : map,
+      );
+      return yield* Effect.void;
+    }
+    const handle = entry;
     return yield* handle
       .kill({
         killSignal: "SIGTERM",

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -65,7 +65,9 @@ const make = Effect.gen(function* () {
       );
   });
 
-  return { run, abort };
+  const jobs = Effect.map(Ref.get(running), (map) => map.size);
+
+  return { run, abort, jobs };
 });
 
 export class Sessions extends Context.Service<Sessions>()("@oligarchy/automation-client/Sessions", {

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -17,46 +17,32 @@ const mapWithout = <V>(map: ReadonlyMap<string, V>, key: string): ReadonlyMap<st
   return next;
 };
 
-type Entry = ChildProcessSpawner.ChildProcessHandle | "starting";
-
 const make = Effect.gen(function* () {
-  const running = yield* Ref.make<ReadonlyMap<string, Entry>>(new Map());
+  const running = yield* Ref.make<ReadonlyMap<string, ChildProcessSpawner.ChildProcessHandle>>(
+    new Map(),
+  );
+  const jobs = yield* Ref.make(0);
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const maxJobs = yield* MaxJobs;
 
   const run = Effect.fn("Sessions.run")(function* (ticket: string, prompt: string) {
-    const reserved = yield* Ref.modify(running, (map) => {
-      if (map.has(ticket)) {
-        return ["duplicate", map] as const;
-      }
-      if (map.size >= maxJobs) {
-        return ["full", map] as const;
-      }
-      return ["ok", mapWith(map, ticket, "starting")] as const;
-    });
-    if (reserved === "full") {
+    const reserved = yield* Ref.modify(jobs, (n) =>
+      n >= maxJobs ? ([false, n] as const) : ([true, n + 1] as const),
+    );
+    if (!reserved) {
       return yield* Errors.AtCapacity.make({});
-    }
-    if (reserved === "duplicate") {
-      return yield* Effect.die(`ticket "${ticket}" is already running`);
     }
     return yield* Effect.scoped(
       Effect.gen(function* () {
+        yield* Effect.addFinalizer(() => Ref.update(jobs, (n) => n - 1));
         const handle = yield* Cli.spawn(OpenCode.BIN, OpenCode.args(prompt));
         const claimed = yield* Ref.modify(running, (map) =>
-          map.get(ticket) === "starting"
-            ? ([true, mapWith(map, ticket, handle)] as const)
-            : ([false, map] as const),
+          map.has(ticket)
+            ? ([false, map] as const)
+            : ([true, mapWith(map, ticket, handle)] as const),
         );
         if (!claimed) {
-          // Aborted while starting; the slot is already gone.
-          yield* handle
-            .kill({
-              killSignal: "SIGTERM",
-              forceKillAfter: Cli.FORCE_KILL_AFTER,
-            })
-            .pipe(Effect.orElseSucceed(() => undefined));
-          return yield* Effect.void;
+          return yield* Effect.die(`ticket "${ticket}" is already running`);
         }
         yield* Effect.addFinalizer(() =>
           Ref.update(running, (map) =>
@@ -67,28 +53,15 @@ const make = Effect.gen(function* () {
       }),
     ).pipe(
       Effect.mapError((error) => Errors.RunFailed.make({ message: error.message, cause: error })),
-      // A spawn that failed still holds "starting"; drop it so the slot can be reused.
-      Effect.ensuring(
-        Ref.update(running, (map) =>
-          map.get(ticket) === "starting" ? mapWithout(map, ticket) : map,
-        ),
-      ),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
     );
   });
 
   const abort = Effect.fn("Sessions.abort")(function* (ticket: string) {
-    const entry = (yield* Ref.get(running)).get(ticket);
-    if (entry === undefined) {
+    const handle = (yield* Ref.get(running)).get(ticket);
+    if (handle === undefined) {
       return yield* Errors.unknownSession(ticket, ticket);
     }
-    if (entry === "starting") {
-      yield* Ref.update(running, (map) =>
-        map.get(ticket) === "starting" ? mapWithout(map, ticket) : map,
-      );
-      return yield* Effect.void;
-    }
-    const handle = entry;
     return yield* handle
       .kill({
         killSignal: "SIGTERM",
@@ -105,9 +78,7 @@ const make = Effect.gen(function* () {
       );
   });
 
-  const jobs = Effect.map(Ref.get(running), (map) => map.size);
-
-  return { run, abort, jobs };
+  return { run, abort, jobs: Ref.get(jobs) };
 });
 
 export class Sessions extends Context.Service<Sessions>()("@oligarchy/automation-client/Sessions", {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -209,7 +209,7 @@ export type ServerStats = {
 // other kind: same heartbeat, listed apart from the qemu fleet. id is the stable handle a
 // job stores when it is claimed; url remains the key a heartbeat upserts on. jobs is how many
 // are running now (a qemu server's live sessions, an automation-client's in-flight runs);
-// max_jobs is the --jobs the process was started with. Both are 0 and 1 until a heartbeat
+// max_jobs is the --max-jobs the process was started with. Both are 0 and 1 until a heartbeat
 // writes them, including a row an operator added.
 export const servers = pgTable("servers", {
   id: uuid("id").notNull().defaultRandom().unique(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,6 +4,7 @@ import {
   check,
   customType,
   index,
+  integer,
   jsonb,
   pgEnum,
   pgTable,
@@ -206,12 +207,17 @@ export type ServerStats = {
 // every writer names it, and the default is what the migration filled the rows that predate
 // the column with — qemu servers were the only kind there was. automation-client is the
 // other kind: same heartbeat, listed apart from the qemu fleet. id is the stable handle a
-// job stores when it is claimed; url remains the key a heartbeat upserts on.
+// job stores when it is claimed; url remains the key a heartbeat upserts on. jobs is how many
+// are running now (a qemu server's live sessions, an automation-client's in-flight runs);
+// max_jobs is the --jobs the process was started with. Both are 0 and 1 until a heartbeat
+// writes them, including a row an operator added.
 export const servers = pgTable("servers", {
   id: uuid("id").notNull().defaultRandom().unique(),
   url: text("url").primaryKey(),
   type: serverType("type").notNull().default("qemu"),
   stats: jsonb("stats").$type<ServerStats>(),
+  jobs: integer("jobs").notNull().default(0),
+  maxJobs: integer("max_jobs").notNull().default(1),
   generation: bigint("generation", { mode: "number" }).notNull().default(0),
   heartbeatAt: timestamp("heartbeat_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/src/db/servers.ts
+++ b/src/db/servers.ts
@@ -29,17 +29,21 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       url: string,
       type: ServerType,
       stats: DbSchema.ServerStats,
+      jobs: number,
+      maxJobs: number,
     ) {
       const now = sql`now()`;
       yield* database.run("heartbeat", (db) =>
         db
           .insert(DbSchema.servers)
-          .values({ url, type, stats, generation: 1, heartbeatAt: now })
+          .values({ url, type, stats, jobs, maxJobs, generation: 1, heartbeatAt: now })
           .onConflictDoUpdate({
             target: DbSchema.servers.url,
             set: {
               type,
               stats,
+              jobs,
+              maxJobs,
               generation: sql`${DbSchema.servers.generation} + 1`,
               heartbeatAt: now,
             },

--- a/src/qemu-server/command.ts
+++ b/src/qemu-server/command.ts
@@ -10,6 +10,7 @@ import * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 
 const DEFAULT_PORT = 42069;
+const DEFAULT_JOBS = 1;
 
 // What main.ts hands the command: the host check, the server as a layer for a display, an
 // automation flag, a port and the url it announces itself under (none: it stays out of the
@@ -23,6 +24,7 @@ export type QemuServer<RHost, RServe> = {
     automation: boolean,
     port: number,
     url: Option.Option<string>,
+    jobs: number,
   ) => Layer.Layer<never, HttpServerError.ServeError, RServe>;
   readonly serverFailed: Deferred.Deferred<never, HttpServerError.ServeError>;
 };
@@ -64,8 +66,13 @@ export const makeQemuServerCommand = <RHost, RServe>(server: QemuServer<RHost, R
           "Announce this server to the fleet under this url, every 30 seconds, and delete the row on shutdown",
         ),
       ),
+      jobs: Flag.integer("jobs").pipe(
+        Flag.withSchema(Domain.Jobs),
+        Flag.withDefault(DEFAULT_JOBS),
+        Flag.withDescription("How many jobs this process can run at once"),
+      ),
     },
-    ({ display, automation, port, url }) =>
+    ({ display, automation, port, url, jobs }) =>
       Effect.gen(function* () {
         if (automation && Option.isSome(display)) {
           return yield* new CliError.UserError({
@@ -92,7 +99,7 @@ export const makeQemuServerCommand = <RHost, RServe>(server: QemuServer<RHost, R
             ),
           );
           return yield* Effect.raceFirst(
-            Layer.launch(server.serve(resolved, automation, port, url)),
+            Layer.launch(server.serve(resolved, automation, port, url, jobs)),
             Deferred.await(server.serverFailed),
           );
         });

--- a/src/qemu-server/command.ts
+++ b/src/qemu-server/command.ts
@@ -10,7 +10,7 @@ import * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 
 const DEFAULT_PORT = 42069;
-const DEFAULT_JOBS = 1;
+const DEFAULT_MAX_JOBS = 1;
 
 // What main.ts hands the command: the host check, the server as a layer for a display, an
 // automation flag, a port and the url it announces itself under (none: it stays out of the
@@ -24,7 +24,7 @@ export type QemuServer<RHost, RServe> = {
     automation: boolean,
     port: number,
     url: Option.Option<string>,
-    jobs: number,
+    maxJobs: number,
   ) => Layer.Layer<never, HttpServerError.ServeError, RServe>;
   readonly serverFailed: Deferred.Deferred<never, HttpServerError.ServeError>;
 };
@@ -66,13 +66,13 @@ export const makeQemuServerCommand = <RHost, RServe>(server: QemuServer<RHost, R
           "Announce this server to the fleet under this url, every 30 seconds, and delete the row on shutdown",
         ),
       ),
-      jobs: Flag.integer("jobs").pipe(
-        Flag.withSchema(Domain.Jobs),
-        Flag.withDefault(DEFAULT_JOBS),
+      maxJobs: Flag.integer("max-jobs").pipe(
+        Flag.withSchema(Domain.MaxJobs),
+        Flag.withDefault(DEFAULT_MAX_JOBS),
         Flag.withDescription("How many jobs this process can run at once"),
       ),
     },
-    ({ display, automation, port, url, jobs }) =>
+    ({ display, automation, port, url, maxJobs }) =>
       Effect.gen(function* () {
         if (automation && Option.isSome(display)) {
           return yield* new CliError.UserError({
@@ -99,7 +99,7 @@ export const makeQemuServerCommand = <RHost, RServe>(server: QemuServer<RHost, R
             ),
           );
           return yield* Effect.raceFirst(
-            Layer.launch(server.serve(resolved, automation, port, url, jobs)),
+            Layer.launch(server.serve(resolved, automation, port, url, maxJobs)),
             Deferred.await(server.serverFailed),
           );
         });

--- a/src/qemu-server/heartbeat.ts
+++ b/src/qemu-server/heartbeat.ts
@@ -27,6 +27,7 @@ const detail = (error: unknown): string =>
 // goes. A delete that fails is one `unannounce failed` line; the process still exits.
 export const announce = (
   url: string,
+  maxJobs: number,
 ): Effect.Effect<void, never, Scope.Scope | Sessions.Sessions | Servers.ServerStore | Log.Log> =>
   Effect.gen(function* () {
     const sessions = yield* Sessions.Sessions;
@@ -35,11 +36,17 @@ export const announce = (
     const tick = sessions.stats.pipe(
       Effect.flatMap((stats) =>
         Effect.uninterruptible(
-          store.heartbeat(url, "qemu", {
-            qemus: stats.qemus,
-            memory: { totalBytes: stats.memory.totalBytes, usedBytes: stats.memory.usedBytes },
-            cpu: { mean1m: stats.cpu.mean1m, mean2m: stats.cpu.mean2m, mean3m: stats.cpu.mean3m },
-          }),
+          store.heartbeat(
+            url,
+            "qemu",
+            {
+              qemus: stats.qemus,
+              memory: { totalBytes: stats.memory.totalBytes, usedBytes: stats.memory.usedBytes },
+              cpu: { mean1m: stats.cpu.mean1m, mean2m: stats.cpu.mean2m, mean3m: stats.cpu.mean3m },
+            },
+            stats.qemus,
+            maxJobs,
+          ),
         ),
       ),
       Effect.catchCause((cause) => {

--- a/src/qemu-server/main.ts
+++ b/src/qemu-server/main.ts
@@ -53,7 +53,7 @@ const ServerLive = (
   automation: boolean,
   port: number,
   url: Option.Option<string>,
-  jobs: number,
+  maxJobs: number,
 ) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
@@ -64,7 +64,7 @@ const ServerLive = (
       );
       yield* Option.match(url, {
         onNone: () => Effect.void,
-        onSome: (announced) => Heartbeat.announce(announced, jobs),
+        onSome: (announced) => Heartbeat.announce(announced, maxJobs),
       });
     }),
   ).pipe(

--- a/src/qemu-server/main.ts
+++ b/src/qemu-server/main.ts
@@ -53,6 +53,7 @@ const ServerLive = (
   automation: boolean,
   port: number,
   url: Option.Option<string>,
+  jobs: number,
 ) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
@@ -61,7 +62,10 @@ const ServerLive = (
         `qemu server listening on ${HOST}:${String(port)}; display ${display}${automation ? "; automation" : ""}${Option.match(url, { onNone: () => "", onSome: (announced) => `; announcing ${announced}` })}`,
         { location: Log.Locations.server },
       );
-      yield* Option.match(url, { onNone: () => Effect.void, onSome: Heartbeat.announce });
+      yield* Option.match(url, {
+        onNone: () => Effect.void,
+        onSome: (announced) => Heartbeat.announce(announced, jobs),
+      });
     }),
   ).pipe(
     Layer.provide(

--- a/src/qemu-server/main.ts
+++ b/src/qemu-server/main.ts
@@ -75,6 +75,7 @@ const ServerLive = (
       }),
     ),
     Layer.provide(Sessions.Sessions.layer),
+    Layer.provide(Layer.succeed(Sessions.MaxJobs)(maxJobs)),
     Layer.provide(Layer.succeed(Sessions.Shutdown)(shutdown)),
     Layer.provide(Layer.mergeAll(Qemu.Qemu.layer, Iso.Iso.layer, Stats.Stats.layer)),
     // Bound before Sessions exists: a port refusal is one fatal line, never a drain.

--- a/src/qemu-server/middleware.ts
+++ b/src/qemu-server/middleware.ts
@@ -41,6 +41,7 @@ const isApiError: (value: unknown) => value is Errors.ApiError = Schema.is(
     Errors.Internal,
     Errors.ServerFailed,
     Errors.NoServer,
+    Errors.AtCapacity,
     Errors.RunFailed,
   ]),
 );
@@ -63,6 +64,7 @@ const attribution = (error: Errors.ApiError, fallback: Log.ProcessAttribution): 
     case "Unauthorized":
     case "NotFound":
     case "RunFailed":
+    case "AtCapacity":
       return fallback;
     case "Forbidden":
       return { location: error.sessionId, agentId: error.agentId };
@@ -111,8 +113,9 @@ const detail = (error: Errors.ApiError): string =>
     : error.message;
 
 // A refusal (< 500) is the caller's problem and skips Sentry; a failure carries its cause there.
+// AtCapacity is 503 (try later) but is still a refusal of work, not a defect.
 const report = (error: Errors.ApiError, fallback: Log.ProcessAttribution): Log.Report =>
-  Errors.apiStatus(error) < 500
+  error._tag === "AtCapacity" || Errors.apiStatus(error) < 500
     ? { ...attribution(error, fallback), skipSentry: true }
     : {
         ...attribution(error, fallback),

--- a/src/qemu-server/middleware.ts
+++ b/src/qemu-server/middleware.ts
@@ -113,9 +113,8 @@ const detail = (error: Errors.ApiError): string =>
     : error.message;
 
 // A refusal (< 500) is the caller's problem and skips Sentry; a failure carries its cause there.
-// AtCapacity is 503 (try later) but is still a refusal of work, not a defect.
 const report = (error: Errors.ApiError, fallback: Log.ProcessAttribution): Log.Report =>
-  error._tag === "AtCapacity" || Errors.apiStatus(error) < 500
+  Errors.apiStatus(error) < 500
     ? { ...attribution(error, fallback), skipSentry: true }
     : {
         ...attribution(error, fallback),

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -77,7 +77,7 @@ export type SessionsService = {
     body: Contract.StartBody,
     display: Domain.QemuDisplay,
     automation: boolean,
-  ) => Effect.Effect<string, Errors.StartFailed | Errors.Internal>;
+  ) => Effect.Effect<string, Errors.StartFailed | Errors.AtCapacity | Errors.Internal>;
   // Resets lastCommandAt before returning: a valid request counts as activity.
   readonly lookup: (
     id: string,
@@ -133,6 +133,10 @@ export const Shutdown = Context.Reference<Shutdown>("@oligarchy/qemu-server/sess
     reason: MutableRef.make(SHUTDOWN_REASON),
     failed: MutableRef.make(false),
   }),
+});
+
+export const MaxJobs = Context.Reference<number>("@oligarchy/qemu-server/sessions/MaxJobs", {
+  defaultValue: () => 1,
 });
 
 const isDatabaseError = Schema.is(Errors.DatabaseError);
@@ -194,6 +198,7 @@ const make = Effect.gen(function* () {
   const log = yield* Log.Log;
   const fs = yield* FileSystem.FileSystem;
   const shutdown = yield* Shutdown;
+  const maxJobs = yield* MaxJobs;
 
   // Running machines, by id; and every session this qemu server holds, booting ones included.
   const sessions = yield* Ref.make<ReadonlyMap<string, LiveSession>>(new Map());
@@ -424,6 +429,9 @@ const make = Effect.gen(function* () {
     display: Domain.QemuDisplay,
     automation: boolean,
   ) {
+    if ((yield* Ref.get(openSessions)).size >= maxJobs) {
+      return yield* Errors.AtCapacity.make({});
+    }
     const started = yield* Clock.currentTimeMillis;
     const id: string = crypto.randomUUID();
     const agent = body.agent;
@@ -439,7 +447,15 @@ const make = Effect.gen(function* () {
       actionSeq: yield* Ref.make(0),
       actionSpans: yield* Ref.make<ReadonlySet<Tracer.Span>>(new Set()),
     };
-    yield* Ref.update(openSessions, (map) => mapWith(map, id, live));
+    const reserved = yield* Ref.modify(openSessions, (map) =>
+      map.size >= maxJobs ? ([false, map] as const) : ([true, mapWith(map, id, live)] as const),
+    );
+    if (!reserved) {
+      // Never entered the map: drop the unused scope and span rather than finish a session.
+      yield* Scope.close(live.scope, Exit.void);
+      yield* Sentry.endSessionSpan(live.span, "aborted");
+      return yield* Errors.AtCapacity.make({});
+    }
     yield* log.acquireColor(agent);
     const disk = body.disk;
     yield* sessionStore

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -203,6 +203,7 @@ const make = Effect.gen(function* () {
   // Running machines, by id; and every session this qemu server holds, booting ones included.
   const sessions = yield* Ref.make<ReadonlyMap<string, LiveSession>>(new Map());
   const openSessions = yield* Ref.make<ReadonlyMap<string, OpenSession>>(new Map());
+  const jobs = yield* Ref.make(0);
 
   const elapsed = (started: number) =>
     Effect.map(Clock.currentTimeMillis, (now) => String(now - started));
@@ -339,6 +340,7 @@ const make = Effect.gen(function* () {
   ): Effect.Effect<void> =>
     Effect.gen(function* () {
       yield* Ref.update(openSessions, (map) => mapWithout(map, [live.id]));
+      yield* Ref.update(jobs, (n) => n - 1);
       yield* log.releaseColor(live.agent);
       for (const span of yield* Ref.get(live.actionSpans)) {
         yield* settleActionSpan(live, span, "failed");
@@ -429,7 +431,10 @@ const make = Effect.gen(function* () {
     display: Domain.QemuDisplay,
     automation: boolean,
   ) {
-    if ((yield* Ref.get(openSessions)).size >= maxJobs) {
+    const reserved = yield* Ref.modify(jobs, (n) =>
+      n >= maxJobs ? ([false, n] as const) : ([true, n + 1] as const),
+    );
+    if (!reserved) {
       return yield* Errors.AtCapacity.make({});
     }
     const started = yield* Clock.currentTimeMillis;
@@ -447,15 +452,7 @@ const make = Effect.gen(function* () {
       actionSeq: yield* Ref.make(0),
       actionSpans: yield* Ref.make<ReadonlySet<Tracer.Span>>(new Set()),
     };
-    const reserved = yield* Ref.modify(openSessions, (map) =>
-      map.size >= maxJobs ? ([false, map] as const) : ([true, mapWith(map, id, live)] as const),
-    );
-    if (!reserved) {
-      // Never entered the map: drop the unused scope and span rather than finish a session.
-      yield* Scope.close(live.scope, Exit.void);
-      yield* Sentry.endSessionSpan(live.span, "aborted");
-      return yield* Errors.AtCapacity.make({});
-    }
+    yield* Ref.update(openSessions, (map) => mapWith(map, id, live));
     yield* log.acquireColor(agent);
     const disk = body.disk;
     yield* sessionStore

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -46,7 +46,7 @@ const png = Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array({ contentType: "im
 export const start = HttpApiEndpoint.post("start", "/start", {
   payload: Contract.StartBody,
   success: Contract.StartResponse,
-  error: Errors.StartFailedWire,
+  error: [Errors.StartFailedWire, Errors.AtCapacityWire],
 });
 
 export const image = HttpApiEndpoint.get("image", "/image", {
@@ -176,7 +176,7 @@ export class Linear extends HttpApiGroup.make("Linear").add(linear).middleware(A
 export const run = HttpApiEndpoint.post("run", "/run", {
   payload: Contract.RunBody,
   success: Contract.Ok,
-  error: Errors.RunFailedWire,
+  error: [Errors.RunFailedWire, Errors.AtCapacityWire],
 });
 
 export const abort = HttpApiEndpoint.post("abort", "/abort", {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -135,6 +135,11 @@ export const isIsoUrl = (iso: string): boolean =>
 
 // A server the reverse proxy forwards to, as an operator registers it: an http(s) url with a
 // host, used exactly as given, as --server-url is.
+export const Jobs = Schema.Number.check(
+  Schema.isGreaterThanOrEqualTo(1, { message: "jobs must be at least 1" }),
+).annotate({ identifier: "@oligarchy/shared/domain/Jobs" });
+export type Jobs = typeof Jobs.Type;
+
 export const ServerUrl = Schema.String.check(
   Schema.makeFilter(
     (value: string) => {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -133,13 +133,13 @@ export type DiagnosisVerdict = typeof DiagnosisVerdict.Type;
 export const isIsoUrl = (iso: string): boolean =>
   iso.startsWith("http://") || iso.startsWith("https://");
 
-// A server the reverse proxy forwards to, as an operator registers it: an http(s) url with a
-// host, used exactly as given, as --server-url is.
 export const Jobs = Schema.Number.check(
   Schema.isGreaterThanOrEqualTo(1, { message: "jobs must be at least 1" }),
 ).annotate({ identifier: "@oligarchy/shared/domain/Jobs" });
 export type Jobs = typeof Jobs.Type;
 
+// A server the reverse proxy forwards to, as an operator registers it: an http(s) url with a
+// host, used exactly as given, as --server-url is.
 export const ServerUrl = Schema.String.check(
   Schema.makeFilter(
     (value: string) => {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -133,10 +133,10 @@ export type DiagnosisVerdict = typeof DiagnosisVerdict.Type;
 export const isIsoUrl = (iso: string): boolean =>
   iso.startsWith("http://") || iso.startsWith("https://");
 
-export const Jobs = Schema.Number.check(
-  Schema.isGreaterThanOrEqualTo(1, { message: "jobs must be at least 1" }),
-).annotate({ identifier: "@oligarchy/shared/domain/Jobs" });
-export type Jobs = typeof Jobs.Type;
+export const MaxJobs = Schema.Number.check(
+  Schema.isGreaterThanOrEqualTo(1, { message: "max-jobs must be at least 1" }),
+).annotate({ identifier: "@oligarchy/shared/domain/MaxJobs" });
+export type MaxJobs = typeof MaxJobs.Type;
 
 // A server the reverse proxy forwards to, as an operator registers it: an http(s) url with a
 // host, used exactly as given, as --server-url is.

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -148,6 +148,13 @@ export class NoServer extends Schema.TaggedError<NoServer>("@oligarchy/shared/er
   override readonly [ErrorReporter.ignore] = true;
 }
 
+// This process is already running as many jobs as --max-jobs allows; the caller should try later.
+export class AtCapacity extends Schema.TaggedError<AtCapacity>(
+  "@oligarchy/shared/errors/AtCapacity",
+)("AtCapacity", { message: fixedMessage("at capacity; try later") }, { httpApiStatus: 503 }) {
+  override readonly [ErrorReporter.ignore] = true;
+}
+
 export class RunFailed extends Schema.TaggedError<RunFailed>("@oligarchy/shared/errors/RunFailed")(
   "RunFailed",
   { message: Schema.String, cause: Schema.optionalKey(Schema.Defect()) },
@@ -168,6 +175,7 @@ export type ApiError =
   | Internal
   | ServerFailed
   | NoServer
+  | AtCapacity
   | RunFailed;
 
 const resolveHttpApiStatus = SchemaAST.resolveAt("httpApiStatus");
@@ -191,6 +199,7 @@ const apiErrorClasses = {
   Internal,
   ServerFailed,
   NoServer,
+  AtCapacity,
   RunFailed,
 } satisfies Record<ApiError["_tag"], Schema.Top>;
 
@@ -258,6 +267,10 @@ export const ServerFailedWire = wireError(
 export const NoServerWire = wireError(
   NoServer,
   (message) => ({ _tag: "NoServer", message }) as const,
+);
+export const AtCapacityWire = wireError(
+  AtCapacity,
+  () => ({ _tag: "AtCapacity", message: "at capacity; try later" }) as const,
 );
 export const RunFailedWire = wireError(
   RunFailed,

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -149,9 +149,10 @@ export class NoServer extends Schema.TaggedError<NoServer>("@oligarchy/shared/er
 }
 
 // This process is already running as many jobs as --max-jobs allows; the caller should try later.
+// 429, not 503: /start already uses 503 for NoServer, and the wire codec keys on status.
 export class AtCapacity extends Schema.TaggedError<AtCapacity>(
   "@oligarchy/shared/errors/AtCapacity",
-)("AtCapacity", { message: fixedMessage("at capacity; try later") }, { httpApiStatus: 503 }) {
+)("AtCapacity", { message: fixedMessage("at capacity; try later") }, { httpApiStatus: 429 }) {
   override readonly [ErrorReporter.ignore] = true;
 }
 

--- a/test/automation-client/command.unit.test.ts
+++ b/test/automation-client/command.unit.test.ts
@@ -41,17 +41,17 @@ const CliTestLayer = Layer.mergeAll(
   ),
 );
 
-type Served = readonly [number, Option.Option<string>];
+type Served = readonly [number, Option.Option<string>, number];
 
 const fakeServer = () => {
   const served: Array<Served> = [];
   const listening = Deferred.makeUnsafe<void>();
   const serverFailed = Deferred.makeUnsafe<never, HttpServerError.ServeError>();
   const server: AutomationClientCommand.AutomationClient<never> = {
-    serve: (port, url) =>
+    serve: (port, url, jobs) =>
       Layer.effectDiscard(
         Effect.gen(function* () {
-          served.push([port, url]);
+          served.push([port, url, jobs]);
           yield* Deferred.succeed(listening, undefined);
         }),
       ),
@@ -118,6 +118,7 @@ describe("automation client command flags", () => {
       expect(stdout.join("\n")).toContain("automation-client");
       expect(stdout.join("\n")).toContain("--port");
       expect(stdout.join("\n")).toContain("--url");
+      expect(stdout.join("\n")).toContain("--jobs");
       expect(stdout.join("\n")).not.toContain("--display");
     }),
   );
@@ -131,7 +132,7 @@ describe("automation client command flags", () => {
       yield* Fiber.interrupt(fiber);
       const exit = yield* Fiber.await(fiber);
       expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
-      expect(fake.served).toEqual([[54322, Option.none()]]);
+      expect(fake.served).toEqual([[54322, Option.none(), 1]]);
       expect(log.lines).toEqual([]);
     }),
   );
@@ -143,7 +144,35 @@ describe("automation client command flags", () => {
       const fiber = yield* Effect.forkChild(run(fake.server, ["--port", "1234"], log));
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
-      expect(fake.served).toEqual([[1234, Option.none()]]);
+      expect(fake.served).toEqual([[1234, Option.none(), 1]]);
+    }),
+  );
+
+  it.effect("--jobs 4 reaches the server as given", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const fiber = yield* Effect.forkChild(run(fake.server, ["--jobs", "4"], log));
+      yield* Deferred.await(fake.listening);
+      yield* Fiber.interrupt(fiber);
+      expect(fake.served).toEqual([[54322, Option.none(), 4]]);
+    }),
+  );
+
+  it.effect("--jobs 0 is a usage error that touches nothing (unhappy)", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(run(fake.server, ["--jobs", "0"], log));
+      expect(error._tag).toBe("ShowHelp");
+      if (error._tag === "ShowHelp") {
+        expect(error.errors.length).toBeGreaterThan(0);
+        expect(error.errors[0]?._tag).toBe("InvalidValue");
+      }
+      const stderr = yield* TestConsole.errorLines;
+      expect(stderr.join("\n")).toContain("jobs must be at least 1");
+      expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([]);
     }),
   );
 
@@ -156,7 +185,7 @@ describe("automation client command flags", () => {
       );
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
-      expect(fake.served).toEqual([[54322, Option.some("http://127.0.0.1:55332")]]);
+      expect(fake.served).toEqual([[54322, Option.some("http://127.0.0.1:55332"), 1]]);
     }),
   );
 

--- a/test/automation-client/command.unit.test.ts
+++ b/test/automation-client/command.unit.test.ts
@@ -48,10 +48,10 @@ const fakeServer = () => {
   const listening = Deferred.makeUnsafe<void>();
   const serverFailed = Deferred.makeUnsafe<never, HttpServerError.ServeError>();
   const server: AutomationClientCommand.AutomationClient<never> = {
-    serve: (port, url, jobs) =>
+    serve: (port, url, maxJobs) =>
       Layer.effectDiscard(
         Effect.gen(function* () {
-          served.push([port, url, jobs]);
+          served.push([port, url, maxJobs]);
           yield* Deferred.succeed(listening, undefined);
         }),
       ),
@@ -118,7 +118,7 @@ describe("automation client command flags", () => {
       expect(stdout.join("\n")).toContain("automation-client");
       expect(stdout.join("\n")).toContain("--port");
       expect(stdout.join("\n")).toContain("--url");
-      expect(stdout.join("\n")).toContain("--jobs");
+      expect(stdout.join("\n")).toContain("--max-jobs");
       expect(stdout.join("\n")).not.toContain("--display");
     }),
   );
@@ -148,29 +148,29 @@ describe("automation client command flags", () => {
     }),
   );
 
-  it.effect("--jobs 4 reaches the server as given", () =>
+  it.effect("--max-jobs 4 reaches the server as given", () =>
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const fiber = yield* Effect.forkChild(run(fake.server, ["--jobs", "4"], log));
+      const fiber = yield* Effect.forkChild(run(fake.server, ["--max-jobs", "4"], log));
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
       expect(fake.served).toEqual([[54322, Option.none(), 4]]);
     }),
   );
 
-  it.effect("--jobs 0 is a usage error that touches nothing (unhappy)", () =>
+  it.effect("--max-jobs 0 is a usage error that touches nothing (unhappy)", () =>
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, ["--jobs", "0"], log));
+      const error = yield* Effect.flip(run(fake.server, ["--max-jobs", "0"], log));
       expect(error._tag).toBe("ShowHelp");
       if (error._tag === "ShowHelp") {
         expect(error.errors.length).toBeGreaterThan(0);
         expect(error.errors[0]?._tag).toBe("InvalidValue");
       }
       const stderr = yield* TestConsole.errorLines;
-      expect(stderr.join("\n")).toContain("jobs must be at least 1");
+      expect(stderr.join("\n")).toContain("max-jobs must be at least 1");
       expect(fake.served).toEqual([]);
       expect(log.lines).toEqual([]);
     }),

--- a/test/automation-client/heartbeat.unit.test.ts
+++ b/test/automation-client/heartbeat.unit.test.ts
@@ -82,7 +82,7 @@ describe("automation-client heartbeat happy path", () => {
       }),
   );
 
-  it.effect("writes the running map size as jobs and --jobs as maxJobs", () =>
+  it.effect("writes the running map size as jobs and --max-jobs as maxJobs", () =>
     Effect.gen(function* () {
       const store = Stores.fakeServerStore();
       const scope = yield* Scope.make();

--- a/test/automation-client/heartbeat.unit.test.ts
+++ b/test/automation-client/heartbeat.unit.test.ts
@@ -20,7 +20,7 @@ const ROW_STATS = {
 };
 
 // One heartbeat as the store records it: this process announces itself as an automation-client.
-const ANNOUNCED = { url: URL, type: "automation-client", stats: ROW_STATS };
+const ANNOUNCED = { url: URL, type: "automation-client", stats: ROW_STATS, jobs: 0, maxJobs: 1 };
 const REGISTERED = { url: URL, type: "automation-client" };
 
 const refused = Errors.DatabaseError.make({
@@ -38,7 +38,7 @@ const fakeStats = (
 const start = (store: Stores.FakeServerStore, stats = fakeStats(), log = FakeLog.fakeLog()) =>
   Effect.gen(function* () {
     const scope = yield* Scope.make();
-    yield* Heartbeat.announce(URL).pipe(
+    yield* Heartbeat.announce(URL, 1).pipe(
       Effect.provide(Layer.mergeAll(stats, store.layer, log.layer)),
       Scope.provide(scope),
     );
@@ -65,6 +65,20 @@ describe("automation-client heartbeat happy path", () => {
         ).toBe(true);
         expect(log.lines).toEqual([]);
       }),
+  );
+
+  it.effect("writes zero running jobs and --jobs as maxJobs", () =>
+    Effect.gen(function* () {
+      const store = Stores.fakeServerStore();
+      const scope = yield* Scope.make();
+      yield* Heartbeat.announce(URL, 4).pipe(
+        Effect.provide(Layer.mergeAll(fakeStats(), store.layer, FakeLog.fakeLog().layer)),
+        Scope.provide(scope),
+      );
+      expect(store.heartbeats).toEqual([
+        { url: URL, type: "automation-client", stats: ROW_STATS, jobs: 0, maxJobs: 4 },
+      ]);
+    }),
   );
 
   it.effect("stops when the scope it was started in closes", () =>
@@ -135,13 +149,13 @@ describe("automation-client heartbeat unhappy path", () => {
         let attempts = 0;
         const written: Array<typeof ANNOUNCED> = [];
         const store = Stores.fakeServerStore({
-          heartbeat: (url, type, stats) =>
+          heartbeat: (url, type, stats, jobs, maxJobs) =>
             Effect.suspend(() => {
               attempts += 1;
               if (attempts === 1) {
                 return Effect.fail(refused);
               }
-              written.push({ url, type, stats });
+              written.push({ url, type, stats, jobs, maxJobs });
               return Effect.void;
             }),
         });

--- a/test/automation-client/heartbeat.unit.test.ts
+++ b/test/automation-client/heartbeat.unit.test.ts
@@ -3,6 +3,7 @@ import { it } from "@effect/vitest";
 import { Deferred, Effect, Exit, Fiber, Layer, Scope } from "effect";
 import { TestClock } from "effect/testing";
 import * as Heartbeat from "../../src/automation-client/heartbeat.ts";
+import * as Sessions from "../../src/automation-client/sessions.ts";
 import * as Stats from "../../src/qemu/stats.ts";
 import * as Contract from "../../src/shared/contract.ts";
 import * as Errors from "../../src/shared/errors.ts";
@@ -34,12 +35,26 @@ const fakeStats = (
     Effect.succeed(Contract.Stats.make({ qemus, ...FakeQemu.ZERO_STATS })),
 ): Layer.Layer<Stats.Stats> => Layer.succeed(Stats.Stats)(Stats.Stats.of({ collect }));
 
+const fakeSessions = (jobs = 0): Layer.Layer<Sessions.Sessions> =>
+  Layer.succeed(Sessions.Sessions)(
+    Sessions.Sessions.of({
+      run: () => Effect.die("Unexpected Sessions.run"),
+      abort: () => Effect.die("Unexpected Sessions.abort"),
+      jobs: Effect.succeed(jobs),
+    }),
+  );
+
 // The loop in a scope of its own, so a test can close it and prove the ticking stops.
-const start = (store: Stores.FakeServerStore, stats = fakeStats(), log = FakeLog.fakeLog()) =>
+const start = (
+  store: Stores.FakeServerStore,
+  stats = fakeStats(),
+  log = FakeLog.fakeLog(),
+  sessions = fakeSessions(),
+) =>
   Effect.gen(function* () {
     const scope = yield* Scope.make();
     yield* Heartbeat.announce(URL, 1).pipe(
-      Effect.provide(Layer.mergeAll(stats, store.layer, log.layer)),
+      Effect.provide(Layer.mergeAll(stats, sessions, store.layer, log.layer)),
       Scope.provide(scope),
     );
     return { scope, log };
@@ -67,16 +82,18 @@ describe("automation-client heartbeat happy path", () => {
       }),
   );
 
-  it.effect("writes zero running jobs and --jobs as maxJobs", () =>
+  it.effect("writes the running map size as jobs and --jobs as maxJobs", () =>
     Effect.gen(function* () {
       const store = Stores.fakeServerStore();
       const scope = yield* Scope.make();
       yield* Heartbeat.announce(URL, 4).pipe(
-        Effect.provide(Layer.mergeAll(fakeStats(), store.layer, FakeLog.fakeLog().layer)),
+        Effect.provide(
+          Layer.mergeAll(fakeStats(), fakeSessions(2), store.layer, FakeLog.fakeLog().layer),
+        ),
         Scope.provide(scope),
       );
       expect(store.heartbeats).toEqual([
-        { url: URL, type: "automation-client", stats: ROW_STATS, jobs: 0, maxJobs: 4 },
+        { url: URL, type: "automation-client", stats: ROW_STATS, jobs: 2, maxJobs: 4 },
       ]);
     }),
   );

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -206,6 +206,37 @@ describe("POST /run unhappy path", () => {
       }).pipe(Effect.provide(serve(fixed)));
     }),
   );
+
+  it.effect("a second run while one is in flight is 503 and does not spawn another opencode", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({}));
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const pending = yield* Effect.forkChild(run(http, "first", headers, TICKET));
+        for (let i = 0; i < 100 && fixed.spawner.spawned[0] === undefined; i++) {
+          yield* Effect.yieldNow;
+        }
+        expect(fixed.spawner.spawned).toHaveLength(1);
+        const response = yield* run(http, "second", headers, "OLI-99");
+        expect(response.status).toBe(503);
+        expect(yield* response.json).toEqual({ error: "at capacity; try later" });
+        expect(fixed.spawner.spawned).toHaveLength(1);
+        yield* fixed.spawner.spawned[0]?.exit(0) ?? Effect.void;
+        expect((yield* Fiber.join(pending)).status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /run failed: at capacity; try later",
+          location: "automation-client",
+          agentId: "automation-client",
+          skipSentry: true,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
 });
 
 describe("interruption", () => {

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -207,7 +207,7 @@ describe("POST /run unhappy path", () => {
     }),
   );
 
-  it.effect("a second run while one is in flight is 503 and does not spawn another opencode", () =>
+  it.effect("a second run while one is in flight is 429 and does not spawn another opencode", () =>
     Effect.gen(function* () {
       const fixed = fixture(() => ({}));
       yield* Effect.gen(function* () {
@@ -218,7 +218,7 @@ describe("POST /run unhappy path", () => {
         }
         expect(fixed.spawner.spawned).toHaveLength(1);
         const response = yield* run(http, "second", headers, "OLI-99");
-        expect(response.status).toBe(503);
+        expect(response.status).toBe(429);
         expect(yield* response.json).toEqual({ error: "at capacity; try later" });
         expect(fixed.spawner.spawned).toHaveLength(1);
         yield* fixed.spawner.spawned[0]?.exit(0) ?? Effect.void;

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -142,6 +142,49 @@ describe("Sessions.run unhappy path", () => {
       yield* Fiber.join(running);
     }).pipe(Effect.provide(layer(spawner, 1)));
   });
+
+  it.effect("two concurrent runs at max-jobs 1: one AtCapacity and only one spawn", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({}));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      const first = yield* Effect.forkChild(sessions.run(TICKET, "first"));
+      const second = yield* Effect.forkChild(sessions.run(OTHER, "second"));
+      for (let i = 0; i < 100 && spawner.spawned.length === 0; i++) {
+        yield* Effect.yieldNow;
+      }
+      expect(spawner.spawned).toHaveLength(1);
+      yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
+      const exits = [yield* Fiber.await(first), yield* Fiber.await(second)];
+      const tags = exits.map((exit) => {
+        if (Exit.isSuccess(exit)) {
+          return "ok";
+        }
+        const error = Cause.squash(exit.cause);
+        return typeof error === "object" && error !== null && "_tag" in error
+          ? String(error._tag)
+          : "other";
+      });
+      expect(tags.sort()).toEqual(["AtCapacity", "ok"]);
+      expect(yield* sessions.jobs).toBe(0);
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
+
+  it.effect("a spawn failure frees the reserved slot for the next ticket", () => {
+    let attempts = 0;
+    const spawner = FakeSpawner.fakeSpawner(() =>
+      ++attempts === 1 ? { spawnError: "spawn opencode ENOENT" } : { exitCode: 0 },
+    );
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      expect(yield* Effect.flip(sessions.run(TICKET, "first"))).toMatchObject({
+        _tag: "RunFailed",
+        message: "spawn opencode ENOENT",
+      });
+      expect(yield* sessions.jobs).toBe(0);
+      yield* sessions.run(OTHER, "second");
+      expect(yield* sessions.jobs).toBe(0);
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
 });
 
 describe("Sessions.abort happy path", () => {

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -10,8 +10,11 @@ import * as FakeSpawner from "../support/fake-spawner.ts";
 const TICKET = "OLI-42";
 const OTHER = "OLI-99";
 
-const layer = (spawner: FakeSpawner.FakeSpawner) =>
-  Sessions.Sessions.layer.pipe(Layer.provide(spawner.layer));
+const layer = (spawner: FakeSpawner.FakeSpawner, maxJobs = 8) =>
+  Sessions.Sessions.layer.pipe(
+    Layer.provide(spawner.layer),
+    Layer.provide(Layer.succeed(Sessions.MaxJobs)(maxJobs)),
+  );
 
 describe("Sessions.jobs happy path", () => {
   it.effect(
@@ -62,6 +65,35 @@ describe("Sessions.run happy path", () => {
       ]);
     }).pipe(Effect.provide(layer(spawner)));
   });
+
+  it.effect("runs as many tickets as max-jobs allows", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({}));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      const first = yield* Effect.forkChild(sessions.run(TICKET, "first"));
+      const second = yield* Effect.forkChild(sessions.run(OTHER, "second"));
+      for (let i = 0; i < 100 && spawner.spawned.length < 2; i++) {
+        yield* Effect.yieldNow;
+      }
+      expect(spawner.spawned).toHaveLength(2);
+      expect(yield* sessions.jobs).toBe(2);
+      yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
+      yield* spawner.spawned[1]?.exit(0) ?? Effect.void;
+      yield* Fiber.join(first);
+      yield* Fiber.join(second);
+      expect(yield* sessions.jobs).toBe(0);
+    }).pipe(Effect.provide(layer(spawner, 2)));
+  });
+
+  it.effect("a finished run frees the slot for the next ticket", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.run(TICKET, "first");
+      yield* sessions.run(OTHER, "second");
+      expect(spawner.spawned).toHaveLength(2);
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
 });
 
 describe("Sessions.run unhappy path", () => {
@@ -88,6 +120,27 @@ describe("Sessions.run unhappy path", () => {
       expect(error._tag).toBe("RunFailed");
       expect(error.message).toBe("out of token credits");
     }).pipe(Effect.provide(layer(spawner)));
+  });
+
+  it.effect("a run at capacity is AtCapacity and never spawns another opencode", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({}));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      const running = yield* Effect.forkChild(sessions.run(TICKET, "first"));
+      for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
+        yield* Effect.yieldNow;
+      }
+      expect(spawner.spawned).toHaveLength(1);
+      const error = yield* Effect.flip(sessions.run(OTHER, "second"));
+      expect(error).toMatchObject({
+        _tag: "AtCapacity",
+        message: "at capacity; try later",
+      });
+      expect(spawner.spawned).toHaveLength(1);
+      expect(yield* sessions.jobs).toBe(1);
+      yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
+      yield* Fiber.join(running);
+    }).pipe(Effect.provide(layer(spawner, 1)));
   });
 });
 

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -13,6 +13,41 @@ const OTHER = "OLI-99";
 const layer = (spawner: FakeSpawner.FakeSpawner) =>
   Sessions.Sessions.layer.pipe(Layer.provide(spawner.layer));
 
+describe("Sessions.jobs happy path", () => {
+  it.effect(
+    "is 0 when nothing is running, 1 while a run is in flight, and 0 after it finishes",
+    () => {
+      const spawner = FakeSpawner.fakeSpawner(() => ({}));
+      return Effect.gen(function* () {
+        const sessions = yield* Sessions.Sessions;
+        expect(yield* sessions.jobs).toBe(0);
+        const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work"));
+        for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
+          yield* Effect.yieldNow;
+        }
+        expect(yield* sessions.jobs).toBe(1);
+        yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
+        yield* Fiber.join(running);
+        expect(yield* sessions.jobs).toBe(0);
+      }).pipe(Effect.provide(layer(spawner)));
+    },
+  );
+});
+
+describe("Sessions.jobs unhappy path", () => {
+  it.effect("is 0 after a run that fails", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({
+      exitCode: 1,
+      stderr: "out of token credits\n",
+    }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* Effect.flip(sessions.run(TICKET, "do the work"));
+      expect(yield* sessions.jobs).toBe(0);
+    }).pipe(Effect.provide(layer(spawner)));
+  });
+});
+
 describe("Sessions.run happy path", () => {
   it.effect("launches opencode with the prompt and succeeds when it exits 0", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -78,7 +78,7 @@ const seedJob = (
 const seedLiveClient = (servers: Stores.FakeServerStore, url = URL) => {
   const id = crypto.randomUUID();
   servers.servers.push({ id, url, type: "automation-client" });
-  servers.heartbeats.push({ url, type: "automation-client", stats: STATS });
+  servers.heartbeats.push({ url, type: "automation-client", stats: STATS, jobs: 0, maxJobs: 1 });
   return id;
 };
 
@@ -314,7 +314,7 @@ describe("dispatch unhappy path", () => {
       seedResult(fixed.tests);
       seedJob(fixed.automation);
       fixed.servers.servers.push({ id: crypto.randomUUID(), url: URL, type: "qemu" });
-      fixed.servers.heartbeats.push({ url: URL, type: "qemu", stats: STATS });
+      fixed.servers.heartbeats.push({ url: URL, type: "qemu", stats: STATS, jobs: 0, maxJobs: 1 });
       yield* start(fixed, FakeHttp.die);
       yield* Effect.yieldNow;
       expect(fixed.automation.jobs[0]?.status).toBe("pending");

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -522,6 +522,8 @@ describe("automation client announce", () => {
           type: "automation-client",
           generation: 1,
           stats: { qemus: 0 },
+          jobs: 0,
+          maxJobs: 1,
         });
         expect(row?.heartbeatAt).toBeInstanceOf(Date);
         const { code } = yield* Effect.promise(() => process.exited);

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -1327,16 +1327,30 @@ Postgres.describeWithDatabase("database", () => {
           const rowOf = database.run("select", (db) =>
             db.select().from(DbSchema.servers).where(eq(DbSchema.servers.url, url)),
           );
-          yield* store.heartbeat(url, "qemu", first);
+          yield* store.heartbeat(url, "qemu", first, 1, 4);
           expect(yield* store.listServers("qemu")).toContain(url);
           const [row] = yield* rowOf;
-          expect(row).toMatchObject({ url, type: "qemu", stats: first, generation: 1 });
+          expect(row).toMatchObject({
+            url,
+            type: "qemu",
+            stats: first,
+            generation: 1,
+            jobs: 1,
+            maxJobs: 4,
+          });
           expect(row?.heartbeatAt).toBeInstanceOf(Date);
           const second: DbSchema.ServerStats = { ...first, qemus: 2 };
-          yield* store.heartbeat(url, "qemu", second);
+          yield* store.heartbeat(url, "qemu", second, 2, 4);
           const rows = yield* rowOf;
           expect(rows).toHaveLength(1);
-          expect(rows[0]).toMatchObject({ url, type: "qemu", stats: second, generation: 2 });
+          expect(rows[0]).toMatchObject({
+            url,
+            type: "qemu",
+            stats: second,
+            generation: 2,
+            jobs: 2,
+            maxJobs: 4,
+          });
           expect(rows[0]?.heartbeatAt?.getTime()).toBeGreaterThanOrEqual(
             row?.heartbeatAt?.getTime() ?? Number.POSITIVE_INFINITY,
           );
@@ -1362,16 +1376,25 @@ Postgres.describeWithDatabase("database", () => {
             stats: null,
             generation: 0,
             heartbeatAt: null,
+            jobs: 0,
+            maxJobs: 1,
           });
           const stats: DbSchema.ServerStats = {
             qemus: 0,
             memory: { totalBytes: 66_900_000_000, usedBytes: 31_500_000_000 },
             cpu: { mean1m: 12.3, mean2m: 11, mean3m: 9.8 },
           };
-          yield* store.heartbeat(url, "qemu", stats);
+          yield* store.heartbeat(url, "qemu", stats, 0, 8);
           const rows = yield* rowOf;
           expect(rows).toHaveLength(1);
-          expect(rows[0]).toMatchObject({ url, type: "qemu", stats, generation: 1 });
+          expect(rows[0]).toMatchObject({
+            url,
+            type: "qemu",
+            stats,
+            generation: 1,
+            jobs: 0,
+            maxJobs: 8,
+          });
           expect(rows[0]?.heartbeatAt).toBeInstanceOf(Date);
           expect(yield* store.removeServer(url)).toBe(true);
         }),
@@ -1392,7 +1415,7 @@ Postgres.describeWithDatabase("database", () => {
           const rowOf = database.run("select", (db) =>
             db.select().from(DbSchema.servers).where(eq(DbSchema.servers.url, url)),
           );
-          yield* store.heartbeat(url, "automation-client", first);
+          yield* store.heartbeat(url, "automation-client", first, 0, 3);
           expect(yield* store.listServers("automation-client")).toContain(url);
           expect(yield* store.listServers("qemu")).not.toContain(url);
           const [row] = yield* rowOf;
@@ -1401,10 +1424,12 @@ Postgres.describeWithDatabase("database", () => {
             type: "automation-client",
             stats: first,
             generation: 1,
+            jobs: 0,
+            maxJobs: 3,
           });
           expect(row?.heartbeatAt).toBeInstanceOf(Date);
           const second: DbSchema.ServerStats = { ...first, cpu: { ...first.cpu, mean1m: 5 } };
-          yield* store.heartbeat(url, "automation-client", second);
+          yield* store.heartbeat(url, "automation-client", second, 2, 3);
           const rows = yield* rowOf;
           expect(rows).toHaveLength(1);
           expect(rows[0]).toMatchObject({
@@ -1412,6 +1437,8 @@ Postgres.describeWithDatabase("database", () => {
             type: "automation-client",
             stats: second,
             generation: 2,
+            jobs: 2,
+            maxJobs: 3,
           });
           expect(yield* store.removeServer(url)).toBe(true);
         }),
@@ -1454,9 +1481,9 @@ Postgres.describeWithDatabase("database", () => {
           const stale = `http://10.0.0.21:${uuid().slice(0, 8)}`;
           const qemu = `http://10.0.0.22:${uuid().slice(0, 8)}`;
           const silent = `http://10.0.0.23:${uuid().slice(0, 8)}`;
-          yield* store.heartbeat(fresh, "automation-client", stats);
-          yield* store.heartbeat(stale, "automation-client", stats);
-          yield* store.heartbeat(qemu, "qemu", stats);
+          yield* store.heartbeat(fresh, "automation-client", stats, 0, 1);
+          yield* store.heartbeat(stale, "automation-client", stats, 0, 1);
+          yield* store.heartbeat(qemu, "qemu", stats, 0, 1);
           yield* store.addServer(silent, "automation-client");
           yield* database.run("stamp", (db) =>
             db

--- a/test/integration/qemu-server.integration.test.ts
+++ b/test/integration/qemu-server.integration.test.ts
@@ -478,7 +478,14 @@ describe("qemu server serving", () => {
             }),
           ),
         );
-        expect(row).toMatchObject({ url, type: "qemu", generation: 1, stats: { qemus: 0 } });
+        expect(row).toMatchObject({
+          url,
+          type: "qemu",
+          generation: 1,
+          stats: { qemus: 0 },
+          jobs: 0,
+          maxJobs: 1,
+        });
         expect(row?.heartbeatAt).toBeInstanceOf(Date);
         const { code } = yield* Effect.promise(() => server.exited);
         expect(code, server.stdout()).toBe(0);

--- a/test/qemu-server/command.unit.test.ts
+++ b/test/qemu-server/command.unit.test.ts
@@ -60,7 +60,7 @@ const refused = Errors.DatabaseError.make({
   cause: new Error("connect ECONNREFUSED 127.0.0.1:1"),
 });
 
-type Served = readonly [Domain.QemuDisplay, boolean, number, Option.Option<string>];
+type Served = readonly [Domain.QemuDisplay, boolean, number, Option.Option<string>, number];
 
 // The host check, the server layer and the failure signal the command is built from.
 const fakeServer = (missing: ReadonlyArray<string> = []) => {
@@ -74,10 +74,10 @@ const fakeServer = (missing: ReadonlyArray<string> = []) => {
         checked.push(display);
         return missing;
       }),
-    serve: (display, automation, port, url) =>
+    serve: (display, automation, port, url, jobs) =>
       Layer.effectDiscard(
         Effect.gen(function* () {
-          served.push([display, automation, port, url]);
+          served.push([display, automation, port, url, jobs]);
           yield* Deferred.succeed(listening, undefined);
         }),
       ),
@@ -165,6 +165,7 @@ describe("qemu server command flags", () => {
       expect(stdout.join("\n")).toContain("--display");
       expect(stdout.join("\n")).toContain("--port");
       expect(stdout.join("\n")).toContain("--url");
+      expect(stdout.join("\n")).toContain("--jobs");
     }),
   );
 
@@ -178,7 +179,7 @@ describe("qemu server command flags", () => {
       const exit = yield* Fiber.await(fiber);
       expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
       expect(fake.checked).toEqual(["none"]);
-      expect(fake.served).toEqual([["none", false, 42069, Option.none()]]);
+      expect(fake.served).toEqual([["none", false, 42069, Option.none(), 1]]);
       expect(log.lines).toEqual([]);
     }),
   );
@@ -193,14 +194,43 @@ describe("qemu server command flags", () => {
       yield* Deferred.await(gtk.listening);
       yield* Fiber.interrupt(first);
       expect(gtk.checked).toEqual(["gtk"]);
-      expect(gtk.served).toEqual([["gtk", false, 1234, Option.none()]]);
+      expect(gtk.served).toEqual([["gtk", false, 1234, Option.none(), 1]]);
 
       const automation = fakeServer();
       const second = yield* Effect.forkChild(run(automation.server, ["--automation"], log));
       yield* Deferred.await(automation.listening);
       yield* Fiber.interrupt(second);
       expect(automation.checked).toEqual(["none"]);
-      expect(automation.served).toEqual([["none", true, 42069, Option.none()]]);
+      expect(automation.served).toEqual([["none", true, 42069, Option.none(), 1]]);
+    }),
+  );
+
+  it.effect("--jobs 4 reaches the server as given", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const fiber = yield* Effect.forkChild(run(fake.server, ["--jobs", "4"], log));
+      yield* Deferred.await(fake.listening);
+      yield* Fiber.interrupt(fiber);
+      expect(fake.served).toEqual([["none", false, 42069, Option.none(), 4]]);
+    }),
+  );
+
+  it.effect("--jobs 0 is a usage error that touches nothing (unhappy)", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(run(fake.server, ["--jobs", "0"], log));
+      expect(error._tag).toBe("ShowHelp");
+      if (error._tag === "ShowHelp") {
+        expect(error.errors.length).toBeGreaterThan(0);
+        expect(error.errors[0]?._tag).toBe("InvalidValue");
+      }
+      const stderr = yield* TestConsole.errorLines;
+      expect(stderr.join("\n")).toContain("jobs must be at least 1");
+      expect(fake.checked).toEqual([]);
+      expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([]);
     }),
   );
 
@@ -213,7 +243,9 @@ describe("qemu server command flags", () => {
       );
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
-      expect(fake.served).toEqual([["none", true, 42069, Option.some("http://127.0.0.1:55332")]]);
+      expect(fake.served).toEqual([
+        ["none", true, 42069, Option.some("http://127.0.0.1:55332"), 1],
+      ]);
     }),
   );
 

--- a/test/qemu-server/command.unit.test.ts
+++ b/test/qemu-server/command.unit.test.ts
@@ -74,10 +74,10 @@ const fakeServer = (missing: ReadonlyArray<string> = []) => {
         checked.push(display);
         return missing;
       }),
-    serve: (display, automation, port, url, jobs) =>
+    serve: (display, automation, port, url, maxJobs) =>
       Layer.effectDiscard(
         Effect.gen(function* () {
-          served.push([display, automation, port, url, jobs]);
+          served.push([display, automation, port, url, maxJobs]);
           yield* Deferred.succeed(listening, undefined);
         }),
       ),
@@ -165,7 +165,7 @@ describe("qemu server command flags", () => {
       expect(stdout.join("\n")).toContain("--display");
       expect(stdout.join("\n")).toContain("--port");
       expect(stdout.join("\n")).toContain("--url");
-      expect(stdout.join("\n")).toContain("--jobs");
+      expect(stdout.join("\n")).toContain("--max-jobs");
     }),
   );
 
@@ -205,29 +205,29 @@ describe("qemu server command flags", () => {
     }),
   );
 
-  it.effect("--jobs 4 reaches the server as given", () =>
+  it.effect("--max-jobs 4 reaches the server as given", () =>
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const fiber = yield* Effect.forkChild(run(fake.server, ["--jobs", "4"], log));
+      const fiber = yield* Effect.forkChild(run(fake.server, ["--max-jobs", "4"], log));
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
       expect(fake.served).toEqual([["none", false, 42069, Option.none(), 4]]);
     }),
   );
 
-  it.effect("--jobs 0 is a usage error that touches nothing (unhappy)", () =>
+  it.effect("--max-jobs 0 is a usage error that touches nothing (unhappy)", () =>
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, ["--jobs", "0"], log));
+      const error = yield* Effect.flip(run(fake.server, ["--max-jobs", "0"], log));
       expect(error._tag).toBe("ShowHelp");
       if (error._tag === "ShowHelp") {
         expect(error.errors.length).toBeGreaterThan(0);
         expect(error.errors[0]?._tag).toBe("InvalidValue");
       }
       const stderr = yield* TestConsole.errorLines;
-      expect(stderr.join("\n")).toContain("jobs must be at least 1");
+      expect(stderr.join("\n")).toContain("max-jobs must be at least 1");
       expect(fake.checked).toEqual([]);
       expect(fake.served).toEqual([]);
       expect(log.lines).toEqual([]);

--- a/test/qemu-server/heartbeat.unit.test.ts
+++ b/test/qemu-server/heartbeat.unit.test.ts
@@ -64,7 +64,7 @@ describe("heartbeat happy path", () => {
       }),
   );
 
-  it.effect("writes the running qemus as jobs and --jobs as maxJobs", () =>
+  it.effect("writes the running qemus as jobs and --max-jobs as maxJobs", () =>
     Effect.gen(function* () {
       const store = Stores.fakeServerStore();
       const scope = yield* Scope.make();

--- a/test/qemu-server/heartbeat.unit.test.ts
+++ b/test/qemu-server/heartbeat.unit.test.ts
@@ -18,7 +18,7 @@ const ROW_STATS = {
 };
 
 // One heartbeat as the store records it: this server announces itself as a qemu server.
-const ANNOUNCED = { url: URL, type: "qemu", stats: ROW_STATS };
+const ANNOUNCED = { url: URL, type: "qemu", stats: ROW_STATS, jobs: 1, maxJobs: 1 };
 const REGISTERED = { url: URL, type: "qemu" };
 
 const refused = Errors.DatabaseError.make({
@@ -35,7 +35,7 @@ const start = (
 ) =>
   Effect.gen(function* () {
     const scope = yield* Scope.make();
-    yield* Heartbeat.announce(URL).pipe(
+    yield* Heartbeat.announce(URL, 1).pipe(
       Effect.provide(Layer.mergeAll(sessions.layer, store.layer, log.layer)),
       Scope.provide(scope),
     );
@@ -62,6 +62,22 @@ describe("heartbeat happy path", () => {
         );
         expect(log.lines).toEqual([]);
       }),
+  );
+
+  it.effect("writes the running qemus as jobs and --jobs as maxJobs", () =>
+    Effect.gen(function* () {
+      const store = Stores.fakeServerStore();
+      const scope = yield* Scope.make();
+      yield* Heartbeat.announce(URL, 4).pipe(
+        Effect.provide(
+          Layer.mergeAll(FakeSessions.fakeSessions().layer, store.layer, FakeLog.fakeLog().layer),
+        ),
+        Scope.provide(scope),
+      );
+      expect(store.heartbeats).toEqual([
+        { url: URL, type: "qemu", stats: ROW_STATS, jobs: 1, maxJobs: 4 },
+      ]);
+    }),
   );
 
   it.effect("stops when the scope it was started in closes", () =>
@@ -128,13 +144,13 @@ describe("heartbeat unhappy path", () => {
         let attempts = 0;
         const written: Array<typeof ANNOUNCED> = [];
         const store = Stores.fakeServerStore({
-          heartbeat: (url, type, stats) =>
+          heartbeat: (url, type, stats, jobs, maxJobs) =>
             Effect.suspend(() => {
               attempts += 1;
               if (attempts === 1) {
                 return Effect.fail(refused);
               }
-              written.push({ url, type, stats });
+              written.push({ url, type, stats, jobs, maxJobs });
               return Effect.void;
             }),
         });

--- a/test/qemu-server/http.unit.test.ts
+++ b/test/qemu-server/http.unit.test.ts
@@ -838,7 +838,7 @@ describe("Sessions failures", () => {
     }),
   );
 
-  it.effect("an AtCapacity start is 503 and skipped for Sentry", () =>
+  it.effect("an AtCapacity start is 429 and skipped for Sentry", () =>
     Effect.gen(function* () {
       const fixed = fixture({
         sessions: FakeSessions.fakeSessions({
@@ -864,7 +864,7 @@ describe("Sessions failures", () => {
             "application/json",
           ),
         });
-        expect(raw.status).toBe(503);
+        expect(raw.status).toBe(429);
         expect(yield* raw.json).toEqual({ error: "at capacity; try later" });
       }).pipe(Effect.provide(serve(fixed)));
       expect(fixed.log.lines).toEqual([

--- a/test/qemu-server/http.unit.test.ts
+++ b/test/qemu-server/http.unit.test.ts
@@ -838,6 +838,57 @@ describe("Sessions failures", () => {
     }),
   );
 
+  it.effect("an AtCapacity start is 503 and skipped for Sentry", () =>
+    Effect.gen(function* () {
+      const fixed = fixture({
+        sessions: FakeSessions.fakeSessions({
+          start: () => Effect.fail(Errors.AtCapacity.make({})),
+        }),
+      });
+      yield* Effect.gen(function* () {
+        const api = yield* client;
+        const error = yield* Effect.flip(
+          api.Sessions.start({
+            payload: Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID }),
+          }),
+        );
+        expect(error).toMatchObject({
+          _tag: "AtCapacity",
+          message: "at capacity; try later",
+        });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/start", {
+          headers: { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          body: HttpBody.text(
+            JSON.stringify({ iso: "omarchy.iso", agent: AGENT_ID }),
+            "application/json",
+          ),
+        });
+        expect(raw.status).toBe(503);
+        expect(yield* raw.json).toEqual({ error: "at capacity; try later" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /start failed: at capacity; try later",
+          location: "server",
+          agentId: undefined,
+          skipSentry: true,
+          cause: undefined,
+        },
+        {
+          level: "error",
+          text: "POST /start failed: at capacity; try later",
+          location: "server",
+          agentId: undefined,
+          skipSentry: true,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
   it.effect(
     "an Internal raised by Sessions is 500 internal error, logged with the driver's reason",
     () =>

--- a/test/qemu-server/sessions.unit.test.ts
+++ b/test/qemu-server/sessions.unit.test.ts
@@ -85,6 +85,7 @@ type Options = {
   readonly debugLogStore?: Parameters<typeof Stores.fakeDebugLogStore>[0];
   readonly log?: Layer.Layer<Log.Log>;
   readonly shutdown?: Sessions.Shutdown;
+  readonly maxJobs?: number;
 };
 
 const harness = (options: Options = {}) => {
@@ -126,6 +127,7 @@ const harness = (options: Options = {}) => {
         fs,
         Path.layer,
         shutdown,
+        Layer.succeed(Sessions.MaxJobs)(options.maxJobs ?? 8),
       ),
     ),
   );
@@ -458,6 +460,131 @@ describe("start", () => {
           expect(h.iso.calls).toEqual([]);
           expect(endedWith(spanNamed(h, AGENT))).toBe("internal_error");
           expect(texts(h)).toEqual([]);
+        }),
+      );
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// capacity
+// ---------------------------------------------------------------------------
+
+describe("capacity", () => {
+  it.effect("starts as many sessions as max-jobs allows", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 2 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const first = yield* start();
+          const second = yield* start(OTHER_AGENT);
+          expect(yield* qemus(first.sessions)).toBe(2);
+          expect(h.qemu.calls.filter((call) => call._tag === "start")).toHaveLength(2);
+          expect(h.sessions.sessions.map((row) => row.status)).toEqual(["running", "running"]);
+          expect(Domain.isSessionId(second.id)).toBe(true);
+        }),
+      );
+    }),
+  );
+
+  it.effect("a start at capacity is AtCapacity and never launches QEMU or writes a row", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const { sessions } = yield* start();
+          const error = yield* Effect.flip(
+            sessions.start(startBody(ISO, OTHER_AGENT), "none", false),
+          );
+          expect(error).toMatchObject({
+            _tag: "AtCapacity",
+            message: "at capacity; try later",
+          });
+          expect(h.qemu.calls.filter((call) => call._tag === "start")).toHaveLength(1);
+          expect(h.qemu.calls.filter((call) => call._tag === "prepare")).toHaveLength(1);
+          expect(h.iso.calls).toHaveLength(1);
+          expect(h.sessions.sessions).toHaveLength(1);
+          expect(h.sessions.sessions[0]?.status).toBe("running");
+          expect(yield* qemus(sessions)).toBe(1);
+          expect(texts(h)).toEqual([`starting; iso ${ISO}`, "running; started in 0ms"]);
+          expect(h.log.released).toEqual([]);
+        }),
+      );
+    }),
+  );
+
+  it.effect("a session still booting counts toward capacity", () =>
+    Effect.gen(function* () {
+      const gate = yield* Deferred.make<void>();
+      const h = harness({ maxJobs: 1, script: { boot: () => Deferred.await(gate) } });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          const booting = yield* Effect.forkChild(sessions.start(startBody(), "none", false), {
+            startImmediately: true,
+          });
+          const id = h.sessions.sessions[0]?.id ?? "";
+          expect(Domain.isSessionId(id)).toBe(true);
+          const error = yield* Effect.flip(
+            sessions.start(startBody(ISO, OTHER_AGENT), "none", false),
+          );
+          expect(error).toMatchObject({
+            _tag: "AtCapacity",
+            message: "at capacity; try later",
+          });
+          expect(h.qemu.calls.filter((call) => call._tag === "prepare")).toHaveLength(1);
+          expect(h.sessions.sessions).toHaveLength(1);
+          yield* Deferred.succeed(gate, undefined);
+          expect(yield* Fiber.join(booting)).toBe(id);
+          expect(yield* qemus(sessions)).toBe(1);
+        }),
+      );
+    }),
+  );
+
+  it.effect("stopping a session frees the slot for the next start", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const { sessions, live } = yield* start();
+          expect(
+            yield* Effect.flip(sessions.start(startBody(ISO, OTHER_AGENT), "none", false)),
+          ).toMatchObject({ _tag: "AtCapacity" });
+          yield* sessions.stop(live, "succeeded", "installed");
+          const again = yield* sessions.start(startBody(ISO, OTHER_AGENT), "none", false);
+          expect(Domain.isSessionId(again)).toBe(true);
+          expect(yield* qemus(sessions)).toBe(1);
+          expect(h.sessions.sessions.map((row) => row.status)).toEqual(["succeeded", "running"]);
+        }),
+      );
+    }),
+  );
+
+  it.effect("a failed start frees the slot for the next start", () =>
+    Effect.gen(function* () {
+      let boots = 0;
+      const h = harness({
+        maxJobs: 1,
+        script: {
+          boot: () =>
+            Effect.suspend(() =>
+              ++boots === 1
+                ? Effect.fail(Errors.QemuStartError.make({ message: "qemu: exited 1" }))
+                : Effect.void,
+            ),
+        },
+      });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          expect(yield* Effect.flip(sessions.start(startBody(), "none", false))).toMatchObject({
+            _tag: "StartFailed",
+            message: "qemu: exited 1",
+          });
+          const id = yield* sessions.start(startBody(ISO, OTHER_AGENT), "none", false);
+          expect(Domain.isSessionId(id)).toBe(true);
+          expect(yield* qemus(sessions)).toBe(1);
         }),
       );
     }),

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -116,7 +116,9 @@ describe("QemuServerApi", () => {
 
   it("declares the error statuses of §2.4 plus the middleware's 400, 401 and 500", () => {
     const sessions = [400, 401, 500];
-    expect(byIdentifier(Api.QemuServerApi, "start").errors).toEqual([...sessions, 502]);
+    expect(byIdentifier(Api.QemuServerApi, "start").errors).toEqual(
+      ascending([...sessions, 429, 502]),
+    );
     expect(byIdentifier(Api.QemuServerApi, "image").errors).toEqual(
       [...sessions, 403, 404, 502].sort((a, b) => a - b),
     );
@@ -208,7 +210,7 @@ describe("QemuReverseProxyApi", () => {
 
   it("declares the boundary's 400, 401, 500, 502 and 503 on every endpoint plus each endpoint's own", () => {
     const boundary = [400, 401, 500, 502, 503];
-    expect(byIdentifier(reverse, "start").errors).toEqual(boundary);
+    expect(byIdentifier(reverse, "start").errors).toEqual(ascending([...boundary, 429]));
     expect(byIdentifier(reverse, "image").errors).toEqual(ascending([...boundary, 403, 404]));
     expect(byIdentifier(reverse, "serial").errors).toEqual(ascending([...boundary, 403, 404]));
     expect(byIdentifier(reverse, "follow").errors).toEqual(ascending([...boundary, 404, 409]));
@@ -278,7 +280,7 @@ describe("AutomationClientApi", () => {
     expect(run.group).toBe("Runs");
     expect(run.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);
     expect(spec.paths["/run"]?.post?.security).toEqual([{ bearer: [] }]);
-    expect(run.errors).toEqual([400, 401, 500]);
+    expect(run.errors).toEqual([400, 401, 429, 500]);
     const abort = byIdentifier(client, "abort");
     expect(abort.group).toBe("Runs");
     expect(abort.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);

--- a/test/shared/errors.unit.test.ts
+++ b/test/shared/errors.unit.test.ts
@@ -107,6 +107,12 @@ const cases: ReadonlyArray<WireCase> = [
     status: 503,
   },
   {
+    name: "AtCapacity",
+    wire: Errors.AtCapacityWire,
+    error: Errors.AtCapacity.make({}),
+    status: 503,
+  },
+  {
     name: "RunFailed",
     wire: Errors.RunFailedWire,
     error: Errors.RunFailed.make({ message: "out of token credits" }),

--- a/test/shared/errors.unit.test.ts
+++ b/test/shared/errors.unit.test.ts
@@ -110,7 +110,7 @@ const cases: ReadonlyArray<WireCase> = [
     name: "AtCapacity",
     wire: Errors.AtCapacityWire,
     error: Errors.AtCapacity.make({}),
-    status: 503,
+    status: 429,
   },
   {
     name: "RunFailed",

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -649,6 +649,8 @@ type Heartbeat = {
   readonly url: string;
   readonly type: Servers.ServerType;
   readonly stats: DbSchema.ServerStats;
+  readonly jobs: number;
+  readonly maxJobs: number;
 };
 
 export type FakeServerStore = {
@@ -678,7 +680,7 @@ export const fakeServerStore = (
           servers.push({ id: crypto.randomUUID(), url, type });
         }
       }),
-    heartbeat: (url, type, stats) =>
+    heartbeat: (url, type, stats, jobs, maxJobs) =>
       Effect.sync(() => {
         const index = indexOf(url);
         if (index === -1) {
@@ -689,7 +691,7 @@ export const fakeServerStore = (
             servers[index] = { id: existing.id, url, type };
           }
         }
-        heartbeats.push({ url, type, stats });
+        heartbeats.push({ url, type, stats, jobs, maxJobs });
       }),
     removeServer: (url) =>
       Effect.sync(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refuse `POST /start` (qemu-server) and `POST /run` (automation-client) when the process is already running `--max-jobs` jobs.

**Status:** `429` with `{ "error": "at capacity; try later" }`.
- 400 would mean a bad request.
- 503 is already `NoServer` on the shared `/start` wire; the client decodes by status, so a second 503 would steal that answer.
- 429 is the 4xx for “try later” and stays distinct. Refusals below 500 skip Sentry.

**How capacity is counted**
- Each process keeps a numeric `jobs` count.
- The count is incremented before spawn/boot and decremented when the job ends.
- The session/ticket map is only for lookup and abort, not for capacity.

**Not in this change**
- automation-server dispatch
- qemu-reverse-proxy placement (it already forwards a non-200 `/start` as-is)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09255-a8bc-72f5-8432-4bcc369a61e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09255-a8bc-72f5-8432-4bcc369a61e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

