### PR TITLE
Add --max-jobs to qemu-server and automation-client; refuse a start or run past it with 503

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -5,7 +5,7 @@
   "terminals": [
     {
       "name": "qemu-server",
-      "command": "./qemu-server --port 42069 --automation"
+      "command": "./qemu-server --port 42069 --automation --max-jobs 2"
     }
   ]
 }

--- a/src/automation-client/command.ts
+++ b/src/automation-client/command.ts
@@ -13,6 +13,7 @@ const DEFAULT_PORT = 54322;
 
 export type AutomationClient<RServe> = {
   readonly serve: (
+    maxJobs: number,
     port: number,
     url: Option.Option<string>,
   ) => Layer.Layer<never, HttpServerError.ServeError, RServe>;
@@ -29,6 +30,14 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
   Command.make(
     "automation-client",
     {
+      // No default: how many OpenCode runs a host carries at once is the operator's knowledge of
+      // that host, and a guess would under-use a large one or overload a small one.
+      maxJobs: Flag.integer("max-jobs").pipe(
+        Flag.withSchema(Domain.MaxJobs),
+        Flag.withDescription(
+          "How many runs this client carries at once; a run past it is refused with 503",
+        ),
+      ),
       port: Flag.integer("port").pipe(
         Flag.withDefault(DEFAULT_PORT),
         Flag.withDescription("Listen port"),
@@ -43,7 +52,7 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
         ),
       ),
     },
-    ({ port, url }) =>
+    ({ maxJobs, port, url }) =>
       Effect.gen(function* () {
         const log = yield* Log.Log;
         const database = yield* Client.Database;
@@ -58,7 +67,7 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
             ),
           );
           return yield* Effect.raceFirst(
-            Layer.launch(server.serve(port, url)),
+            Layer.launch(server.serve(maxJobs, port, url)),
             Deferred.await(server.serverFailed),
           );
         });

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -36,13 +36,13 @@ server.on("error", (cause) => {
 
 // The heartbeat starts once the listener is up, in the same scope: a port refusal announces
 // nothing, and a shutdown deletes the row it wrote.
-const ServerLive = (port: number, url: Option.Option<string>) =>
+const ServerLive = (maxJobs: number, port: number, url: Option.Option<string>) =>
   Layer.effectDiscard(
     Effect.gen(function* () {
       const log = yield* Log.Log;
       yield* log.acquireColor(Log.AutomationClientAgentId);
       yield* log.info(
-        `automation client listening on ${HOST}:${String(port)}${Option.match(url, { onNone: () => "", onSome: (announced) => `; announcing ${announced}` })}`,
+        `automation client listening on ${HOST}:${String(port)}; max jobs ${String(maxJobs)}${Option.match(url, { onNone: () => "", onSome: (announced) => `; announcing ${announced}` })}`,
         automationClientAttr,
       );
       yield* Option.match(url, { onNone: () => Effect.void, onSome: Heartbeat.announce });
@@ -54,7 +54,7 @@ const ServerLive = (port: number, url: Option.Option<string>) =>
         disableListenLog: true,
       }).pipe(Layer.provide(NodeHttpServer.layer(() => server, { host: HOST, port }))),
     ),
-    Layer.provide(Sessions.Sessions.layer),
+    Layer.provide(Sessions.Sessions.layer(maxJobs)),
     Layer.provide(Stats.Stats.layer),
     Layer.provide(Layer.succeed(HttpMiddleware.TracerDisabledWhen)(() => true)),
   );

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -13,63 +13,89 @@ const mapWithout = <V>(map: ReadonlyMap<string, V>, key: string): ReadonlyMap<st
   return next;
 };
 
-const make = Effect.gen(function* () {
-  const running = yield* Ref.make<ReadonlyMap<string, ChildProcessSpawner.ChildProcessHandle>>(
-    new Map(),
-  );
-  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-
-  const run = Effect.fn("Sessions.run")(function* (ticket: string, prompt: string) {
-    return yield* Effect.scoped(
-      Effect.gen(function* () {
-        const handle = yield* Cli.spawn(OpenCode.BIN, OpenCode.args(prompt));
-        const claimed = yield* Ref.modify(running, (map) =>
-          map.has(ticket)
-            ? ([false, map] as const)
-            : ([true, mapWith(map, ticket, handle)] as const),
-        );
-        if (!claimed) {
-          return yield* Effect.die(`ticket "${ticket}" is already running`);
-        }
-        yield* Effect.addFinalizer(() =>
-          Ref.update(running, (map) =>
-            map.get(ticket) === handle ? mapWithout(map, ticket) : map,
-          ),
-        );
-        return yield* Cli.awaitExit(OpenCode.BIN, handle);
-      }),
-    ).pipe(
-      Effect.mapError((error) => Errors.RunFailed.make({ message: error.message, cause: error })),
-      Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+const make = (maxJobs: number) =>
+  Effect.gen(function* () {
+    const running = yield* Ref.make<ReadonlyMap<string, ChildProcessSpawner.ChildProcessHandle>>(
+      new Map(),
     );
-  });
+    // How many runs are admitted against --max-jobs. `running` cannot count them: a run is only
+    // in it once OpenCode has spawned, and the slot must be taken before that, so a refused run
+    // spawns nothing.
+    const jobs = yield* Ref.make(0);
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
 
-  const abort = Effect.fn("Sessions.abort")(function* (ticket: string) {
-    const handle = (yield* Ref.get(running)).get(ticket);
-    if (handle === undefined) {
-      return yield* Errors.unknownSession(ticket, ticket);
-    }
-    return yield* handle
-      .kill({
-        killSignal: "SIGTERM",
-        forceKillAfter: Cli.FORCE_KILL_AFTER,
-      })
-      .pipe(
-        Effect.catch((error) =>
-          // A child already gone cannot be killed. isRunning can itself fail; treat that as still
-          // running so a probe failure does not look like a successful abort.
-          Effect.flatMap(handle.isRunning.pipe(Effect.orElseSucceed(() => true)), (alive) =>
-            alive ? Errors.RunFailed.make({ message: error.message, cause: error }) : Effect.void,
-          ),
-        ),
+    const admit = (ticket: string): Effect.Effect<void, Errors.AtCapacity> =>
+      Effect.flatMap(
+        Ref.modify(jobs, (n) => (n < maxJobs ? [true, n + 1] : [false, n])),
+        (admitted) =>
+          admitted
+            ? Effect.void
+            : Errors.AtCapacity.make({
+                message: `at capacity: max-jobs is ${String(maxJobs)}`,
+                agentId: ticket,
+              }),
       );
-  });
 
-  return { run, abort };
-});
+    const run = Effect.fn("Sessions.run")(function* (ticket: string, prompt: string) {
+      return yield* Effect.scoped(
+        Effect.gen(function* () {
+          // The slot is the run's first resource: taken and its release registered in one
+          // uninterruptible step, so it is given back however the run ends, and last, after the
+          // child is reaped and the ticket forgotten.
+          yield* Effect.acquireRelease(admit(ticket), () => Ref.update(jobs, (n) => n - 1));
+          const handle = yield* Cli.spawn(OpenCode.BIN, OpenCode.args(prompt));
+          const claimed = yield* Ref.modify(running, (map) =>
+            map.has(ticket)
+              ? ([false, map] as const)
+              : ([true, mapWith(map, ticket, handle)] as const),
+          );
+          if (!claimed) {
+            return yield* Effect.die(`ticket "${ticket}" is already running`);
+          }
+          yield* Effect.addFinalizer(() =>
+            Ref.update(running, (map) =>
+              map.get(ticket) === handle ? mapWithout(map, ticket) : map,
+            ),
+          );
+          return yield* Cli.awaitExit(OpenCode.BIN, handle);
+        }),
+      ).pipe(
+        Effect.catchTag("CliFailed", (error) =>
+          Errors.RunFailed.make({ message: error.message, cause: error }),
+        ),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+    });
+
+    const abort = Effect.fn("Sessions.abort")(function* (ticket: string) {
+      const handle = (yield* Ref.get(running)).get(ticket);
+      if (handle === undefined) {
+        return yield* Errors.unknownSession(ticket, ticket);
+      }
+      return yield* handle
+        .kill({
+          killSignal: "SIGTERM",
+          forceKillAfter: Cli.FORCE_KILL_AFTER,
+        })
+        .pipe(
+          Effect.catch((error) =>
+            // A child already gone cannot be killed. isRunning can itself fail; treat that as
+            // still running so a probe failure does not look like a successful abort.
+            Effect.flatMap(handle.isRunning.pipe(Effect.orElseSucceed(() => true)), (alive) =>
+              alive ? Errors.RunFailed.make({ message: error.message, cause: error }) : Effect.void,
+            ),
+          ),
+        );
+    });
+
+    return { run, abort };
+  });
 
 export class Sessions extends Context.Service<Sessions>()("@oligarchy/automation-client/Sessions", {
   make,
 }) {
-  static readonly layer = Layer.effect(this)(this.make);
+  static readonly layer = (
+    maxJobs: number,
+  ): Layer.Layer<Sessions, never, ChildProcessSpawner.ChildProcessSpawner> =>
+    Layer.effect(this)(this.make(maxJobs));
 }

--- a/src/qemu-server/command.ts
+++ b/src/qemu-server/command.ts
@@ -12,8 +12,8 @@ import * as Errors from "../shared/errors.ts";
 const DEFAULT_PORT = 42069;
 
 // What main.ts hands the command: the host check, the server as a layer for a display, an
-// automation flag, a port and the url it announces itself under (none: it stays out of the
-// fleet), and the signal a server error raises after listen.
+// automation flag, how many sessions it runs at once, a port and the url it announces itself
+// under (none: it stays out of the fleet), and the signal a server error raises after listen.
 export type QemuServer<RHost, RServe> = {
   readonly missingHostRequirements: (
     display: Domain.QemuDisplay,
@@ -21,6 +21,7 @@ export type QemuServer<RHost, RServe> = {
   readonly serve: (
     display: Domain.QemuDisplay,
     automation: boolean,
+    maxJobs: number,
     port: number,
     url: Option.Option<string>,
   ) => Layer.Layer<never, HttpServerError.ServeError, RServe>;
@@ -50,6 +51,14 @@ export const makeQemuServerCommand = <RHost, RServe>(server: QemuServer<RHost, R
         Flag.withDefault(false),
         Flag.withDescription("Force the automation QEMU profile for every session"),
       ),
+      // No default: how many machines a host runs at once is the operator's knowledge of that
+      // host, and a guess would under-use a large one or overload a small one.
+      maxJobs: Flag.integer("max-jobs").pipe(
+        Flag.withSchema(Domain.MaxJobs),
+        Flag.withDescription(
+          "How many sessions this server runs at once; a start past it is refused with 503",
+        ),
+      ),
       port: Flag.integer("port").pipe(
         Flag.withDefault(DEFAULT_PORT),
         Flag.withDescription("Listen port"),
@@ -65,7 +74,7 @@ export const makeQemuServerCommand = <RHost, RServe>(server: QemuServer<RHost, R
         ),
       ),
     },
-    ({ display, automation, port, url }) =>
+    ({ display, automation, maxJobs, port, url }) =>
       Effect.gen(function* () {
         if (automation && Option.isSome(display)) {
           return yield* new CliError.UserError({
@@ -92,7 +101,7 @@ export const makeQemuServerCommand = <RHost, RServe>(server: QemuServer<RHost, R
             ),
           );
           return yield* Effect.raceFirst(
-            Layer.launch(server.serve(resolved, automation, port, url)),
+            Layer.launch(server.serve(resolved, automation, maxJobs, port, url)),
             Deferred.await(server.serverFailed),
           );
         });

--- a/src/qemu-server/main.ts
+++ b/src/qemu-server/main.ts
@@ -51,6 +51,7 @@ server.on("error", (cause) => {
 const ServerLive = (
   display: Domain.QemuDisplay,
   automation: boolean,
+  maxJobs: number,
   port: number,
   url: Option.Option<string>,
 ) =>
@@ -58,7 +59,7 @@ const ServerLive = (
     Effect.gen(function* () {
       const log = yield* Log.Log;
       yield* log.info(
-        `qemu server listening on ${HOST}:${String(port)}; display ${display}${automation ? "; automation" : ""}${Option.match(url, { onNone: () => "", onSome: (announced) => `; announcing ${announced}` })}`,
+        `qemu server listening on ${HOST}:${String(port)}; display ${display}${automation ? "; automation" : ""}; max jobs ${String(maxJobs)}${Option.match(url, { onNone: () => "", onSome: (announced) => `; announcing ${announced}` })}`,
         { location: Log.Locations.server },
       );
       yield* Option.match(url, { onNone: () => Effect.void, onSome: Heartbeat.announce });
@@ -70,7 +71,7 @@ const ServerLive = (
         disableListenLog: true,
       }),
     ),
-    Layer.provide(Sessions.Sessions.layer),
+    Layer.provide(Sessions.Sessions.layer(maxJobs)),
     Layer.provide(Layer.succeed(Sessions.Shutdown)(shutdown)),
     Layer.provide(Layer.mergeAll(Qemu.Qemu.layer, Iso.Iso.layer, Stats.Stats.layer)),
     // Bound before Sessions exists: a port refusal is one fatal line, never a drain.

--- a/src/qemu-server/middleware.ts
+++ b/src/qemu-server/middleware.ts
@@ -42,6 +42,7 @@ const isApiError: (value: unknown) => value is Errors.ApiError = Schema.is(
     Errors.ServerFailed,
     Errors.NoServer,
     Errors.RunFailed,
+    Errors.AtCapacity,
   ]),
 );
 
@@ -77,7 +78,9 @@ const attribution = (error: Errors.ApiError, fallback: Log.ProcessAttribution): 
             : { agentId: fallback.agentId }
           : { agentId: error.agentId },
       );
+    // Refused before a session existed: the process bucket, under the agent that asked.
     case "NoServer":
+    case "AtCapacity":
       return Object.assign(
         { location: fallback.location },
         error.agentId === undefined

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -73,11 +73,12 @@ export type LiveSession = {
 type OpenSession = Omit<LiveSession, "qemu">;
 
 export type SessionsService = {
+  // Fails AtCapacity, before anything is minted or written, once --max-jobs sessions are held.
   readonly start: (
     body: Contract.StartBody,
     display: Domain.QemuDisplay,
     automation: boolean,
-  ) => Effect.Effect<string, Errors.StartFailed | Errors.Internal>;
+  ) => Effect.Effect<string, Errors.AtCapacity | Errors.StartFailed | Errors.Internal>;
   // Resets lastCommandAt before returning: a valid request counts as activity.
   readonly lookup: (
     id: string,
@@ -184,767 +185,797 @@ const exchangeFailed = (error: unknown, live: OpenSession): Errors.ExchangeFaile
 const badRequest = (message: string, live: OpenSession): Errors.BadRequest =>
   Errors.BadRequest.make({ message, sessionId: live.id, agentId: live.agent });
 
-const make = Effect.gen(function* () {
-  const qemu = yield* Qemu.Qemu;
-  const iso = yield* Iso.Iso;
-  const stats = yield* Stats.Stats;
-  const sessionStore = yield* SessionStore.SessionStore;
-  const actionStore = yield* Actions.ActionStore;
-  const debugLogs = yield* DebugLogs.DebugLogStore;
-  const log = yield* Log.Log;
-  const fs = yield* FileSystem.FileSystem;
-  const shutdown = yield* Shutdown;
+const make = (maxJobs: number) =>
+  Effect.gen(function* () {
+    const qemu = yield* Qemu.Qemu;
+    const iso = yield* Iso.Iso;
+    const stats = yield* Stats.Stats;
+    const sessionStore = yield* SessionStore.SessionStore;
+    const actionStore = yield* Actions.ActionStore;
+    const debugLogs = yield* DebugLogs.DebugLogStore;
+    const log = yield* Log.Log;
+    const fs = yield* FileSystem.FileSystem;
+    const shutdown = yield* Shutdown;
 
-  // Running machines, by id; and every session this qemu server holds, booting ones included.
-  const sessions = yield* Ref.make<ReadonlyMap<string, LiveSession>>(new Map());
-  const openSessions = yield* Ref.make<ReadonlyMap<string, OpenSession>>(new Map());
+    // Running machines, by id; and every session this qemu server holds, booting ones included.
+    const sessions = yield* Ref.make<ReadonlyMap<string, LiveSession>>(new Map());
+    const openSessions = yield* Ref.make<ReadonlyMap<string, OpenSession>>(new Map());
+    // How many sessions are admitted against --max-jobs. Taken at the top of start, before the
+    // span, scope or row exist, so a refusal allocates nothing; given back in finishLiveSession,
+    // the one place every admitted session ends.
+    const jobs = yield* Ref.make(0);
 
-  const elapsed = (started: number) =>
-    Effect.map(Clock.currentTimeMillis, (now) => String(now - started));
+    const elapsed = (started: number) =>
+      Effect.map(Clock.currentTimeMillis, (now) => String(now - started));
 
-  // -------------------------------------------------------------------------
-  // followers
-  // -------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
+    // followers
+    // -------------------------------------------------------------------------
 
-  const emit = (live: OpenSession, event: Domain.FollowEvent): Effect.Effect<void> =>
-    Effect.gen(function* () {
-      for (const follower of yield* Ref.get(live.followers)) {
-        if (Queue.offerUnsafe(follower, event)) {
-          continue;
+    const emit = (live: OpenSession, event: Domain.FollowEvent): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        for (const follower of yield* Ref.get(live.followers)) {
+          if (Queue.offerUnsafe(follower, event)) {
+            continue;
+          }
+          yield* Ref.update(live.followers, (set) => without(set, follower));
+          Queue.endUnsafe(follower);
+          yield* log.warning(`follower dropped; ${String(FOLLOW_BACKLOG)} events behind`, {
+            location: live.id,
+            agentId: live.agent,
+          });
         }
-        yield* Ref.update(live.followers, (set) => without(set, follower));
-        Queue.endUnsafe(follower);
-        yield* log.warning(`follower dropped; ${String(FOLLOW_BACKLOG)} events behind`, {
-          location: live.id,
-          agentId: live.agent,
+      });
+
+    // Brackets one request's work for the followers: a running line when it starts, then its verdict.
+    const followed = <A, E>(
+      live: OpenSession,
+      name: Domain.ActionName,
+      work: Effect.Effect<A, E>,
+    ): Effect.Effect<A, E> =>
+      Effect.gen(function* () {
+        const id = yield* Ref.updateAndGet(live.actionSeq, (n) => n + 1);
+        yield* emit(live, { type: "action", id, name, state: "running" });
+        return yield* Effect.onExit(work, (exit) =>
+          emit(live, { type: "action", id, state: Exit.isSuccess(exit) ? "completed" : "failed" }),
+        );
+      });
+
+    const detach = (live: OpenSession, follower: Follower): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const removed = yield* Ref.modify(live.followers, (set) =>
+          set.has(follower) ? [true, without(set, follower)] : [false, set],
+        );
+        if (removed) {
+          yield* log.info("follower detached", { location: live.id, agentId: live.agent });
+        }
+      });
+
+    // -------------------------------------------------------------------------
+    // action spans and the recorder
+    // -------------------------------------------------------------------------
+
+    // Open from the recorder's open to its close, under the open intent or the session.
+    const openActionSpan = (
+      live: OpenSession,
+      command: Domain.QmpCommand,
+    ): Effect.Effect<Tracer.Span> =>
+      Effect.gen(function* () {
+        const parent = Option.match(yield* Ref.get(live.intent), {
+          onNone: () => live.span,
+          onSome: (intent) => intent.span,
+        });
+        const span = yield* Sentry.actionSpan(parent, command.execute, live.id, live.agent);
+        yield* Ref.update(live.actionSpans, (spans) => withItem(spans, span));
+        return span;
+      });
+
+    // Ends the span once: a session ending with actions in flight fails what is still open.
+    const settleActionSpan = (
+      live: OpenSession,
+      span: Tracer.Span,
+      state: Domain.ActionState,
+      imageUrl?: string,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const open = yield* Ref.modify(live.actionSpans, (spans) =>
+          spans.has(span) ? [true, without(spans, span)] : [false, spans],
+        );
+        if (open) {
+          yield* Sentry.endActionSpan(span, state, imageUrl);
+        }
+      });
+
+    // Opens the span and the action row; a refused insert fails the exchange up front.
+    const beginAction = (live: OpenSession, command: Domain.QmpCommand) =>
+      Effect.gen(function* () {
+        const span = yield* openActionSpan(live, command);
+        const id = yield* actionStore
+          .startAction({ sessionId: live.id, agentId: live.agent, request: command })
+          .pipe(Effect.tapError(() => settleActionSpan(live, span, "failed")));
+        return { span, id };
+      });
+
+    const recorder =
+      (live: OpenSession): Qmp.Recorder =>
+      (command) =>
+        Effect.map(
+          beginAction(live, command),
+          ({ span, id }) =>
+            (outcome) =>
+              Effect.gen(function* () {
+                yield* settleActionSpan(live, span, outcome.state);
+                yield* actionStore.finishAction(id, outcome).pipe(
+                  Effect.tapError((error) =>
+                    log.error(`db: closing action ${String(id)} failed: ${detail(error)}`, {
+                      location: live.id,
+                      agentId: live.agent,
+                      cause: error,
+                    }),
+                  ),
+                );
+              }),
+        );
+
+    // -------------------------------------------------------------------------
+    // ending a session
+    // -------------------------------------------------------------------------
+
+    const finishOpenIntent = (
+      live: OpenSession,
+      state: "completed" | "cancelled",
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const intent = yield* Ref.getAndSet(live.intent, Option.none());
+        if (Option.isNone(intent)) {
+          return;
+        }
+        yield* Sentry.endIntentSpan(intent.value.span, state);
+        yield* emit(live, { type: "intent", state });
+      });
+
+    const finishLiveSession = (
+      live: OpenSession,
+      status: Domain.SessionEndStatus,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        yield* Ref.update(openSessions, (map) => mapWithout(map, [live.id]));
+        yield* Ref.update(jobs, (n) => n - 1);
+        yield* log.releaseColor(live.agent);
+        for (const span of yield* Ref.get(live.actionSpans)) {
+          yield* settleActionSpan(live, span, "failed");
+        }
+        yield* finishOpenIntent(live, "cancelled");
+        yield* Sentry.endSessionSpan(live.span, status);
+        yield* emit(live, { type: "session", status });
+        for (const follower of yield* Ref.getAndSet(live.followers, new Set())) {
+          Queue.endUnsafe(follower);
+        }
+      });
+
+    // Leaving the session scope kills QEMU and removes its directory.
+    const kill = (live: OpenSession): Effect.Effect<void> => Scope.close(live.scope, Exit.void);
+
+    const killLogged = (live: OpenSession, prefix: string, agentId: string | undefined) =>
+      kill(live).pipe(
+        Effect.catchCause((cause) => {
+          if (Cause.hasInterruptsOnly(cause)) {
+            return Effect.interrupt;
+          }
+          const error = Cause.squash(cause);
+          return log.error(`${prefix}: ${detail(error)}`, {
+            ...attribution(live.id, agentId),
+            cause: error,
+          });
+        }),
+      );
+
+    // -------------------------------------------------------------------------
+    // start
+    // -------------------------------------------------------------------------
+
+    const launch = (
+      live: OpenSession,
+      body: Contract.StartBody,
+      display: Domain.QemuDisplay,
+      automation: boolean,
+    ): Effect.Effect<
+      Qemu.QemuHandle,
+      Errors.QemuStartError | Errors.IsoError | Errors.DatabaseError
+    > =>
+      Effect.gen(function* () {
+        // Checked before anything else: a wrong disk path must not cost an iso download, and it
+        // must fail ahead of registerAgent, or the agent's one registration is spent on a machine
+        // that never booted.
+        const disk = body.disk;
+        if (disk !== undefined) {
+          yield* fs
+            .stat(disk)
+            .pipe(
+              Effect.mapError(() =>
+                Errors.QemuStartError.make({ message: `qemu: disk not found: ${disk}` }),
+              ),
+            );
+        }
+        const isoPath = yield* iso.getIso(body.iso, { sessionId: live.id, agentId: live.agent });
+        const prepared = yield* qemu.prepare(live.id, disk).pipe(Scope.provide(live.scope));
+        // Register right before boot: the handshake records an action that references agent_runs,
+        // so this must precede start(), but a failed download or disk create before here must not
+        // burn the agent id on its one-registration key.
+        yield* sessionStore.registerAgent(live.agent, live.id);
+        const handle = yield* qemu
+          .start(prepared, { iso: isoPath, display, automation, record: recorder(live) })
+          .pipe(Scope.provide(live.scope));
+        yield* sessionStore.sessionRunning(live.id);
+        return handle;
+      }).pipe(
+        Effect.tapError((error) =>
+          Effect.gen(function* () {
+            // Best effort: the row and the caller's error are what matter once boot has failed.
+            yield* Effect.ignore(kill(live));
+            yield* sessionStore.endSession(live.id, "failed", detail(error)).pipe(
+              Effect.catch((failure) =>
+                log.error(`db: recording a failed start failed too: ${failure.message}`, {
+                  location: live.id,
+                  agentId: live.agent,
+                  cause: failure,
+                }),
+              ),
+            );
+          }),
+        ),
+      );
+
+    const start = Effect.fn("Sessions.start")(function* (
+      body: Contract.StartBody,
+      display: Domain.QemuDisplay,
+      automation: boolean,
+    ) {
+      const agent = body.agent;
+      const admitted = yield* Ref.modify(jobs, (n) => (n < maxJobs ? [true, n + 1] : [false, n]));
+      if (!admitted) {
+        return yield* Errors.AtCapacity.make({
+          message: `at capacity: max-jobs is ${String(maxJobs)}`,
+          agentId: agent,
         });
       }
-    });
-
-  // Brackets one request's work for the followers: a running line when it starts, then its verdict.
-  const followed = <A, E>(
-    live: OpenSession,
-    name: Domain.ActionName,
-    work: Effect.Effect<A, E>,
-  ): Effect.Effect<A, E> =>
-    Effect.gen(function* () {
-      const id = yield* Ref.updateAndGet(live.actionSeq, (n) => n + 1);
-      yield* emit(live, { type: "action", id, name, state: "running" });
-      return yield* Effect.onExit(work, (exit) =>
-        emit(live, { type: "action", id, state: Exit.isSuccess(exit) ? "completed" : "failed" }),
-      );
-    });
-
-  const detach = (live: OpenSession, follower: Follower): Effect.Effect<void> =>
-    Effect.gen(function* () {
-      const removed = yield* Ref.modify(live.followers, (set) =>
-        set.has(follower) ? [true, without(set, follower)] : [false, set],
-      );
-      if (removed) {
-        yield* log.info("follower detached", { location: live.id, agentId: live.agent });
-      }
-    });
-
-  // -------------------------------------------------------------------------
-  // action spans and the recorder
-  // -------------------------------------------------------------------------
-
-  // Open from the recorder's open to its close, under the open intent or the session.
-  const openActionSpan = (
-    live: OpenSession,
-    command: Domain.QmpCommand,
-  ): Effect.Effect<Tracer.Span> =>
-    Effect.gen(function* () {
-      const parent = Option.match(yield* Ref.get(live.intent), {
-        onNone: () => live.span,
-        onSome: (intent) => intent.span,
+      const started = yield* Clock.currentTimeMillis;
+      const id: string = crypto.randomUUID();
+      const live: OpenSession = {
+        id,
+        agent,
+        span: yield* Sentry.sessionSpan(id, agent),
+        scope: yield* Scope.make(),
+        lastCommandAt: yield* Ref.make(started),
+        intent: yield* Ref.make(Option.none<Intent>()),
+        image: yield* Ref.make(Option.none<Image>()),
+        followers: yield* Ref.make<ReadonlySet<Follower>>(new Set()),
+        actionSeq: yield* Ref.make(0),
+        actionSpans: yield* Ref.make<ReadonlySet<Tracer.Span>>(new Set()),
+      };
+      yield* Ref.update(openSessions, (map) => mapWith(map, id, live));
+      yield* log.acquireColor(agent);
+      const disk = body.disk;
+      yield* sessionStore
+        .insertSession(
+          id,
+          disk === undefined ? { iso: body.iso } : { iso: body.iso, disk },
+          Domain.isIsoUrl(body.iso) ? "downloading" : "running",
+        )
+        .pipe(
+          Effect.catch((cause) =>
+            finishLiveSession(live, "failed").pipe(
+              Effect.andThen(Effect.fail(internal(cause, id, agent))),
+            ),
+          ),
+        );
+      yield* log.info(`starting; iso ${body.iso}${disk === undefined ? "" : `, disk ${disk}`}`, {
+        location: id,
+        agentId: agent,
       });
-      const span = yield* Sentry.actionSpan(parent, command.execute, live.id, live.agent);
-      yield* Ref.update(live.actionSpans, (spans) => withItem(spans, span));
-      return span;
+      const handle = yield* launch(live, body, display, automation).pipe(
+        Effect.catch((error) =>
+          finishLiveSession(live, "failed").pipe(
+            Effect.andThen(
+              Effect.fail(
+                Errors.StartFailed.make({
+                  message: detail(error),
+                  cause: error,
+                  sessionId: id,
+                  agentId: agent,
+                }),
+              ),
+            ),
+          ),
+        ),
+      );
+      const running: LiveSession = { ...live, qemu: handle };
+      yield* Ref.set(running.lastCommandAt, yield* Clock.currentTimeMillis);
+      yield* Ref.update(sessions, (map) => mapWith(map, id, running));
+      yield* emit(running, { type: "session", status: "running" });
+      yield* log.info(`running; started in ${yield* elapsed(started)}ms`, {
+        location: id,
+        agentId: agent,
+      });
+      return id;
     });
 
-  // Ends the span once: a session ending with actions in flight fails what is still open.
-  const settleActionSpan = (
-    live: OpenSession,
-    span: Tracer.Span,
-    state: Domain.ActionState,
-    imageUrl?: string,
-  ): Effect.Effect<void> =>
-    Effect.gen(function* () {
-      const open = yield* Ref.modify(live.actionSpans, (spans) =>
-        spans.has(span) ? [true, without(spans, span)] : [false, spans],
-      );
-      if (open) {
-        yield* Sentry.endActionSpan(span, state, imageUrl);
+    // -------------------------------------------------------------------------
+    // driving a running session
+    // -------------------------------------------------------------------------
+
+    const lookup = Effect.fn("Sessions.lookup")(function* (id: string, agent: string) {
+      if (id === "") {
+        return yield* Errors.BadRequest.make({ message: "session id is required", agentId: agent });
       }
+      const live = (yield* Ref.get(sessions)).get(id);
+      if (live === undefined) {
+        return yield* Errors.unknownSession(id, agent);
+      }
+      if (live.agent !== agent) {
+        return yield* Errors.Forbidden.make({
+          message: `agent "${agent}" does not own session "${id}"`,
+          sessionId: id,
+          agentId: agent,
+        });
+      }
+      // A valid request counts as activity even when the exchange it starts later fails.
+      yield* Ref.set(live.lastCommandAt, yield* Clock.currentTimeMillis);
+      return live;
     });
 
-  // Opens the span and the action row; a refused insert fails the exchange up front.
-  const beginAction = (live: OpenSession, command: Domain.QmpCommand) =>
-    Effect.gen(function* () {
-      const span = yield* openActionSpan(live, command);
-      const id = yield* actionStore
-        .startAction({ sessionId: live.id, agentId: live.agent, request: command })
-        .pipe(Effect.tapError(() => settleActionSpan(live, span, "failed")));
-      return { span, id };
-    });
-
-  const recorder =
-    (live: OpenSession): Qmp.Recorder =>
-    (command) =>
-      Effect.map(
-        beginAction(live, command),
-        ({ span, id }) =>
-          (outcome) =>
+    const image = Effect.fn("Sessions.image")(function* (live: LiveSession) {
+      const started = yield* Clock.currentTimeMillis;
+      const imageId: string = crypto.randomUUID();
+      const url = Contract.StoredImageUrl(imageId);
+      // The images row must ride the same transaction that closes the action (they are 1:1), so
+      // this recorder only stashes and the method closes.
+      const opened = yield* Ref.make(Option.none<number>());
+      const outcome = yield* Ref.make(Option.none<Domain.QmpExchangeOutcome>());
+      const record: Qmp.Recorder = (command) =>
+        Effect.gen(function* () {
+          const { span, id } = yield* beginAction(live, command);
+          yield* Ref.set(opened, Option.some(id));
+          return (result) =>
             Effect.gen(function* () {
-              yield* settleActionSpan(live, span, outcome.state);
-              yield* actionStore.finishAction(id, outcome).pipe(
-                Effect.tapError((error) =>
-                  log.error(`db: closing action ${String(id)} failed: ${detail(error)}`, {
-                    location: live.id,
-                    agentId: live.agent,
-                    cause: error,
-                  }),
-                ),
+              yield* Ref.set(outcome, Option.some(result));
+              yield* settleActionSpan(
+                live,
+                span,
+                result.state,
+                result.state === "completed" ? url : undefined,
               );
+            });
+        });
+      // Only a failed exchange is closed without an image; a completed one whose image write failed
+      // stays open rather than break the 1:1 promise.
+      const closeFailedExchange = Effect.gen(function* () {
+        const id = yield* Ref.get(opened);
+        const result = yield* Ref.get(outcome);
+        if (Option.isNone(id) || Option.isNone(result) || result.value.state !== "failed") {
+          return;
+        }
+        yield* actionStore.finishAction(id.value, result.value).pipe(
+          Effect.catch((failure) =>
+            log.error(`db: recording a failed screendump failed too: ${failure.message}`, {
+              location: live.id,
+              agentId: live.agent,
+              cause: failure,
             }),
+          ),
+        );
+      });
+      const work = Effect.gen(function* () {
+        const png = yield* live.qemu.screendump(record).pipe(
+          Effect.mapError((error) =>
+            error._tag === "PlatformError"
+              ? internal(error, live.id, live.agent)
+              : exchangeFailed(error, live),
+          ),
+          Effect.tapError(() => closeFailedExchange),
+        );
+        const id = yield* Ref.get(opened);
+        const result = yield* Ref.get(outcome);
+        if (Option.isNone(id) || Option.isNone(result)) {
+          return yield* Effect.die("screendump completed without recording its exchange");
+        }
+        yield* actionStore
+          .finishAction(id.value, result.value, { id: imageId, data: png })
+          .pipe(Effect.mapError((cause) => internal(cause, live.id, live.agent)));
+        const stored: Image = { id: imageId, png: Buffer.from(png).toString("base64") };
+        yield* Ref.set(live.image, Option.some(stored));
+        yield* emit(live, { type: "image", id: stored.id, png: stored.png });
+        yield* log.info(
+          `image; ${String(png.length)} bytes in ${yield* elapsed(started)}ms; ${url}`,
+          { location: live.id, agentId: live.agent },
+        );
+        return { png, imageId };
+      });
+      return yield* followed(live, "get-image", work);
+    });
+
+    const serial = Effect.fn("Sessions.serial")(function* (live: LiveSession) {
+      const started = yield* Clock.currentTimeMillis;
+      const data = yield* followed(
+        live,
+        "get-serial",
+        fs
+          .readFile(live.qemu.serialPath)
+          .pipe(Effect.mapError((cause) => internal(cause, live.id, live.agent))),
+      );
+      yield* log.info(`serial; ${String(data.length)} bytes in ${yield* elapsed(started)}ms`, {
+        location: live.id,
+        agentId: live.agent,
+      });
+      return data;
+    });
+
+    const sendKeys = Effect.fn("Sessions.sendKeys")(function* (
+      live: LiveSession,
+      keys: string,
+      encoding: string | undefined,
+    ) {
+      const started = yield* Clock.currentTimeMillis;
+      const parsed = Keys.parseKeys(keys, encoding ?? "oligarchy");
+      if (Result.isFailure(parsed)) {
+        return yield* badRequest(parsed.failure.message, live);
+      }
+      const chords = parsed.success;
+      if (chords.length > MAX_KEYS) {
+        return yield* badRequest(`send-keys: at most ${String(MAX_KEYS)} keys per request`, live);
+      }
+      yield* followed(
+        live,
+        "send-keys",
+        live.qemu
+          .sendKeys(chords, recorder(live))
+          .pipe(Effect.mapError((error) => exchangeFailed(error, live))),
+      );
+      return yield* log.info(
+        `sent ${String(chords.length)} chords in ${yield* elapsed(started)}ms`,
+        {
+          location: live.id,
+          agentId: live.agent,
+        },
+      );
+    });
+
+    const sendMouse = Effect.fn("Sessions.sendMouse")(function* (
+      live: LiveSession,
+      input: Contract.SendMouseBody,
+    ) {
+      const started = yield* Clock.currentTimeMillis;
+      const { x, y, button, clicks } = input;
+      if (!(x >= 0 && x <= 1 && y >= 0 && y <= 1)) {
+        return yield* badRequest("mouse: x and y must be in 0..1", live);
+      }
+      if (
+        clicks !== undefined &&
+        (!Number.isInteger(clicks) || clicks < 1 || clicks > MAX_CLICKS)
+      ) {
+        return yield* badRequest(
+          `mouse: clicks must be an integer in 1..${String(MAX_CLICKS)}`,
+          live,
+        );
+      }
+      const gesture = Object.assign(
+        { x, y },
+        button === undefined ? undefined : { button },
+        clicks === undefined ? undefined : { clicks },
+      );
+      yield* followed(
+        live,
+        "send-mouse",
+        live.qemu
+          .sendMouse(gesture, recorder(live))
+          .pipe(Effect.mapError((error) => exchangeFailed(error, live))),
+      );
+      const pulses = clicks === undefined || clicks === 1 ? "" : ` ×${String(clicks)}`;
+      return yield* log.info(
+        `mouse ${String(x)} ${String(y)}${button === undefined ? "" : ` ${button}${pulses}`} in ${yield* elapsed(started)}ms`,
+        { location: live.id, agentId: live.agent },
+      );
+    });
+
+    const intentStart = Effect.fn("Sessions.intentStart")(function* (
+      live: LiveSession,
+      testResultId: string,
+      message: string,
+    ) {
+      if (Option.isSome(yield* Ref.get(live.intent))) {
+        return yield* badRequest(
+          "Cannot start one intent when one's already running. Please end your previous intent.",
+          live,
+        );
+      }
+      const span = yield* Sentry.intentSpan(live.span, live.id, live.agent, testResultId, message);
+      yield* Ref.set(live.intent, Option.some({ span, message }));
+      yield* emit(live, { type: "intent", state: "started", message });
+      return yield* log.info(`intent start; ${message}`, {
+        location: live.id,
+        agentId: live.agent,
+      });
+    });
+
+    const intentEnd = Effect.fn("Sessions.intentEnd")(function* (live: LiveSession) {
+      if (Option.isNone(yield* Ref.get(live.intent))) {
+        return yield* badRequest("no active intent", live);
+      }
+      yield* finishOpenIntent(live, "completed");
+      return yield* log.info("intent end", { location: live.id, agentId: live.agent });
+    });
+
+    const readSerialText = (live: LiveSession): Effect.Effect<string> =>
+      fs.readFile(live.qemu.serialPath).pipe(
+        Effect.map((bytes) => new TextDecoder().decode(bytes)),
+        Effect.catch((error) =>
+          error.reason._tag === "NotFound"
+            ? Effect.succeed("")
+            : log
+                .error(`debug log: serial read failed: ${detail(error)}`, {
+                  location: live.id,
+                  agentId: live.agent,
+                  cause: error,
+                })
+                .pipe(Effect.as("")),
+        ),
       );
 
-  // -------------------------------------------------------------------------
-  // ending a session
-  // -------------------------------------------------------------------------
+    type Captured = { readonly serial: string; readonly qemu: string };
 
-  const finishOpenIntent = (
-    live: OpenSession,
-    state: "completed" | "cancelled",
-  ): Effect.Effect<void> =>
-    Effect.gen(function* () {
-      const intent = yield* Ref.getAndSet(live.intent, Option.none());
-      if (Option.isNone(intent)) {
+    // What vanishes with the machine, read before the kill: the console file and QEMU's stderr.
+    const captureDebugLog = (live: LiveSession): Effect.Effect<Captured> =>
+      Effect.all({ serial: readSerialText(live), qemu: live.qemu.stderrTail });
+
+    const saveDebugLog = (live: LiveSession, captured: Captured): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        // Drain the log queue so the snapshot includes the stopped line just offered.
+        yield* log.flush;
+        yield* debugLogs.saveDebugLog(live.id, captured).pipe(
+          Effect.catch((error) =>
+            log.error(`debug log save failed: ${detail(error)}`, {
+              location: live.id,
+              agentId: live.agent,
+              cause: error,
+            }),
+          ),
+        );
+      });
+
+    const stop = Effect.fn("Sessions.stop")(function* (
+      live: LiveSession,
+      status: Domain.StopStatus | undefined,
+      reason: string | undefined,
+    ) {
+      const finalStatus = status ?? "aborted";
+      // The sweep may have taken the session between the lookup and here; whoever removes the id
+      // owns its one verdict, and the other caller sees the session as already gone.
+      const owned = yield* Ref.modify(sessions, (map) =>
+        map.has(live.id) ? [true, mapWithout(map, [live.id])] : [false, map],
+      );
+      if (!owned) {
+        return yield* Errors.unknownSession(live.id, live.agent);
+      }
+      // Every end but a succeeded stop is a session to explain. The session dir dies with kill; the
+      // serial has to be read while the file still exists. QEMU stderr is the in-memory tail
+      // drained so far. Reading it after kill is racy: closing the scope interrupts the drain
+      // fiber, so a death line written on SIGTERM can be lost.
+      const captured = finalStatus === "succeeded" ? undefined : yield* captureDebugLog(live);
+      // The kill destroys the socket and signals QEMU before it removes the dir, so a cleanup
+      // failure still leaves a dead machine: log it, but close the record.
+      yield* killLogged(live, "stop cleanup failed", live.agent);
+      yield* sessionStore
+        .endSession(live.id, finalStatus, reason ?? null)
+        .pipe(
+          Effect.catch((cause) =>
+            finishLiveSession(live, finalStatus).pipe(
+              Effect.andThen(Effect.fail(internal(cause, live.id, live.agent))),
+            ),
+          ),
+        );
+      // Colour is released in finishLiveSession; log first so the stopped line keeps it.
+      yield* log.info(`stopped; ${finalStatus}${reason === undefined ? "" : `; ${reason}`}`, {
+        location: live.id,
+        agentId: live.agent,
+      });
+      if (captured !== undefined) {
+        yield* saveDebugLog(live, captured);
+      }
+      return yield* finishLiveSession(live, finalStatus);
+    });
+
+    // -------------------------------------------------------------------------
+    // follow
+    // -------------------------------------------------------------------------
+
+    const follow = Effect.fn("Sessions.follow")(function* (id: string) {
+      const running = (yield* Ref.get(sessions)).get(id);
+      const live = running ?? (yield* Ref.get(openSessions)).get(id);
+      if (live === undefined) {
+        const status = Domain.isSessionId(id)
+          ? yield* sessionStore
+              .getSessionStatus(id)
+              .pipe(Effect.mapError((cause) => internal(cause, id)))
+          : Option.none<Domain.SessionStatus>();
+        if (Option.isNone(status)) {
+          return yield* Errors.unknownSession(id);
+        }
+        // A row still downloading or running that this qemu server does not hold was booted by
+        // another server, or by one that died with it.
+        return yield* Errors.Conflict.make({
+          message:
+            status.value === "downloading" || status.value === "running"
+              ? `session "${id}" is not running on this qemu server`
+              : `session "${id}" has already completed (${status.value})`,
+          sessionId: id,
+        });
+      }
+      // Registered here, synchronously after the lookup, so a session that ends before the body
+      // starts streaming still ends this queue rather than leaving it hanging.
+      const queue = yield* Queue.dropping<Domain.FollowEvent, Cause.Done>(FOLLOW_BACKLOG);
+      yield* Ref.update(live.followers, (set) => withItem(set, queue));
+      // finishLiveSession leaves openSessions first and ends the followers last; a registration
+      // that lands between those two steps would otherwise never be ended.
+      if (!(yield* Ref.get(openSessions)).has(live.id)) {
+        Queue.endUnsafe(queue);
+      }
+      yield* log.info("follower attached", { location: id, agentId: live.agent });
+      Queue.offerUnsafe(queue, {
+        type: "session",
+        status: running === undefined ? "pending" : "running",
+      });
+      const intent = yield* Ref.get(live.intent);
+      if (Option.isSome(intent)) {
+        Queue.offerUnsafe(queue, {
+          type: "intent",
+          state: "started",
+          message: intent.value.message,
+        });
+      }
+      const latest = yield* Ref.get(live.image);
+      if (Option.isSome(latest)) {
+        Queue.offerUnsafe(queue, { type: "image", id: latest.value.id, png: latest.value.png });
+      }
+      return Stream.fromQueue(queue).pipe(Stream.ensuring(detach(live, queue)));
+    });
+
+    // -------------------------------------------------------------------------
+    // the sweep
+    // -------------------------------------------------------------------------
+
+    const timeOut = (live: LiveSession): Effect.Effect<void, Errors.DatabaseError> =>
+      Effect.gen(function* () {
+        const captured = yield* captureDebugLog(live);
+        // The kill already destroyed the socket and signalled QEMU, so still close the record.
+        yield* killLogged(live, "timeout cleanup failed", undefined);
+        yield* sessionStore
+          .endSession(live.id, "timed_out", SESSION_TIMEOUT_REASON)
+          .pipe(
+            Effect.andThen(log.info(`timed out; ${SESSION_TIMEOUT_REASON}`, { location: live.id })),
+            Effect.andThen(saveDebugLog(live, captured)),
+            Effect.ensuring(finishLiveSession(live, "timed_out")),
+          );
+      });
+
+    const sweep = Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      const timedOut: Array<LiveSession> = [];
+      for (const live of (yield* Ref.get(sessions)).values()) {
+        if (now - (yield* Ref.get(live.lastCommandAt)) >= SESSION_TIMEOUT_MS) {
+          timedOut.push(live);
+        }
+      }
+      if (timedOut.length === 0) {
         return;
       }
-      yield* Sentry.endIntentSpan(intent.value.span, state);
-      yield* emit(live, { type: "intent", state });
-    });
-
-  const finishLiveSession = (
-    live: OpenSession,
-    status: Domain.SessionEndStatus,
-  ): Effect.Effect<void> =>
-    Effect.gen(function* () {
-      yield* Ref.update(openSessions, (map) => mapWithout(map, [live.id]));
-      yield* log.releaseColor(live.agent);
-      for (const span of yield* Ref.get(live.actionSpans)) {
-        yield* settleActionSpan(live, span, "failed");
-      }
-      yield* finishOpenIntent(live, "cancelled");
-      yield* Sentry.endSessionSpan(live.span, status);
-      yield* emit(live, { type: "session", status });
-      for (const follower of yield* Ref.getAndSet(live.followers, new Set())) {
-        Queue.endUnsafe(follower);
-      }
-    });
-
-  // Leaving the session scope kills QEMU and removes its directory.
-  const kill = (live: OpenSession): Effect.Effect<void> => Scope.close(live.scope, Exit.void);
-
-  const killLogged = (live: OpenSession, prefix: string, agentId: string | undefined) =>
-    kill(live).pipe(
-      Effect.catchCause((cause) => {
-        if (Cause.hasInterruptsOnly(cause)) {
-          return Effect.interrupt;
+      yield* Ref.update(sessions, (map) =>
+        mapWithout(
+          map,
+          timedOut.map((live) => live.id),
+        ),
+      );
+      const settled = yield* Effect.forEach(
+        timedOut,
+        (live) => Effect.map(Effect.exit(timeOut(live)), (exit) => ({ live, exit })),
+        { concurrency: "unbounded" },
+      );
+      for (const { live, exit } of settled) {
+        if (Exit.isFailure(exit)) {
+          const error = Cause.squash(exit.cause);
+          yield* log.error(`recording timeout failed: ${detail(error)}`, {
+            location: live.id,
+            cause: error,
+          });
         }
+      }
+    });
+
+    const guard = yield* Semaphore.make(1);
+    // Uninterruptible so that shutdown's interrupt waits for a tick in flight instead of tearing it.
+    const tick = sweep.pipe(
+      Effect.catchCause((cause) => {
         const error = Cause.squash(cause);
-        return log.error(`${prefix}: ${detail(error)}`, {
-          ...attribution(live.id, agentId),
+        return log.error(`session timeout cleanup failed: ${detail(error)}`, {
+          location: Log.Locations.server,
           cause: error,
         });
       }),
+      Effect.uninterruptible,
+      guard.withPermitsIfAvailable(1),
+      Effect.asVoid,
+    );
+    const sweeper = yield* tick.pipe(
+      Effect.repeat(Schedule.spaced(SESSION_TIMEOUT_CHECK)),
+      Effect.forkScoped({ startImmediately: true }),
     );
 
-  // -------------------------------------------------------------------------
-  // start
-  // -------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
+    // the drain
+    // -------------------------------------------------------------------------
 
-  const launch = (
-    live: OpenSession,
-    body: Contract.StartBody,
-    display: Domain.QemuDisplay,
-    automation: boolean,
-  ): Effect.Effect<
-    Qemu.QemuHandle,
-    Errors.QemuStartError | Errors.IsoError | Errors.DatabaseError
-  > =>
-    Effect.gen(function* () {
-      // Checked before anything else: a wrong disk path must not cost an iso download, and it
-      // must fail ahead of registerAgent, or the agent's one registration is spent on a machine
-      // that never booted.
-      const disk = body.disk;
-      if (disk !== undefined) {
-        yield* fs
-          .stat(disk)
-          .pipe(
-            Effect.mapError(() =>
-              Errors.QemuStartError.make({ message: `qemu: disk not found: ${disk}` }),
-            ),
-          );
-      }
-      const isoPath = yield* iso.getIso(body.iso, { sessionId: live.id, agentId: live.agent });
-      const prepared = yield* qemu.prepare(live.id, disk).pipe(Scope.provide(live.scope));
-      // Register right before boot: the handshake records an action that references agent_runs,
-      // so this must precede start(), but a failed download or disk create before here must not
-      // burn the agent id on its one-registration key.
-      yield* sessionStore.registerAgent(live.agent, live.id);
-      const handle = yield* qemu
-        .start(prepared, { iso: isoPath, display, automation, record: recorder(live) })
-        .pipe(Scope.provide(live.scope));
-      yield* sessionStore.sessionRunning(live.id);
-      return handle;
-    }).pipe(
-      Effect.tapError((error) =>
-        Effect.gen(function* () {
-          // Best effort: the row and the caller's error are what matter once boot has failed.
-          yield* Effect.ignore(kill(live));
-          yield* sessionStore.endSession(live.id, "failed", detail(error)).pipe(
-            Effect.catch((failure) =>
-              log.error(`db: recording a failed start failed too: ${failure.message}`, {
-                location: live.id,
-                agentId: live.agent,
-                cause: failure,
-              }),
-            ),
-          );
-        }),
-      ),
-    );
-
-  const start = Effect.fn("Sessions.start")(function* (
-    body: Contract.StartBody,
-    display: Domain.QemuDisplay,
-    automation: boolean,
-  ) {
-    const started = yield* Clock.currentTimeMillis;
-    const id: string = crypto.randomUUID();
-    const agent = body.agent;
-    const live: OpenSession = {
-      id,
-      agent,
-      span: yield* Sentry.sessionSpan(id, agent),
-      scope: yield* Scope.make(),
-      lastCommandAt: yield* Ref.make(started),
-      intent: yield* Ref.make(Option.none<Intent>()),
-      image: yield* Ref.make(Option.none<Image>()),
-      followers: yield* Ref.make<ReadonlySet<Follower>>(new Set()),
-      actionSeq: yield* Ref.make(0),
-      actionSpans: yield* Ref.make<ReadonlySet<Tracer.Span>>(new Set()),
-    };
-    yield* Ref.update(openSessions, (map) => mapWith(map, id, live));
-    yield* log.acquireColor(agent);
-    const disk = body.disk;
-    yield* sessionStore
-      .insertSession(
-        id,
-        disk === undefined ? { iso: body.iso } : { iso: body.iso, disk },
-        Domain.isIsoUrl(body.iso) ? "downloading" : "running",
-      )
-      .pipe(
-        Effect.catch((cause) =>
-          finishLiveSession(live, "failed").pipe(
-            Effect.andThen(Effect.fail(internal(cause, id, agent))),
-          ),
-        ),
-      );
-    yield* log.info(`starting; iso ${body.iso}${disk === undefined ? "" : `, disk ${disk}`}`, {
-      location: id,
-      agentId: agent,
-    });
-    const handle = yield* launch(live, body, display, automation).pipe(
-      Effect.catch((error) =>
-        finishLiveSession(live, "failed").pipe(
-          Effect.andThen(
-            Effect.fail(
-              Errors.StartFailed.make({
-                message: detail(error),
-                cause: error,
-                sessionId: id,
-                agentId: agent,
-              }),
-            ),
-          ),
-        ),
-      ),
-    );
-    const running: LiveSession = { ...live, qemu: handle };
-    yield* Ref.set(running.lastCommandAt, yield* Clock.currentTimeMillis);
-    yield* Ref.update(sessions, (map) => mapWith(map, id, running));
-    yield* emit(running, { type: "session", status: "running" });
-    yield* log.info(`running; started in ${yield* elapsed(started)}ms`, {
-      location: id,
-      agentId: agent,
-    });
-    return id;
-  });
-
-  // -------------------------------------------------------------------------
-  // driving a running session
-  // -------------------------------------------------------------------------
-
-  const lookup = Effect.fn("Sessions.lookup")(function* (id: string, agent: string) {
-    if (id === "") {
-      return yield* Errors.BadRequest.make({ message: "session id is required", agentId: agent });
-    }
-    const live = (yield* Ref.get(sessions)).get(id);
-    if (live === undefined) {
-      return yield* Errors.unknownSession(id, agent);
-    }
-    if (live.agent !== agent) {
-      return yield* Errors.Forbidden.make({
-        message: `agent "${agent}" does not own session "${id}"`,
-        sessionId: id,
-        agentId: agent,
-      });
-    }
-    // A valid request counts as activity even when the exchange it starts later fails.
-    yield* Ref.set(live.lastCommandAt, yield* Clock.currentTimeMillis);
-    return live;
-  });
-
-  const image = Effect.fn("Sessions.image")(function* (live: LiveSession) {
-    const started = yield* Clock.currentTimeMillis;
-    const imageId: string = crypto.randomUUID();
-    const url = Contract.StoredImageUrl(imageId);
-    // The images row must ride the same transaction that closes the action (they are 1:1), so
-    // this recorder only stashes and the method closes.
-    const opened = yield* Ref.make(Option.none<number>());
-    const outcome = yield* Ref.make(Option.none<Domain.QmpExchangeOutcome>());
-    const record: Qmp.Recorder = (command) =>
+    const drainOne = (
+      live: LiveSession,
+      reason: string,
+    ): Effect.Effect<void, Errors.DatabaseError> =>
       Effect.gen(function* () {
-        const { span, id } = yield* beginAction(live, command);
-        yield* Ref.set(opened, Option.some(id));
-        return (result) =>
-          Effect.gen(function* () {
-            yield* Ref.set(outcome, Option.some(result));
-            yield* settleActionSpan(
-              live,
-              span,
-              result.state,
-              result.state === "completed" ? url : undefined,
-            );
-          });
-      });
-    // Only a failed exchange is closed without an image; a completed one whose image write failed
-    // stays open rather than break the 1:1 promise.
-    const closeFailedExchange = Effect.gen(function* () {
-      const id = yield* Ref.get(opened);
-      const result = yield* Ref.get(outcome);
-      if (Option.isNone(id) || Option.isNone(result) || result.value.state !== "failed") {
-        return;
-      }
-      yield* actionStore.finishAction(id.value, result.value).pipe(
-        Effect.catch((failure) =>
-          log.error(`db: recording a failed screendump failed too: ${failure.message}`, {
-            location: live.id,
-            agentId: live.agent,
-            cause: failure,
+        const status = yield* Ref.make<Domain.SessionEndStatus>("failed");
+        yield* Effect.gen(function* () {
+          const captured = yield* captureDebugLog(live);
+          yield* kill(live);
+          yield* Ref.set(status, "aborted");
+          yield* sessionStore.endSession(live.id, "aborted", reason);
+          yield* log.info(`stopped; aborted; ${reason}`, { location: live.id });
+          yield* saveDebugLog(live, captured);
+        }).pipe(
+          Effect.catchCause((cause) => {
+            const error = Cause.squash(cause);
+            return log
+              .error(`shutdown: ${Render.errorDetail(error)}`, { location: live.id, cause: error })
+              .pipe(Effect.andThen(Effect.failCause(cause)));
           }),
-        ),
-      );
-    });
-    const work = Effect.gen(function* () {
-      const png = yield* live.qemu.screendump(record).pipe(
-        Effect.mapError((error) =>
-          error._tag === "PlatformError"
-            ? internal(error, live.id, live.agent)
-            : exchangeFailed(error, live),
-        ),
-        Effect.tapError(() => closeFailedExchange),
-      );
-      const id = yield* Ref.get(opened);
-      const result = yield* Ref.get(outcome);
-      if (Option.isNone(id) || Option.isNone(result)) {
-        return yield* Effect.die("screendump completed without recording its exchange");
-      }
-      yield* actionStore
-        .finishAction(id.value, result.value, { id: imageId, data: png })
-        .pipe(Effect.mapError((cause) => internal(cause, live.id, live.agent)));
-      const stored: Image = { id: imageId, png: Buffer.from(png).toString("base64") };
-      yield* Ref.set(live.image, Option.some(stored));
-      yield* emit(live, { type: "image", id: stored.id, png: stored.png });
-      yield* log.info(
-        `image; ${String(png.length)} bytes in ${yield* elapsed(started)}ms; ${url}`,
-        { location: live.id, agentId: live.agent },
-      );
-      return { png, imageId };
-    });
-    return yield* followed(live, "get-image", work);
-  });
-
-  const serial = Effect.fn("Sessions.serial")(function* (live: LiveSession) {
-    const started = yield* Clock.currentTimeMillis;
-    const data = yield* followed(
-      live,
-      "get-serial",
-      fs
-        .readFile(live.qemu.serialPath)
-        .pipe(Effect.mapError((cause) => internal(cause, live.id, live.agent))),
-    );
-    yield* log.info(`serial; ${String(data.length)} bytes in ${yield* elapsed(started)}ms`, {
-      location: live.id,
-      agentId: live.agent,
-    });
-    return data;
-  });
-
-  const sendKeys = Effect.fn("Sessions.sendKeys")(function* (
-    live: LiveSession,
-    keys: string,
-    encoding: string | undefined,
-  ) {
-    const started = yield* Clock.currentTimeMillis;
-    const parsed = Keys.parseKeys(keys, encoding ?? "oligarchy");
-    if (Result.isFailure(parsed)) {
-      return yield* badRequest(parsed.failure.message, live);
-    }
-    const chords = parsed.success;
-    if (chords.length > MAX_KEYS) {
-      return yield* badRequest(`send-keys: at most ${String(MAX_KEYS)} keys per request`, live);
-    }
-    yield* followed(
-      live,
-      "send-keys",
-      live.qemu
-        .sendKeys(chords, recorder(live))
-        .pipe(Effect.mapError((error) => exchangeFailed(error, live))),
-    );
-    return yield* log.info(`sent ${String(chords.length)} chords in ${yield* elapsed(started)}ms`, {
-      location: live.id,
-      agentId: live.agent,
-    });
-  });
-
-  const sendMouse = Effect.fn("Sessions.sendMouse")(function* (
-    live: LiveSession,
-    input: Contract.SendMouseBody,
-  ) {
-    const started = yield* Clock.currentTimeMillis;
-    const { x, y, button, clicks } = input;
-    if (!(x >= 0 && x <= 1 && y >= 0 && y <= 1)) {
-      return yield* badRequest("mouse: x and y must be in 0..1", live);
-    }
-    if (clicks !== undefined && (!Number.isInteger(clicks) || clicks < 1 || clicks > MAX_CLICKS)) {
-      return yield* badRequest(
-        `mouse: clicks must be an integer in 1..${String(MAX_CLICKS)}`,
-        live,
-      );
-    }
-    const gesture = Object.assign(
-      { x, y },
-      button === undefined ? undefined : { button },
-      clicks === undefined ? undefined : { clicks },
-    );
-    yield* followed(
-      live,
-      "send-mouse",
-      live.qemu
-        .sendMouse(gesture, recorder(live))
-        .pipe(Effect.mapError((error) => exchangeFailed(error, live))),
-    );
-    const pulses = clicks === undefined || clicks === 1 ? "" : ` ×${String(clicks)}`;
-    return yield* log.info(
-      `mouse ${String(x)} ${String(y)}${button === undefined ? "" : ` ${button}${pulses}`} in ${yield* elapsed(started)}ms`,
-      { location: live.id, agentId: live.agent },
-    );
-  });
-
-  const intentStart = Effect.fn("Sessions.intentStart")(function* (
-    live: LiveSession,
-    testResultId: string,
-    message: string,
-  ) {
-    if (Option.isSome(yield* Ref.get(live.intent))) {
-      return yield* badRequest(
-        "Cannot start one intent when one's already running. Please end your previous intent.",
-        live,
-      );
-    }
-    const span = yield* Sentry.intentSpan(live.span, live.id, live.agent, testResultId, message);
-    yield* Ref.set(live.intent, Option.some({ span, message }));
-    yield* emit(live, { type: "intent", state: "started", message });
-    return yield* log.info(`intent start; ${message}`, {
-      location: live.id,
-      agentId: live.agent,
-    });
-  });
-
-  const intentEnd = Effect.fn("Sessions.intentEnd")(function* (live: LiveSession) {
-    if (Option.isNone(yield* Ref.get(live.intent))) {
-      return yield* badRequest("no active intent", live);
-    }
-    yield* finishOpenIntent(live, "completed");
-    return yield* log.info("intent end", { location: live.id, agentId: live.agent });
-  });
-
-  const readSerialText = (live: LiveSession): Effect.Effect<string> =>
-    fs.readFile(live.qemu.serialPath).pipe(
-      Effect.map((bytes) => new TextDecoder().decode(bytes)),
-      Effect.catch((error) =>
-        error.reason._tag === "NotFound"
-          ? Effect.succeed("")
-          : log
-              .error(`debug log: serial read failed: ${detail(error)}`, {
-                location: live.id,
-                agentId: live.agent,
-                cause: error,
-              })
-              .pipe(Effect.as("")),
-      ),
-    );
-
-  type Captured = { readonly serial: string; readonly qemu: string };
-
-  // What vanishes with the machine, read before the kill: the console file and QEMU's stderr.
-  const captureDebugLog = (live: LiveSession): Effect.Effect<Captured> =>
-    Effect.all({ serial: readSerialText(live), qemu: live.qemu.stderrTail });
-
-  const saveDebugLog = (live: LiveSession, captured: Captured): Effect.Effect<void> =>
-    Effect.gen(function* () {
-      // Drain the log queue so the snapshot includes the stopped line just offered.
-      yield* log.flush;
-      yield* debugLogs.saveDebugLog(live.id, captured).pipe(
-        Effect.catch((error) =>
-          log.error(`debug log save failed: ${detail(error)}`, {
-            location: live.id,
-            agentId: live.agent,
-            cause: error,
-          }),
-        ),
-      );
-    });
-
-  const stop = Effect.fn("Sessions.stop")(function* (
-    live: LiveSession,
-    status: Domain.StopStatus | undefined,
-    reason: string | undefined,
-  ) {
-    const finalStatus = status ?? "aborted";
-    // The sweep may have taken the session between the lookup and here; whoever removes the id
-    // owns its one verdict, and the other caller sees the session as already gone.
-    const owned = yield* Ref.modify(sessions, (map) =>
-      map.has(live.id) ? [true, mapWithout(map, [live.id])] : [false, map],
-    );
-    if (!owned) {
-      return yield* Errors.unknownSession(live.id, live.agent);
-    }
-    // Every end but a succeeded stop is a session to explain. The session dir dies with kill; the
-    // serial has to be read while the file still exists. QEMU stderr is the in-memory tail
-    // drained so far. Reading it after kill is racy: closing the scope interrupts the drain
-    // fiber, so a death line written on SIGTERM can be lost.
-    const captured = finalStatus === "succeeded" ? undefined : yield* captureDebugLog(live);
-    // The kill destroys the socket and signals QEMU before it removes the dir, so a cleanup
-    // failure still leaves a dead machine: log it, but close the record.
-    yield* killLogged(live, "stop cleanup failed", live.agent);
-    yield* sessionStore
-      .endSession(live.id, finalStatus, reason ?? null)
-      .pipe(
-        Effect.catch((cause) =>
-          finishLiveSession(live, finalStatus).pipe(
-            Effect.andThen(Effect.fail(internal(cause, live.id, live.agent))),
+          Effect.ensuring(
+            Effect.flatMap(Ref.get(status), (ended) => finishLiveSession(live, ended)),
           ),
-        ),
-      );
-    // Colour is released in finishLiveSession; log first so the stopped line keeps it.
-    yield* log.info(`stopped; ${finalStatus}${reason === undefined ? "" : `; ${reason}`}`, {
-      location: live.id,
-      agentId: live.agent,
-    });
-    if (captured !== undefined) {
-      yield* saveDebugLog(live, captured);
-    }
-    return yield* finishLiveSession(live, finalStatus);
-  });
-
-  // -------------------------------------------------------------------------
-  // follow
-  // -------------------------------------------------------------------------
-
-  const follow = Effect.fn("Sessions.follow")(function* (id: string) {
-    const running = (yield* Ref.get(sessions)).get(id);
-    const live = running ?? (yield* Ref.get(openSessions)).get(id);
-    if (live === undefined) {
-      const status = Domain.isSessionId(id)
-        ? yield* sessionStore
-            .getSessionStatus(id)
-            .pipe(Effect.mapError((cause) => internal(cause, id)))
-        : Option.none<Domain.SessionStatus>();
-      if (Option.isNone(status)) {
-        return yield* Errors.unknownSession(id);
-      }
-      // A row still downloading or running that this qemu server does not hold was booted by
-      // another server, or by one that died with it.
-      return yield* Errors.Conflict.make({
-        message:
-          status.value === "downloading" || status.value === "running"
-            ? `session "${id}" is not running on this qemu server`
-            : `session "${id}" has already completed (${status.value})`,
-        sessionId: id,
-      });
-    }
-    // Registered here, synchronously after the lookup, so a session that ends before the body
-    // starts streaming still ends this queue rather than leaving it hanging.
-    const queue = yield* Queue.dropping<Domain.FollowEvent, Cause.Done>(FOLLOW_BACKLOG);
-    yield* Ref.update(live.followers, (set) => withItem(set, queue));
-    // finishLiveSession leaves openSessions first and ends the followers last; a registration
-    // that lands between those two steps would otherwise never be ended.
-    if (!(yield* Ref.get(openSessions)).has(live.id)) {
-      Queue.endUnsafe(queue);
-    }
-    yield* log.info("follower attached", { location: id, agentId: live.agent });
-    Queue.offerUnsafe(queue, {
-      type: "session",
-      status: running === undefined ? "pending" : "running",
-    });
-    const intent = yield* Ref.get(live.intent);
-    if (Option.isSome(intent)) {
-      Queue.offerUnsafe(queue, { type: "intent", state: "started", message: intent.value.message });
-    }
-    const latest = yield* Ref.get(live.image);
-    if (Option.isSome(latest)) {
-      Queue.offerUnsafe(queue, { type: "image", id: latest.value.id, png: latest.value.png });
-    }
-    return Stream.fromQueue(queue).pipe(Stream.ensuring(detach(live, queue)));
-  });
-
-  // -------------------------------------------------------------------------
-  // the sweep
-  // -------------------------------------------------------------------------
-
-  const timeOut = (live: LiveSession): Effect.Effect<void, Errors.DatabaseError> =>
-    Effect.gen(function* () {
-      const captured = yield* captureDebugLog(live);
-      // The kill already destroyed the socket and signalled QEMU, so still close the record.
-      yield* killLogged(live, "timeout cleanup failed", undefined);
-      yield* sessionStore
-        .endSession(live.id, "timed_out", SESSION_TIMEOUT_REASON)
-        .pipe(
-          Effect.andThen(log.info(`timed out; ${SESSION_TIMEOUT_REASON}`, { location: live.id })),
-          Effect.andThen(saveDebugLog(live, captured)),
-          Effect.ensuring(finishLiveSession(live, "timed_out")),
         );
-    });
-
-  const sweep = Effect.gen(function* () {
-    const now = yield* Clock.currentTimeMillis;
-    const timedOut: Array<LiveSession> = [];
-    for (const live of (yield* Ref.get(sessions)).values()) {
-      if (now - (yield* Ref.get(live.lastCommandAt)) >= SESSION_TIMEOUT_MS) {
-        timedOut.push(live);
-      }
-    }
-    if (timedOut.length === 0) {
-      return;
-    }
-    yield* Ref.update(sessions, (map) =>
-      mapWithout(
-        map,
-        timedOut.map((live) => live.id),
-      ),
-    );
-    const settled = yield* Effect.forEach(
-      timedOut,
-      (live) => Effect.map(Effect.exit(timeOut(live)), (exit) => ({ live, exit })),
-      { concurrency: "unbounded" },
-    );
-    for (const { live, exit } of settled) {
-      if (Exit.isFailure(exit)) {
-        const error = Cause.squash(exit.cause);
-        yield* log.error(`recording timeout failed: ${detail(error)}`, {
-          location: live.id,
-          cause: error,
-        });
-      }
-    }
-  });
-
-  const guard = yield* Semaphore.make(1);
-  // Uninterruptible so that shutdown's interrupt waits for a tick in flight instead of tearing it.
-  const tick = sweep.pipe(
-    Effect.catchCause((cause) => {
-      const error = Cause.squash(cause);
-      return log.error(`session timeout cleanup failed: ${detail(error)}`, {
-        location: Log.Locations.server,
-        cause: error,
       });
-    }),
-    Effect.uninterruptible,
-    guard.withPermitsIfAvailable(1),
-    Effect.asVoid,
-  );
-  const sweeper = yield* tick.pipe(
-    Effect.repeat(Schedule.spaced(SESSION_TIMEOUT_CHECK)),
-    Effect.forkScoped({ startImmediately: true }),
-  );
 
-  // -------------------------------------------------------------------------
-  // the drain
-  // -------------------------------------------------------------------------
+    const drain = Effect.gen(function* () {
+      // Clear the sweep, then await one in flight: the tick is uninterruptible, so this waits.
+      yield* Fiber.interrupt(sweeper);
+      const draining = [...(yield* Ref.getAndSet(sessions, new Map())).values()];
+      const reason = MutableRef.get(shutdown.reason);
+      yield* log.info(`qemu server: shutting down; stopping ${String(draining.length)} sessions`, {
+        location: Log.Locations.server,
+      });
+      const exits = yield* Effect.forEach(draining, (live) => Effect.exit(drainOne(live, reason)), {
+        concurrency: "unbounded",
+      });
+      MutableRef.set(shutdown.failed, exits.some(Exit.isFailure));
+    });
+    yield* Effect.addFinalizer(() => drain);
 
-  const drainOne = (live: LiveSession, reason: string): Effect.Effect<void, Errors.DatabaseError> =>
-    Effect.gen(function* () {
-      const status = yield* Ref.make<Domain.SessionEndStatus>("failed");
-      yield* Effect.gen(function* () {
-        const captured = yield* captureDebugLog(live);
-        yield* kill(live);
-        yield* Ref.set(status, "aborted");
-        yield* sessionStore.endSession(live.id, "aborted", reason);
-        yield* log.info(`stopped; aborted; ${reason}`, { location: live.id });
-        yield* saveDebugLog(live, captured);
-      }).pipe(
-        Effect.catchCause((cause) => {
-          const error = Cause.squash(cause);
-          return log
-            .error(`shutdown: ${Render.errorDetail(error)}`, { location: live.id, cause: error })
-            .pipe(Effect.andThen(Effect.failCause(cause)));
-        }),
-        Effect.ensuring(Effect.flatMap(Ref.get(status), (ended) => finishLiveSession(live, ended))),
-      );
-    });
-
-  const drain = Effect.gen(function* () {
-    // Clear the sweep, then await one in flight: the tick is uninterruptible, so this waits.
-    yield* Fiber.interrupt(sweeper);
-    const draining = [...(yield* Ref.getAndSet(sessions, new Map())).values()];
-    const reason = MutableRef.get(shutdown.reason);
-    yield* log.info(`qemu server: shutting down; stopping ${String(draining.length)} sessions`, {
-      location: Log.Locations.server,
-    });
-    const exits = yield* Effect.forEach(draining, (live) => Effect.exit(drainOne(live, reason)), {
-      concurrency: "unbounded",
-    });
-    MutableRef.set(shutdown.failed, exits.some(Exit.isFailure));
+    const service: SessionsService = {
+      start,
+      lookup,
+      image,
+      serial,
+      sendKeys,
+      sendMouse,
+      intentStart,
+      intentEnd,
+      stop,
+      follow,
+      stats: Effect.flatMap(Ref.get(sessions), (map) => stats.collect(map.size)),
+    };
+    return service;
   });
-  yield* Effect.addFinalizer(() => drain);
-
-  const service: SessionsService = {
-    start,
-    lookup,
-    image,
-    serial,
-    sendKeys,
-    sendMouse,
-    intentStart,
-    intentEnd,
-    stop,
-    follow,
-    stats: Effect.flatMap(Ref.get(sessions), (map) => stats.collect(map.size)),
-  };
-  return service;
-});
 
 export class Sessions extends Context.Service<Sessions>()("@oligarchy/qemu-server/Sessions", {
   make,
 }) {
-  static readonly layer: Layer.Layer<
+  static readonly layer = (
+    maxJobs: number,
+  ): Layer.Layer<
     Sessions,
     never,
     | Qemu.Qemu
@@ -955,5 +986,5 @@ export class Sessions extends Context.Service<Sessions>()("@oligarchy/qemu-serve
     | DebugLogs.DebugLogStore
     | Log.Log
     | FileSystem.FileSystem
-  > = Layer.effect(this)(this.make);
+  > => Layer.effect(this)(this.make(maxJobs));
 }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -46,7 +46,7 @@ const png = Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array({ contentType: "im
 export const start = HttpApiEndpoint.post("start", "/start", {
   payload: Contract.StartBody,
   success: Contract.StartResponse,
-  error: Errors.StartFailedWire,
+  error: [Errors.StartFailedWire, Errors.AtCapacityWire],
 });
 
 export const image = HttpApiEndpoint.get("image", "/image", {
@@ -176,7 +176,7 @@ export class Linear extends HttpApiGroup.make("Linear").add(linear).middleware(A
 export const run = HttpApiEndpoint.post("run", "/run", {
   payload: Contract.RunBody,
   success: Contract.Ok,
-  error: Errors.RunFailedWire,
+  error: [Errors.RunFailedWire, Errors.AtCapacityWire],
 });
 
 export const abort = HttpApiEndpoint.post("abort", "/abort", {

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -149,6 +149,13 @@ export const ServerUrl = Schema.String.check(
 ).annotate({ identifier: "@oligarchy/shared/domain/ServerUrl" });
 export type ServerUrl = typeof ServerUrl.Type;
 
+// How many jobs a qemu server or automation client runs at once, as --max-jobs names it: a
+// start or run past it is refused. A host that takes no jobs is not a server.
+export const MaxJobs = Schema.Int.check(
+  Schema.isGreaterThanOrEqualTo(1, { message: "max-jobs must be at least 1" }),
+).annotate({ identifier: "@oligarchy/shared/domain/MaxJobs" });
+export type MaxJobs = typeof MaxJobs.Type;
+
 export const SessionConfig = Schema.Struct({
   iso: Schema.String,
   disk: Schema.optionalKey(Schema.String),

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -156,6 +156,19 @@ export class RunFailed extends Schema.TaggedError<RunFailed>("@oligarchy/shared/
   override readonly [ErrorReporter.ignore] = true;
 }
 
+// A start or run refused because the process already runs --max-jobs jobs. 503: the server is
+// temporarily unable to take the work (RFC 9110 §15.6.4), not the caller's mistake; the caller
+// places it elsewhere or retries later.
+export class AtCapacity extends Schema.TaggedError<AtCapacity>(
+  "@oligarchy/shared/errors/AtCapacity",
+)(
+  "AtCapacity",
+  { message: Schema.String, agentId: Schema.optionalKey(Schema.String) },
+  { httpApiStatus: 503 },
+) {
+  override readonly [ErrorReporter.ignore] = true;
+}
+
 export type ApiError =
   | BadRequest
   | Unauthorized
@@ -168,7 +181,8 @@ export type ApiError =
   | Internal
   | ServerFailed
   | NoServer
-  | RunFailed;
+  | RunFailed
+  | AtCapacity;
 
 const resolveHttpApiStatus = SchemaAST.resolveAt("httpApiStatus");
 
@@ -192,6 +206,7 @@ const apiErrorClasses = {
   ServerFailed,
   NoServer,
   RunFailed,
+  AtCapacity,
 } satisfies Record<ApiError["_tag"], Schema.Top>;
 
 export const apiStatus = (error: ApiError): number => httpStatus(apiErrorClasses[error._tag]);
@@ -262,6 +277,10 @@ export const NoServerWire = wireError(
 export const RunFailedWire = wireError(
   RunFailed,
   (message) => ({ _tag: "RunFailed", message }) as const,
+);
+export const AtCapacityWire = wireError(
+  AtCapacity,
+  (message) => ({ _tag: "AtCapacity", message }) as const,
 );
 
 // ---------------------------------------------------------------------------

--- a/test/automation-client/command.unit.test.ts
+++ b/test/automation-client/command.unit.test.ts
@@ -41,17 +41,20 @@ const CliTestLayer = Layer.mergeAll(
   ),
 );
 
-type Served = readonly [number, Option.Option<string>];
+type Served = readonly [number, number, Option.Option<string>];
+
+// --max-jobs has no default, so every run that should reach the handler carries one.
+const MAX_JOBS: ReadonlyArray<string> = ["--max-jobs", "2"];
 
 const fakeServer = () => {
   const served: Array<Served> = [];
   const listening = Deferred.makeUnsafe<void>();
   const serverFailed = Deferred.makeUnsafe<never, HttpServerError.ServeError>();
   const server: AutomationClientCommand.AutomationClient<never> = {
-    serve: (port, url) =>
+    serve: (maxJobs, port, url) =>
       Layer.effectDiscard(
         Effect.gen(function* () {
-          served.push([port, url]);
+          served.push([maxJobs, port, url]);
           yield* Deferred.succeed(listening, undefined);
         }),
       ),
@@ -84,9 +87,50 @@ describe("automation client command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, ["--port", "forty"], log));
+      const error = yield* Effect.flip(run(fake.server, [...MAX_JOBS, "--port", "forty"], log));
       expect(error._tag).toBe("ShowHelp");
       expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("a missing --max-jobs is a usage error that touches nothing", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(run(fake.server, ["--port", "1234"], log));
+      expect(error._tag).toBe("ShowHelp");
+      if (error._tag === "ShowHelp") {
+        expect(error.errors).toMatchObject([{ _tag: "MissingOption", option: "max-jobs" }]);
+      }
+      const stderr = yield* TestConsole.errorLines;
+      expect(stderr.join("\n")).toContain("--max-jobs");
+      expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("--max-jobs below 1 or not an integer is a usage error with the flag's rule", () =>
+    Effect.gen(function* () {
+      const log = FakeLog.fakeLog();
+      // The negative in `=` form: a bare `-1` after the flag is itself read as a flag.
+      for (const args of [["--max-jobs", "0"], ["--max-jobs=-1"]]) {
+        const fake = fakeServer();
+        const error = yield* Effect.flip(run(fake.server, args, log));
+        expect(error._tag).toBe("ShowHelp");
+        if (error._tag === "ShowHelp") {
+          expect(error.errors).toMatchObject([{ _tag: "InvalidValue", option: "max-jobs" }]);
+        }
+        expect(fake.served).toEqual([]);
+      }
+      const stderr = yield* TestConsole.errorLines;
+      expect(stderr.join("\n")).toContain("max-jobs must be at least 1");
+      for (const value of ["1.5", "two"]) {
+        const fake = fakeServer();
+        const error = yield* Effect.flip(run(fake.server, ["--max-jobs", value], log));
+        expect(error._tag).toBe("ShowHelp");
+        expect(fake.served).toEqual([]);
+      }
       expect(log.lines).toEqual([]);
     }),
   );
@@ -116,6 +160,7 @@ describe("automation client command flags", () => {
       expect(log.lines).toEqual([]);
       const stdout = yield* TestConsole.logLines;
       expect(stdout.join("\n")).toContain("automation-client");
+      expect(stdout.join("\n")).toContain("--max-jobs");
       expect(stdout.join("\n")).toContain("--port");
       expect(stdout.join("\n")).toContain("--url");
       expect(stdout.join("\n")).not.toContain("--display");
@@ -126,12 +171,12 @@ describe("automation client command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const fiber = yield* Effect.forkChild(run(fake.server, [], log));
+      const fiber = yield* Effect.forkChild(run(fake.server, [...MAX_JOBS], log));
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
       const exit = yield* Fiber.await(fiber);
       expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
-      expect(fake.served).toEqual([[54322, Option.none()]]);
+      expect(fake.served).toEqual([[2, 54322, Option.none()]]);
       expect(log.lines).toEqual([]);
     }),
   );
@@ -140,10 +185,27 @@ describe("automation client command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const fiber = yield* Effect.forkChild(run(fake.server, ["--port", "1234"], log));
+      const fiber = yield* Effect.forkChild(run(fake.server, [...MAX_JOBS, "--port", "1234"], log));
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
-      expect(fake.served).toEqual([[1234, Option.none()]]);
+      expect(fake.served).toEqual([[2, 1234, Option.none()]]);
+    }),
+  );
+
+  it.effect("--max-jobs reaches the server as given, in either flag form", () =>
+    Effect.gen(function* () {
+      const log = FakeLog.fakeLog();
+      const spaced = fakeServer();
+      const first = yield* Effect.forkChild(run(spaced.server, ["--max-jobs", "3"], log));
+      yield* Deferred.await(spaced.listening);
+      yield* Fiber.interrupt(first);
+      expect(spaced.served).toEqual([[3, 54322, Option.none()]]);
+
+      const joined = fakeServer();
+      const second = yield* Effect.forkChild(run(joined.server, ["--max-jobs=1"], log));
+      yield* Deferred.await(joined.listening);
+      yield* Fiber.interrupt(second);
+      expect(joined.served).toEqual([[1, 54322, Option.none()]]);
     }),
   );
 
@@ -152,11 +214,11 @@ describe("automation client command flags", () => {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
       const fiber = yield* Effect.forkChild(
-        run(fake.server, ["--url", "http://127.0.0.1:55332"], log),
+        run(fake.server, [...MAX_JOBS, "--url", "http://127.0.0.1:55332"], log),
       );
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
-      expect(fake.served).toEqual([[54322, Option.some("http://127.0.0.1:55332")]]);
+      expect(fake.served).toEqual([[2, 54322, Option.some("http://127.0.0.1:55332")]]);
     }),
   );
 
@@ -164,7 +226,9 @@ describe("automation client command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, ["--url", "ftp://qemu.example.com"], log));
+      const error = yield* Effect.flip(
+        run(fake.server, [...MAX_JOBS, "--url", "ftp://qemu.example.com"], log),
+      );
       expect(error._tag).toBe("ShowHelp");
       if (error._tag === "ShowHelp") {
         expect(error.errors.length).toBeGreaterThan(0);
@@ -189,7 +253,7 @@ describe("automation client command startup failures", () => {
         cause: new Error("connect ECONNREFUSED"),
       });
       const error = yield* Effect.flip(
-        run(fake.server, [], log, DatabaseLive(Effect.fail(unreachable))),
+        run(fake.server, [...MAX_JOBS], log, DatabaseLive(Effect.fail(unreachable))),
       );
       expect(error).toMatchObject({
         _tag: "DatabaseError",
@@ -210,7 +274,7 @@ describe("automation client command startup failures", () => {
       const error = yield* Effect.flip(
         run(
           fake.server,
-          [],
+          [...MAX_JOBS],
           log,
           DatabaseLive(
             Effect.fail(Errors.DatabaseError.make({ operation: "ping", message: "pool ended" })),
@@ -226,7 +290,7 @@ describe("automation client command startup failures", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const fiber = yield* Effect.forkChild(run(fake.server, [], log));
+      const fiber = yield* Effect.forkChild(run(fake.server, [...MAX_JOBS], log));
       yield* Deferred.await(fake.listening);
       const cause = new Error("accept EMFILE: too many open files");
       yield* Deferred.fail(fake.serverFailed, new HttpServerError.ServeError({ cause }));
@@ -255,7 +319,7 @@ describe("automation client command startup failures", () => {
         serve: () => Layer.effectDiscard(Effect.fail(new HttpServerError.ServeError({ cause }))),
       };
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(failing, ["--port", "54322"], log));
+      const error = yield* Effect.flip(run(failing, [...MAX_JOBS, "--port", "54322"], log));
       expect(error).toMatchObject({ _tag: "ServeError", cause });
       expect(log.lines.map((line) => [line.level, line.text])).toEqual([
         ["fatal", "automation client: listen EADDRINUSE: address already in use 127.0.0.1:54322"],

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -24,17 +24,25 @@ type Fixture = {
   readonly spawner: FakeSpawner.FakeSpawner;
   readonly log: FakeLog.FakeLog;
   readonly reporter: Reporter.Collector;
+  readonly maxJobs: number;
 };
 
-const fixture = (script: FakeSpawner.Script = () => ({ exitCode: 0 })): Fixture => ({
+// Room for the two runs some tests hold at once; the capacity test passes 1.
+const MAX_JOBS = 2;
+
+const fixture = (
+  script: FakeSpawner.Script = () => ({ exitCode: 0 }),
+  maxJobs = MAX_JOBS,
+): Fixture => ({
   spawner: FakeSpawner.fakeSpawner(script),
   log: FakeLog.fakeLog(),
   reporter: Reporter.collect(),
+  maxJobs,
 });
 
 const serve = (fixed: Fixture) =>
   HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
-    Layer.provide(Sessions.Sessions.layer),
+    Layer.provide(Sessions.Sessions.layer(fixed.maxJobs)),
     Layer.provide(Layer.mergeAll(fixed.spawner.layer, fixed.log.layer, ProxyConfigLive)),
     Layer.provide(Layer.succeed(Log.ProcessAttribution)(Log.AutomationClientProcessAttribution)),
     Layer.provideMerge(NodeHttpServer.layerTest),
@@ -205,6 +213,50 @@ describe("POST /run unhappy path", () => {
         expect(yield* response.json).toEqual({ error: "out of token credits" });
       }).pipe(Effect.provide(serve(fixed)));
     }),
+  );
+
+  it.effect(
+    "a run past --max-jobs is 503 at capacity, spawns nothing, and is taken once a run ends",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture(() => ({}), 1);
+        yield* Effect.gen(function* () {
+          const http = yield* HttpClient.HttpClient;
+          const pending = yield* Effect.forkChild(run(http, "first"));
+          for (let i = 0; i < 100 && fixed.spawner.spawned[0] === undefined; i++) {
+            yield* Effect.yieldNow;
+          }
+          const refused = yield* run(http, "second", headers, "OLI-99");
+          expect(refused.status).toBe(503);
+          expect(yield* refused.json).toEqual({ error: "at capacity: max-jobs is 1" });
+          expect(fixed.spawner.spawned).toHaveLength(1);
+          yield* fixed.spawner.spawned[0]?.exit(0) ?? Effect.void;
+          expect((yield* Fiber.join(pending)).status).toBe(200);
+          const accepted = yield* Effect.forkChild(run(http, "second", headers, "OLI-99"));
+          for (let i = 0; i < 100 && fixed.spawner.spawned.length < 2; i++) {
+            yield* Effect.yieldNow;
+          }
+          expect(fixed.spawner.spawned.map((spawned) => spawned.args[2])).toEqual([
+            "first",
+            "second",
+          ]);
+          yield* fixed.spawner.spawned[1]?.exit(0) ?? Effect.void;
+          expect((yield* Fiber.join(accepted)).status).toBe(200);
+        }).pipe(Effect.provide(serve(fixed)));
+        // The refusal names the ticket it turned away; a 503 is the dispatcher's problem to place
+        // elsewhere, so unlike a 4xx it reaches Sentry.
+        expect(fixed.log.lines).toEqual([
+          {
+            level: "error",
+            text: "POST /run failed: at capacity: max-jobs is 1",
+            location: "automation-client",
+            agentId: "OLI-99",
+            skipSentry: false,
+            cause: undefined,
+          },
+        ]);
+        expect(fixed.reporter.reported).toEqual([]);
+      }),
   );
 });
 

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -9,9 +9,11 @@ import * as FakeSpawner from "../support/fake-spawner.ts";
 
 const TICKET = "OLI-42";
 const OTHER = "OLI-99";
+// Room for the two runs the tests above capacity start at once; the capacity tests pass 1.
+const MAX_JOBS = 2;
 
-const layer = (spawner: FakeSpawner.FakeSpawner) =>
-  Sessions.Sessions.layer.pipe(Layer.provide(spawner.layer));
+const layer = (spawner: FakeSpawner.FakeSpawner, maxJobs = MAX_JOBS) =>
+  Sessions.Sessions.layer(maxJobs).pipe(Layer.provide(spawner.layer));
 
 describe("Sessions.run happy path", () => {
   it.effect("launches opencode with the prompt and succeeds when it exits 0", () => {
@@ -205,5 +207,104 @@ describe("Sessions.abort unhappy path", () => {
       expect(spawner.spawned[0]?.kills).toEqual(["SIGTERM"]);
       yield* Effect.flip(Fiber.join(first));
     }).pipe(Effect.provide(layer(spawner)));
+  });
+});
+
+describe("capacity", () => {
+  it.effect("a run past --max-jobs is AtCapacity and spawns nothing", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({}));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      const running = yield* Effect.forkChild(sessions.run(TICKET, "first"));
+      for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
+        yield* Effect.yieldNow;
+      }
+      expect(spawner.spawned).toHaveLength(1);
+      const error = yield* Effect.flip(sessions.run(OTHER, "second"));
+      expect(error).toMatchObject({
+        _tag: "AtCapacity",
+        message: "at capacity: max-jobs is 1",
+        agentId: OTHER,
+      });
+      expect(spawner.spawned).toHaveLength(1);
+      // The refused ticket was never registered: nothing to abort.
+      expect((yield* Effect.flip(sessions.abort(OTHER)))._tag).toBe("UnknownSession");
+      yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
+      yield* Fiber.join(running);
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
+
+  it.effect("a run that exited, zero or not, frees its slot", () => {
+    const exits = [0, 1];
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: exits.shift() ?? 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.run(TICKET, "first");
+      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("RunFailed");
+      yield* sessions.run("OLI-7", "third");
+      expect(spawner.spawned.map((spawned) => spawned.args[2])).toEqual([
+        "first",
+        "second",
+        "third",
+      ]);
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
+
+  it.effect("an aborted run frees its slot", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({}));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      const running = yield* Effect.forkChild(sessions.run(TICKET, "first"));
+      for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
+        yield* Effect.yieldNow;
+      }
+      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("AtCapacity");
+      yield* sessions.abort(TICKET);
+      expect((yield* Effect.flip(Fiber.join(running)))._tag).toBe("RunFailed");
+      const next = yield* Effect.forkChild(sessions.run(OTHER, "second"));
+      for (let i = 0; i < 100 && spawner.spawned.length < 2; i++) {
+        yield* Effect.yieldNow;
+      }
+      expect(spawner.spawned).toHaveLength(2);
+      yield* spawner.spawned[1]?.exit(0) ?? Effect.void;
+      yield* Fiber.join(next);
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
+
+  it.effect("an interrupted run frees its slot once its child is gone", () => {
+    // The first child runs until killed; the one admitted afterwards exits at once.
+    let spawns = 0;
+    const spawner = FakeSpawner.fakeSpawner(() => (++spawns === 1 ? {} : { exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      const running = yield* Effect.forkChild(sessions.run(TICKET, "first"));
+      for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
+        yield* Effect.yieldNow;
+      }
+      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("AtCapacity");
+      yield* Fiber.interrupt(running);
+      const exit = yield* Fiber.await(running);
+      expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+      // Leaving the scope killed the child before the slot came back.
+      expect(spawner.spawned[0]?.kills).toEqual(["SIGTERM"]);
+      expect(yield* spawner.spawned[0]?.isRunning ?? Effect.succeed(true)).toBe(false);
+      yield* sessions.run(OTHER, "second");
+      expect(spawner.spawned.map((spawned) => spawned.args[2])).toEqual(["first", "second"]);
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
+
+  it.effect("a run whose spawn failed frees its slot", () => {
+    let spawns = 0;
+    const spawner = FakeSpawner.fakeSpawner(() =>
+      ++spawns === 1 ? { spawnError: "spawn opencode ENOENT" } : { exitCode: 0 },
+    );
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      const error = yield* Effect.flip(sessions.run(TICKET, "first"));
+      expect(error).toMatchObject({ _tag: "RunFailed", message: "spawn opencode ENOENT" });
+      yield* sessions.run(OTHER, "second");
+      // A spawn that failed is no process; only the second run's is recorded.
+      expect(spawner.spawned.map((spawned) => spawned.args[2])).toEqual(["second"]);
+    }).pipe(Effect.provide(layer(spawner, 1)));
   });
 });

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -19,6 +19,8 @@ const AUTOMATION_CLIENT = fileURLToPath(new URL("../../automation-client", impor
 const TOKEN = "t";
 const UNREACHABLE = "postgres://user:sentinel-pw@127.0.0.1:1/oligarchy";
 const EXIT_WITHIN_MS = 60_000;
+// --max-jobs has no default, so every client that should get past parsing carries one.
+const MAX_JOBS: ReadonlyArray<string> = ["--max-jobs", "1"];
 
 const dbUrl = inject("dbUrl");
 
@@ -167,12 +169,13 @@ const logsForClient = async () => {
 };
 
 describe("automation client startup refusals", () => {
-  it.live("--help exits 0 and lists --port and --url", () =>
+  it.live("--help exits 0 and lists --max-jobs, --port and --url", () =>
     Effect.promise(async () => {
       const process = spawnAutomationClient(["--help"]);
       const { code } = await process.exited;
       expect(code).toBe(0);
       expect(process.stdout()).toContain("automation-client");
+      expect(process.stdout()).toContain("--max-jobs");
       expect(process.stdout()).toContain("--port");
       expect(process.stdout()).toContain("--url");
       expect(process.stdout()).not.toContain("--display");
@@ -181,7 +184,7 @@ describe("automation client startup refusals", () => {
 
   it.live("a --port that is not an integer exits 1 with a usage error", () =>
     Effect.promise(async () => {
-      const process = spawnAutomationClient(["--port", "forty"]);
+      const process = spawnAutomationClient([...MAX_JOBS, "--port", "forty"]);
       const { code } = await process.exited;
       expect(code).toBe(1);
       expect(process.stderr()).toContain("forty");
@@ -189,9 +192,29 @@ describe("automation client startup refusals", () => {
     }),
   );
 
+  it.live("a missing --max-jobs exits 1 with the usage error and never listens", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomationClient(["--port", "54322"]);
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("Missing required flag: --max-jobs");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live("--max-jobs 0 exits 1 with the rule", () =>
+    Effect.promise(async () => {
+      const process = spawnAutomationClient(["--max-jobs", "0"]);
+      const { code } = await process.exited;
+      expect(code).toBe(1);
+      expect(process.stderr()).toContain("max-jobs must be at least 1");
+      expect(process.stdout()).not.toContain("listening");
+    }),
+  );
+
   it.live("a --url that is not an http or https url exits 1 with the rule", () =>
     Effect.promise(async () => {
-      const process = spawnAutomationClient(["--url", "ftp://qemu.example.com"]);
+      const process = spawnAutomationClient([...MAX_JOBS, "--url", "ftp://qemu.example.com"]);
       const { code } = await process.exited;
       expect(code).toBe(1);
       expect(process.stderr()).toContain("url must be an http or https url");
@@ -201,7 +224,7 @@ describe("automation client startup refusals", () => {
 
   it.live("a missing OLIGARCHY_TOKEN exits 1 with OLIGARCHY_TOKEN is not set", () =>
     Effect.promise(async () => {
-      const process = spawnAutomationClient([], { OLIGARCHY_TOKEN: "" });
+      const process = spawnAutomationClient([...MAX_JOBS], { OLIGARCHY_TOKEN: "" });
       const { code } = await process.exited;
       expect(code).toBe(1);
       expect(process.stderr()).toContain("OLIGARCHY_TOKEN is not set");
@@ -212,7 +235,7 @@ describe("automation client startup refusals", () => {
 
   it.live("a missing DATABASE_URL exits 1 with DATABASE_URL is not set", () =>
     Effect.promise(async () => {
-      const process = spawnAutomationClient([], { DATABASE_URL: "" });
+      const process = spawnAutomationClient([...MAX_JOBS], { DATABASE_URL: "" });
       const { code } = await process.exited;
       expect(code).toBe(1);
       expect(process.stderr()).toContain("DATABASE_URL is not set");
@@ -222,7 +245,7 @@ describe("automation client startup refusals", () => {
 
   it.live("an unreachable database exits 1 and never listens", () =>
     Effect.promise(async () => {
-      const process = spawnAutomationClient([], { DATABASE_URL: UNREACHABLE });
+      const process = spawnAutomationClient([...MAX_JOBS], { DATABASE_URL: UNREACHABLE });
       const { code } = await process.exited;
       expect(code).toBe(1);
       const fatal = lines(process.stdout()).find((line) =>
@@ -244,7 +267,7 @@ describeWithDatabase("automation client startup refusals with a database", () =>
     Effect.promise(async () => {
       const { port, release } = await occupy();
       try {
-        const process = spawnAutomationClient(["--port", String(port)]);
+        const process = spawnAutomationClient([...MAX_JOBS, "--port", String(port)]);
         const { code } = await process.exited;
         expect(code).toBe(1);
         const fatal = lines(process.stdout()).find((line) =>
@@ -267,7 +290,7 @@ describeWithDatabase("automation client POST /run", () => {
       const bin = installOpencode("exit 0");
       const port = await freePort();
       const process = spawnAutomationClient(
-        ["--port", String(port)],
+        [...MAX_JOBS, "--port", String(port)],
         {},
         `${bin}:${processEnv.PATH ?? ""}`,
       );
@@ -296,7 +319,7 @@ describeWithDatabase("automation client POST /run", () => {
       const bin = installOpencode("echo out of token credits >&2; exit 1");
       const port = await freePort();
       const process = spawnAutomationClient(
-        ["--port", String(port)],
+        [...MAX_JOBS, "--port", String(port)],
         {},
         `${bin}:${processEnv.PATH ?? ""}`,
       );
@@ -325,7 +348,7 @@ describeWithDatabase("automation client POST /run", () => {
       const bin = installOpencode("exit 0");
       const port = await freePort();
       const process = spawnAutomationClient(
-        ["--port", String(port)],
+        [...MAX_JOBS, "--port", String(port)],
         {},
         `${bin}:${processEnv.PATH ?? ""}`,
       );
@@ -350,6 +373,64 @@ describeWithDatabase("automation client POST /run", () => {
       }
     }),
   );
+
+  it.live("answers 503 at capacity while --max-jobs runs are in flight", () =>
+    Effect.promise(async () => {
+      const startedDir = mkdtempSync(join(tmpdir(), "oligarchy-opencode-started-"));
+      const started = join(startedDir, "ready");
+      const bin = installOpencode(`touch "${started}"; sleep 60`);
+      const port = await freePort();
+      const process = spawnAutomationClient(
+        [...MAX_JOBS, "--port", String(port)],
+        {},
+        `${bin}:${processEnv.PATH ?? ""}`,
+      );
+      try {
+        await process.waitFor(
+          new RegExp(`automation client listening on 127.0.0.1:${String(port)}; max jobs 1`),
+        );
+        const running = request(
+          port,
+          "/run",
+          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          JSON.stringify({ prompt: "do the work", ticket: "OLI-42" }),
+        );
+        const began = Date.now();
+        while (!existsSync(started)) {
+          if (Date.now() - began > 10_000) {
+            throw new Error("opencode did not start");
+          }
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        const refused = await request(
+          port,
+          "/run",
+          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          JSON.stringify({ prompt: "more work", ticket: "OLI-99" }),
+        );
+        expect(refused.status).toBe(503);
+        expect(await refused.json()).toEqual({ error: "at capacity: max-jobs is 1" });
+        const aborted = await request(
+          port,
+          "/abort",
+          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          JSON.stringify({ ticket: "OLI-42" }),
+        );
+        expect(aborted.status).toBe(200);
+        expect((await running).status).toBe(500);
+        expect(
+          lines(process.stdout()).some((line) =>
+            line.includes("POST /run failed: at capacity: max-jobs is 1"),
+          ),
+        ).toBe(true);
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+        rmSync(bin, { recursive: true, force: true });
+        rmSync(startedDir, { recursive: true, force: true });
+      }
+    }),
+  );
 });
 
 describeWithDatabase("automation client POST /abort", () => {
@@ -360,7 +441,7 @@ describeWithDatabase("automation client POST /abort", () => {
       const bin = installOpencode(`touch "${started}"; sleep 60`);
       const port = await freePort();
       const process = spawnAutomationClient(
-        ["--port", String(port)],
+        [...MAX_JOBS, "--port", String(port)],
         {},
         `${bin}:${processEnv.PATH ?? ""}`,
       );
@@ -407,7 +488,7 @@ describeWithDatabase("automation client POST /abort", () => {
       const bin = installOpencode(`trap "" TERM; touch "${started}"; sleep 60`);
       const port = await freePort();
       const process = spawnAutomationClient(
-        ["--port", String(port)],
+        [...MAX_JOBS, "--port", String(port)],
         {},
         `${bin}:${processEnv.PATH ?? ""}`,
       );
@@ -452,7 +533,7 @@ describeWithDatabase("automation client POST /abort", () => {
       const bin = installOpencode("exit 0");
       const port = await freePort();
       const process = spawnAutomationClient(
-        ["--port", String(port)],
+        [...MAX_JOBS, "--port", String(port)],
         {},
         `${bin}:${processEnv.PATH ?? ""}`,
       );
@@ -495,13 +576,13 @@ describe("automation client announce", () => {
       Effect.gen(function* () {
         const port = yield* Effect.promise(freePort);
         const url = `http://automation-client.test:${String(port)}`;
-        const process = spawnAutomationClient(["--url", url, "--port", String(port)], {
+        const process = spawnAutomationClient([...MAX_JOBS, "--url", url, "--port", String(port)], {
           DATABASE_URL: dbUrl,
         });
         const row = yield* Effect.gen(function* () {
           yield* Effect.promise(() => process.waitFor(/automation client listening/));
           expect(process.stdout()).toContain(
-            `automation client listening on 127.0.0.1:${String(port)}; announcing ${url}`,
+            `automation client listening on 127.0.0.1:${String(port)}; max jobs 1; announcing ${url}`,
           );
           return yield* announced(url).pipe(
             Effect.repeat({

--- a/test/integration/qemu-server.integration.test.ts
+++ b/test/integration/qemu-server.integration.test.ts
@@ -25,6 +25,8 @@ const QEMU_SERVER = fileURLToPath(new URL("../../qemu-server", import.meta.url))
 const TOKEN = "t";
 const UNREACHABLE = "postgres://user:sentinel-pw@127.0.0.1:1/oligarchy";
 const EXIT_WITHIN_MS = 60_000;
+// --max-jobs has no default, so every server that should get past parsing carries one.
+const MAX_JOBS: ReadonlyArray<string> = ["--max-jobs", "1"];
 
 const dbUrl = inject("dbUrl");
 
@@ -194,7 +196,7 @@ const request = (
 describe("qemu server startup refusals", () => {
   it.live("--automation --display none exits 1 with --automation is exclusive", () =>
     Effect.promise(async () => {
-      const server = spawnQemuServer(["--automation", "--display", "none"]);
+      const server = spawnQemuServer([...MAX_JOBS, "--automation", "--display", "none"]);
       const { code } = await server.exited;
       expect(code).toBe(1);
       expect(server.stderr()).toContain("--automation is exclusive");
@@ -205,7 +207,7 @@ describe("qemu server startup refusals", () => {
 
   it.live("an unknown --display value exits 1 with a usage error", () =>
     Effect.promise(async () => {
-      const server = spawnQemuServer(["--display", "curses"]);
+      const server = spawnQemuServer([...MAX_JOBS, "--display", "curses"]);
       const { code } = await server.exited;
       expect(code).toBe(1);
       expect(server.stderr()).toContain("curses");
@@ -213,7 +215,27 @@ describe("qemu server startup refusals", () => {
     }),
   );
 
-  it.live("--help exits 0 and lists the four flags", () =>
+  it.live("a missing --max-jobs exits 1 with the usage error and never listens", () =>
+    Effect.promise(async () => {
+      const server = spawnQemuServer(["--automation"]);
+      const { code } = await server.exited;
+      expect(code).toBe(1);
+      expect(server.stderr()).toContain("Missing required flag: --max-jobs");
+      expect(server.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live("--max-jobs 0 exits 1 with the rule", () =>
+    Effect.promise(async () => {
+      const server = spawnQemuServer(["--max-jobs", "0"]);
+      const { code } = await server.exited;
+      expect(code).toBe(1);
+      expect(server.stderr()).toContain("max-jobs must be at least 1");
+      expect(server.stdout()).not.toContain("listening");
+    }),
+  );
+
+  it.live("--help exits 0 and lists the five flags", () =>
     Effect.promise(async () => {
       const server = spawnQemuServer(["--help"]);
       const { code } = await server.exited;
@@ -221,6 +243,7 @@ describe("qemu server startup refusals", () => {
       expect(server.stdout()).toContain("qemu-server");
       expect(server.stdout()).toContain("--display");
       expect(server.stdout()).toContain("--automation");
+      expect(server.stdout()).toContain("--max-jobs");
       expect(server.stdout()).toContain("--port");
       expect(server.stdout()).toContain("--url");
     }),
@@ -228,7 +251,7 @@ describe("qemu server startup refusals", () => {
 
   it.live("a --url that is not an http or https url exits 1 with the rule", () =>
     Effect.promise(async () => {
-      const server = spawnQemuServer(["--url", "ftp://qemu.example.com"]);
+      const server = spawnQemuServer([...MAX_JOBS, "--url", "ftp://qemu.example.com"]);
       const { code } = await server.exited;
       expect(code).toBe(1);
       expect(server.stderr()).toContain("url must be an http or https url");
@@ -238,7 +261,7 @@ describe("qemu server startup refusals", () => {
 
   it.live("a missing OLIGARCHY_TOKEN exits 1 with OLIGARCHY_TOKEN is not set", () =>
     Effect.promise(async () => {
-      const server = spawnQemuServer([], { OLIGARCHY_TOKEN: "" });
+      const server = spawnQemuServer([...MAX_JOBS], { OLIGARCHY_TOKEN: "" });
       const { code } = await server.exited;
       expect(code).toBe(1);
       expect(server.stderr()).toContain("OLIGARCHY_TOKEN is not set");
@@ -250,7 +273,7 @@ describe("qemu server startup refusals", () => {
     "missing host requirements exit 1 with the fatal line last on stdout",
     () =>
       Effect.promise(async () => {
-        const server = spawnQemuServer([], (dir) => ({ PATH: pathWithoutQemu(dir) }));
+        const server = spawnQemuServer([...MAX_JOBS], (dir) => ({ PATH: pathWithoutQemu(dir) }));
         const { code } = await server.exited;
         expect(code).toBe(1);
         const output = lines(server.stdout());
@@ -267,7 +290,7 @@ describe("qemu server startup refusals", () => {
 
   it.live.skipIf(!hasQemu)("an unreachable database exits 1 with database unreachable", () =>
     Effect.promise(async () => {
-      const server = spawnQemuServer([], { DATABASE_URL: UNREACHABLE });
+      const server = spawnQemuServer([...MAX_JOBS], { DATABASE_URL: UNREACHABLE });
       const { code } = await server.exited;
       expect(code).toBe(1);
       const fatal = lines(server.stdout()).find((line) =>
@@ -285,7 +308,7 @@ describe("qemu server startup refusals", () => {
     Effect.promise(async () => {
       const { port, release } = await occupy();
       try {
-        const server = spawnQemuServer(["--port", String(port)]);
+        const server = spawnQemuServer([...MAX_JOBS, "--port", String(port)]);
         const { code } = await server.exited;
         expect(code).toBe(1);
         const fatal = lines(server.stdout()).find((line) =>
@@ -309,7 +332,7 @@ describe("qemu server serving", () => {
   ) =>
     Effect.promise(async () => {
       const port = await freePort();
-      const server = spawnQemuServer([...args, "--port", String(port)]);
+      const server = spawnQemuServer([...MAX_JOBS, ...args, "--port", String(port)]);
       await server.waitFor(/qemu server listening/);
       expect(lines(server.stdout())).toContain(listenLine(port));
 
@@ -375,7 +398,7 @@ describe("qemu server serving", () => {
         const port = await freePort();
         const full = openSync("/dev/full", "w");
         const dir = mkdtempSync(join(tmpdir(), "oligarchy-qemu-server-test-"));
-        const child = spawn(QEMU_SERVER, ["--port", String(port)], {
+        const child = spawn(QEMU_SERVER, [...MAX_JOBS, "--port", String(port)], {
           cwd: dir,
           env: environment({}),
           stdio: ["ignore", full, full],
@@ -421,7 +444,7 @@ describe("qemu server serving", () => {
       serving(
         [],
         (port) =>
-          `[global] server: qemu server listening on 127.0.0.1:${String(port)}; display none`,
+          `[global] server: qemu server listening on 127.0.0.1:${String(port)}; display none; max jobs 1`,
         "SIGINT",
       ),
     120_000,
@@ -433,7 +456,7 @@ describe("qemu server serving", () => {
       serving(
         ["--automation"],
         (port) =>
-          `[global] server: qemu server listening on 127.0.0.1:${String(port)}; display none; automation`,
+          `[global] server: qemu server listening on 127.0.0.1:${String(port)}; display none; automation; max jobs 1`,
         "SIGTERM",
       ),
     120_000,
@@ -456,11 +479,18 @@ describe("qemu server serving", () => {
       Effect.gen(function* () {
         const port = yield* Effect.promise(freePort);
         const url = `http://qemu-a.test:${String(port)}`;
-        const server = spawnQemuServer(["--automation", "--url", url, "--port", String(port)]);
+        const server = spawnQemuServer([
+          ...MAX_JOBS,
+          "--automation",
+          "--url",
+          url,
+          "--port",
+          String(port),
+        ]);
         const row = yield* Effect.gen(function* () {
           yield* Effect.promise(() => server.waitFor(/qemu server listening/));
           expect(lines(server.stdout())).toContain(
-            `[global] server: qemu server listening on 127.0.0.1:${String(port)}; display none; automation; announcing ${url}`,
+            `[global] server: qemu server listening on 127.0.0.1:${String(port)}; display none; automation; max jobs 1; announcing ${url}`,
           );
           // The first heartbeat is written right after the listen line; the insert takes a moment.
           return yield* announced(url).pipe(

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -592,10 +592,13 @@ describe("placement", () => {
     Effect.gen(function* () {
       const fixed = fixture();
       yield* Effect.gen(function* () {
-        // The reverse proxy's own contract decodes the 503; ./client sees ProxyRefusal 503.
+        // /start answers 503 twice over — the reverse proxy's own NoServer and a server's
+        // AtCapacity passed through — on one `{ error }` body, so the generated client cannot
+        // tell them apart by tag; the status and the message are the contract, as ./client's
+        // ProxyRefusal 503 reads them.
         const api = yield* qemuReverseProxyClient;
         const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
-        expect(error).toMatchObject({ _tag: "NoServer", message: "no server registered" });
+        expect(error.message).toBe("no server registered");
         const http = yield* HttpClient.HttpClient;
         const raw = yield* http.post("/start", {
           headers: { authorization: AUTHORIZATION },
@@ -633,7 +636,7 @@ describe("placement", () => {
       yield* Effect.gen(function* () {
         const api = yield* qemuReverseProxyClient;
         const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
-        expect(error).toMatchObject({ _tag: "NoServer", message: "no server available" });
+        expect(error.message).toBe("no server available");
       }).pipe(Effect.provide(serve(fixed)));
       expect(fixed.store.routes.size).toBe(0);
       expect(fixed.log.lines.map((line) => [line.level, line.text, line.agentId])).toEqual([

--- a/test/qemu-server/command.unit.test.ts
+++ b/test/qemu-server/command.unit.test.ts
@@ -60,7 +60,10 @@ const refused = Errors.DatabaseError.make({
   cause: new Error("connect ECONNREFUSED 127.0.0.1:1"),
 });
 
-type Served = readonly [Domain.QemuDisplay, boolean, number, Option.Option<string>];
+type Served = readonly [Domain.QemuDisplay, boolean, number, number, Option.Option<string>];
+
+// --max-jobs has no default, so every run that should reach the handler carries one.
+const MAX_JOBS: ReadonlyArray<string> = ["--max-jobs", "2"];
 
 // The host check, the server layer and the failure signal the command is built from.
 const fakeServer = (missing: ReadonlyArray<string> = []) => {
@@ -74,10 +77,10 @@ const fakeServer = (missing: ReadonlyArray<string> = []) => {
         checked.push(display);
         return missing;
       }),
-    serve: (display, automation, port, url) =>
+    serve: (display, automation, maxJobs, port, url) =>
       Layer.effectDiscard(
         Effect.gen(function* () {
-          served.push([display, automation, port, url]);
+          served.push([display, automation, maxJobs, port, url]);
           yield* Deferred.succeed(listening, undefined);
         }),
       ),
@@ -101,7 +104,9 @@ describe("qemu server command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, ["--automation", "--display", "gtk"], log));
+      const error = yield* Effect.flip(
+        run(fake.server, [...MAX_JOBS, "--automation", "--display", "gtk"], log),
+      );
       expect(CliError.isCliError(error)).toBe(true);
       expect(error).toMatchObject({ _tag: "UserError", userMessage: "--automation is exclusive" });
       expect(fake.checked).toEqual([]);
@@ -117,7 +122,7 @@ describe("qemu server command flags", () => {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
       const error = yield* Effect.flip(
-        run(fake.server, ["--display", "none", "--automation"], log),
+        run(fake.server, [...MAX_JOBS, "--display", "none", "--automation"], log),
       );
       expect(error).toMatchObject({ _tag: "UserError", userMessage: "--automation is exclusive" });
       expect(fake.served).toEqual([]);
@@ -128,7 +133,7 @@ describe("qemu server command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, ["--display", "curses"], log));
+      const error = yield* Effect.flip(run(fake.server, [...MAX_JOBS, "--display", "curses"], log));
       expect(error._tag).toBe("ShowHelp");
       if (error._tag === "ShowHelp") {
         expect(error.errors.length).toBeGreaterThan(0);
@@ -144,9 +149,52 @@ describe("qemu server command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, ["--port", "forty"], log));
+      const error = yield* Effect.flip(run(fake.server, [...MAX_JOBS, "--port", "forty"], log));
       expect(error._tag).toBe("ShowHelp");
       expect(fake.served).toEqual([]);
+    }),
+  );
+
+  it.effect("a missing --max-jobs is a usage error that touches nothing", () =>
+    Effect.gen(function* () {
+      const fake = fakeServer();
+      const log = FakeLog.fakeLog();
+      const error = yield* Effect.flip(run(fake.server, ["--automation"], log));
+      expect(error._tag).toBe("ShowHelp");
+      if (error._tag === "ShowHelp") {
+        expect(error.errors).toMatchObject([{ _tag: "MissingOption", option: "max-jobs" }]);
+      }
+      const stderr = yield* TestConsole.errorLines;
+      expect(stderr.join("\n")).toContain("--max-jobs");
+      expect(fake.checked).toEqual([]);
+      expect(fake.served).toEqual([]);
+      expect(log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("--max-jobs below 1 or not an integer is a usage error with the flag's rule", () =>
+    Effect.gen(function* () {
+      const log = FakeLog.fakeLog();
+      // The negative in `=` form: a bare `-1` after the flag is itself read as a flag.
+      for (const args of [["--max-jobs", "0"], ["--max-jobs=-1"]]) {
+        const fake = fakeServer();
+        const error = yield* Effect.flip(run(fake.server, args, log));
+        expect(error._tag).toBe("ShowHelp");
+        if (error._tag === "ShowHelp") {
+          expect(error.errors).toMatchObject([{ _tag: "InvalidValue", option: "max-jobs" }]);
+        }
+        expect(fake.checked).toEqual([]);
+        expect(fake.served).toEqual([]);
+      }
+      const stderr = yield* TestConsole.errorLines;
+      expect(stderr.join("\n")).toContain("max-jobs must be at least 1");
+      for (const value of ["1.5", "two"]) {
+        const fake = fakeServer();
+        const error = yield* Effect.flip(run(fake.server, ["--max-jobs", value], log));
+        expect(error._tag).toBe("ShowHelp");
+        expect(fake.served).toEqual([]);
+      }
+      expect(log.lines).toEqual([]);
     }),
   );
 
@@ -163,6 +211,7 @@ describe("qemu server command flags", () => {
       expect(stdout.join("\n")).toContain("qemu-server");
       expect(stdout.join("\n")).toContain("--automation");
       expect(stdout.join("\n")).toContain("--display");
+      expect(stdout.join("\n")).toContain("--max-jobs");
       expect(stdout.join("\n")).toContain("--port");
       expect(stdout.join("\n")).toContain("--url");
     }),
@@ -172,13 +221,13 @@ describe("qemu server command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const fiber = yield* Effect.forkChild(run(fake.server, [], log));
+      const fiber = yield* Effect.forkChild(run(fake.server, [...MAX_JOBS], log));
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
       const exit = yield* Fiber.await(fiber);
       expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
       expect(fake.checked).toEqual(["none"]);
-      expect(fake.served).toEqual([["none", false, 42069, Option.none()]]);
+      expect(fake.served).toEqual([["none", false, 2, 42069, Option.none()]]);
       expect(log.lines).toEqual([]);
     }),
   );
@@ -188,19 +237,38 @@ describe("qemu server command flags", () => {
       const gtk = fakeServer();
       const log = FakeLog.fakeLog();
       const first = yield* Effect.forkChild(
-        run(gtk.server, ["--display", "gtk", "--port", "1234"], log),
+        run(gtk.server, [...MAX_JOBS, "--display", "gtk", "--port", "1234"], log),
       );
       yield* Deferred.await(gtk.listening);
       yield* Fiber.interrupt(first);
       expect(gtk.checked).toEqual(["gtk"]);
-      expect(gtk.served).toEqual([["gtk", false, 1234, Option.none()]]);
+      expect(gtk.served).toEqual([["gtk", false, 2, 1234, Option.none()]]);
 
       const automation = fakeServer();
-      const second = yield* Effect.forkChild(run(automation.server, ["--automation"], log));
+      const second = yield* Effect.forkChild(
+        run(automation.server, [...MAX_JOBS, "--automation"], log),
+      );
       yield* Deferred.await(automation.listening);
       yield* Fiber.interrupt(second);
       expect(automation.checked).toEqual(["none"]);
-      expect(automation.served).toEqual([["none", true, 42069, Option.none()]]);
+      expect(automation.served).toEqual([["none", true, 2, 42069, Option.none()]]);
+    }),
+  );
+
+  it.effect("--max-jobs reaches the server as given, in either flag form", () =>
+    Effect.gen(function* () {
+      const log = FakeLog.fakeLog();
+      const spaced = fakeServer();
+      const first = yield* Effect.forkChild(run(spaced.server, ["--max-jobs", "3"], log));
+      yield* Deferred.await(spaced.listening);
+      yield* Fiber.interrupt(first);
+      expect(spaced.served).toEqual([["none", false, 3, 42069, Option.none()]]);
+
+      const joined = fakeServer();
+      const second = yield* Effect.forkChild(run(joined.server, ["--max-jobs=1"], log));
+      yield* Deferred.await(joined.listening);
+      yield* Fiber.interrupt(second);
+      expect(joined.served).toEqual([["none", false, 1, 42069, Option.none()]]);
     }),
   );
 
@@ -209,11 +277,13 @@ describe("qemu server command flags", () => {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
       const fiber = yield* Effect.forkChild(
-        run(fake.server, ["--url", "http://127.0.0.1:55332", "--automation"], log),
+        run(fake.server, [...MAX_JOBS, "--url", "http://127.0.0.1:55332", "--automation"], log),
       );
       yield* Deferred.await(fake.listening);
       yield* Fiber.interrupt(fiber);
-      expect(fake.served).toEqual([["none", true, 42069, Option.some("http://127.0.0.1:55332")]]);
+      expect(fake.served).toEqual([
+        ["none", true, 2, 42069, Option.some("http://127.0.0.1:55332")],
+      ]);
     }),
   );
 
@@ -221,7 +291,9 @@ describe("qemu server command flags", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, ["--url", "ftp://qemu.example.com"], log));
+      const error = yield* Effect.flip(
+        run(fake.server, [...MAX_JOBS, "--url", "ftp://qemu.example.com"], log),
+      );
       expect(error._tag).toBe("ShowHelp");
       if (error._tag === "ShowHelp") {
         expect(error.errors.length).toBeGreaterThan(0);
@@ -245,7 +317,7 @@ describe("qemu server command startup failures", () => {
       ];
       const fake = fakeServer(missing);
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, [], log, Effect.fail(refused)));
+      const error = yield* Effect.flip(run(fake.server, [...MAX_JOBS], log, Effect.fail(refused)));
       expect(error).toMatchObject({ _tag: "HostRequirementsMissing", missing });
       expect(fake.served).toEqual([]);
       expect(log.lines).toEqual([
@@ -265,7 +337,7 @@ describe("qemu server command startup failures", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(fake.server, [], log, Effect.fail(refused)));
+      const error = yield* Effect.flip(run(fake.server, [...MAX_JOBS], log, Effect.fail(refused)));
       expect(error).toMatchObject({
         _tag: "DatabaseError",
         operation: "ping",
@@ -293,7 +365,7 @@ describe("qemu server command startup failures", () => {
       const error = yield* Effect.flip(
         run(
           fake.server,
-          [],
+          [...MAX_JOBS],
           log,
           Effect.fail(Errors.DatabaseError.make({ operation: "ping", message: "pool ended" })),
         ),
@@ -307,7 +379,7 @@ describe("qemu server command startup failures", () => {
     Effect.gen(function* () {
       const fake = fakeServer();
       const log = FakeLog.fakeLog();
-      const fiber = yield* Effect.forkChild(run(fake.server, [], log));
+      const fiber = yield* Effect.forkChild(run(fake.server, [...MAX_JOBS], log));
       yield* Deferred.await(fake.listening);
       const cause = new Error("accept EMFILE: too many open files");
       yield* Deferred.fail(fake.serverFailed, new HttpServerError.ServeError({ cause }));
@@ -336,7 +408,7 @@ describe("qemu server command startup failures", () => {
         serve: () => Layer.effectDiscard(Effect.fail(new HttpServerError.ServeError({ cause }))),
       };
       const log = FakeLog.fakeLog();
-      const error = yield* Effect.flip(run(failing, ["--port", "42069"], log));
+      const error = yield* Effect.flip(run(failing, [...MAX_JOBS, "--port", "42069"], log));
       expect(error).toMatchObject({ _tag: "ServeError", cause });
       expect(log.lines.map((line) => [line.level, line.text])).toEqual([
         ["fatal", "qemu server: listen EADDRINUSE: address already in use 127.0.0.1:42069"],

--- a/test/qemu-server/http.unit.test.ts
+++ b/test/qemu-server/http.unit.test.ts
@@ -838,6 +838,59 @@ describe("Sessions failures", () => {
     }),
   );
 
+  it.effect("an AtCapacity from start is 503 with its message, attributed to the agent", () =>
+    Effect.gen(function* () {
+      const fixed = fixture({
+        sessions: FakeSessions.fakeSessions({
+          start: (body) =>
+            Effect.fail(
+              Errors.AtCapacity.make({
+                message: "at capacity: max-jobs is 2",
+                agentId: body.agent,
+              }),
+            ),
+        }),
+      });
+      yield* Effect.gen(function* () {
+        const api = yield* client;
+        const error = yield* Effect.flip(
+          api.Sessions.start({
+            payload: Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID }),
+          }),
+        );
+        expect(error).toMatchObject({ _tag: "AtCapacity", message: "at capacity: max-jobs is 2" });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/start", {
+          headers: { authorization: `Bearer ${TOKEN}` },
+          body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: AGENT_ID }),
+        });
+        expect(raw.status).toBe(503);
+        expect(yield* raw.json).toEqual({ error: "at capacity: max-jobs is 2" });
+      }).pipe(Effect.provide(serve(fixed)));
+      // No session was minted, so the line sits in the server bucket under the refused agent;
+      // a 503 is the fleet's problem to place elsewhere, so unlike a 4xx it reaches Sentry.
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /start failed: at capacity: max-jobs is 2",
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: false,
+          cause: undefined,
+        },
+        {
+          level: "error",
+          text: "POST /start failed: at capacity: max-jobs is 2",
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
   it.effect(
     "an Internal raised by Sessions is 500 internal error, logged with the driver's reason",
     () =>

--- a/test/qemu-server/sessions.unit.test.ts
+++ b/test/qemu-server/sessions.unit.test.ts
@@ -35,6 +35,8 @@ const URL_ISO = "https://example.com/omarchy.iso";
 const DISK = "/disks/omarchy.qcow2";
 const UNKNOWN_ID = "1baaad43-674b-4bdb-88d7-3f18fce50aba";
 const SERIAL = new TextEncoder().encode("boot log\n");
+// Room for every session a test below starts; the capacity tests pass their own.
+const MAX_JOBS = 4;
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -85,6 +87,7 @@ type Options = {
   readonly debugLogStore?: Parameters<typeof Stores.fakeDebugLogStore>[0];
   readonly log?: Layer.Layer<Log.Log>;
   readonly shutdown?: Sessions.Shutdown;
+  readonly maxJobs?: number;
 };
 
 const harness = (options: Options = {}) => {
@@ -113,7 +116,7 @@ const harness = (options: Options = {}) => {
     options.shutdown === undefined
       ? Layer.empty
       : Layer.succeed(Sessions.Shutdown)(options.shutdown);
-  const layer = Sessions.Sessions.layer.pipe(
+  const layer = Sessions.Sessions.layer(options.maxJobs ?? MAX_JOBS).pipe(
     Layer.provide(
       Layer.mergeAll(
         qemu.layer,
@@ -2005,6 +2008,147 @@ describe("stats", () => {
           expect(yield* qemus(sessions)).toBe(2);
           yield* sessions.stop(live, undefined, undefined);
           expect((yield* sessions.stats).qemus).toBe(1);
+        }),
+      );
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// capacity
+// ---------------------------------------------------------------------------
+
+describe("capacity", () => {
+  it.effect("a start past --max-jobs is AtCapacity before anything is minted or written", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const { sessions, id } = yield* start();
+          const error = yield* Effect.flip(
+            sessions.start(startBody(ISO, OTHER_AGENT), "none", false),
+          );
+          expect(error).toMatchObject({
+            _tag: "AtCapacity",
+            message: "at capacity: max-jobs is 1",
+            agentId: OTHER_AGENT,
+          });
+          // Nothing of the refused start exists: no row, no iso lookup, no machine, no span, no
+          // colour, no log line; the running session is untouched.
+          expect(h.sessions.sessions.map((row) => row.id)).toEqual([id]);
+          expect(h.sessions.agentRuns.map((row) => row.agentId)).toEqual([AGENT]);
+          expect(h.iso.calls).toHaveLength(1);
+          expect(h.qemu.calls.map((call) => call._tag)).toEqual(["prepare", "start"]);
+          expect(spanNamed(h, OTHER_AGENT)).toBeUndefined();
+          expect(h.log.acquired).toEqual([AGENT]);
+          expect(texts(h)).toEqual([`starting; iso ${ISO}`, "running; started in 0ms"]);
+          expect(yield* qemus(sessions)).toBe(1);
+          expect(yield* sessions.lookup(id, AGENT)).toBeDefined();
+        }),
+      );
+    }),
+  );
+
+  it.effect("a booting session holds its slot until it is running", () =>
+    Effect.gen(function* () {
+      const gate = yield* Deferred.make<void>();
+      const h = harness({ maxJobs: 1, script: { boot: () => Deferred.await(gate) } });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          const booting = yield* Effect.forkChild(sessions.start(startBody(), "none", false), {
+            startImmediately: true,
+          });
+          expect(yield* qemus(sessions)).toBe(0);
+          const error = yield* Effect.flip(
+            sessions.start(startBody(ISO, OTHER_AGENT), "none", false),
+          );
+          expect(error).toMatchObject({ _tag: "AtCapacity", agentId: OTHER_AGENT });
+          yield* Deferred.succeed(gate, undefined);
+          const id = yield* Fiber.join(booting);
+          expect(h.sessions.sessions.map((row) => row.id)).toEqual([id]);
+          expect(yield* qemus(sessions)).toBe(1);
+        }),
+      );
+    }),
+  );
+
+  it.effect("a stopped session frees its slot", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const { sessions, live } = yield* start();
+          expect(
+            (yield* Effect.flip(sessions.start(startBody(ISO, OTHER_AGENT), "none", false)))._tag,
+          ).toBe("AtCapacity");
+          yield* sessions.stop(live, "succeeded", "done");
+          const next = yield* sessions.start(startBody(ISO, OTHER_AGENT), "none", false);
+          expect(h.sessions.sessions.map((row) => [row.id, row.status])).toEqual([
+            [live.id, "succeeded"],
+            [next, "running"],
+          ]);
+          expect(yield* qemus(sessions)).toBe(1);
+        }),
+      );
+    }),
+  );
+
+  it.effect("a start that fails to boot or to insert its row frees its slot", () =>
+    Effect.gen(function* () {
+      let boots = 0;
+      let inserts = 0;
+      const h = harness({
+        maxJobs: 1,
+        script: {
+          boot: () =>
+            Effect.suspend(() =>
+              ++boots === 1
+                ? Effect.fail(Errors.QemuStartError.make({ message: "qemu: exited 1" }))
+                : Effect.void,
+            ),
+        },
+        sessionStore: {
+          insertSession: () =>
+            Effect.suspend(() =>
+              ++inserts === 2
+                ? Effect.fail(failure("insertSession", "connect ECONNREFUSED"))
+                : Effect.void,
+            ),
+        },
+      });
+      // A boot failure spends the agent's one registration, so every start names a new agent.
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          const booted = yield* Effect.flip(sessions.start(startBody(ISO, AGENT), "none", false));
+          expect(booted._tag).toBe("StartFailed");
+          const inserted = yield* Effect.flip(
+            sessions.start(startBody(ISO, OTHER_AGENT), "none", false),
+          );
+          expect(inserted._tag).toBe("Internal");
+          const id = yield* sessions.start(startBody(ISO, "OLI-63"), "none", false);
+          expect(Domain.isSessionId(id)).toBe(true);
+          expect(yield* qemus(sessions)).toBe(1);
+          expect(
+            (yield* Effect.flip(sessions.start(startBody(ISO, "OLI-64"), "none", false)))._tag,
+          ).toBe("AtCapacity");
+        }),
+      );
+    }),
+  );
+
+  it.effect("a timed-out session frees its slot", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const { sessions, id } = yield* start();
+          yield* TestClock.adjust("10 minutes");
+          expect(h.sessions.sessions[0]).toMatchObject({ id, status: "timed_out" });
+          const next = yield* sessions.start(startBody(ISO, OTHER_AGENT), "none", false);
+          expect(next).not.toBe(id);
+          expect(yield* qemus(sessions)).toBe(1);
         }),
       );
     }),

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -116,7 +116,8 @@ describe("QemuServerApi", () => {
 
   it("declares the error statuses of §2.4 plus the middleware's 400, 401 and 500", () => {
     const sessions = [400, 401, 500];
-    expect(byIdentifier(Api.QemuServerApi, "start").errors).toEqual([...sessions, 502]);
+    // 502: the machine failed to boot; 503: the server is at --max-jobs.
+    expect(byIdentifier(Api.QemuServerApi, "start").errors).toEqual([...sessions, 502, 503]);
     expect(byIdentifier(Api.QemuServerApi, "image").errors).toEqual(
       [...sessions, 403, 404, 502].sort((a, b) => a - b),
     );
@@ -278,7 +279,8 @@ describe("AutomationClientApi", () => {
     expect(run.group).toBe("Runs");
     expect(run.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);
     expect(spec.paths["/run"]?.post?.security).toEqual([{ bearer: [] }]);
-    expect(run.errors).toEqual([400, 401, 500]);
+    // 500: opencode failed; 503: the client is at --max-jobs.
+    expect(run.errors).toEqual([400, 401, 500, 503]);
     const abort = byIdentifier(client, "abort");
     expect(abort.group).toBe("Runs");
     expect(abort.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);

--- a/test/shared/errors.unit.test.ts
+++ b/test/shared/errors.unit.test.ts
@@ -112,6 +112,12 @@ const cases: ReadonlyArray<WireCase> = [
     error: Errors.RunFailed.make({ message: "out of token credits" }),
     status: 500,
   },
+  {
+    name: "AtCapacity",
+    wire: Errors.AtCapacityWire,
+    error: Errors.AtCapacity.make({ message: "at capacity: max-jobs is 2", agentId: AGENT_ID }),
+    status: 503,
+  },
 ];
 
 describe("API error wire codecs", () => {
@@ -246,5 +252,6 @@ describe("domain error messages", () => {
     expect(Errors.LogLine.make({ text: "x", level: "error" })._tag).toBe("LogLine");
     expect(Errors.CliFailed.make({ command: "tool", message: "x" })._tag).toBe("CliFailed");
     expect(Errors.RunFailed.make({ message: "x" })._tag).toBe("RunFailed");
+    expect(Errors.AtCapacity.make({ message: "x" })._tag).toBe("AtCapacity");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Both processes take a required `--max-jobs` flag and keep one in-process integer of admitted jobs. `POST /start` (qemu server) and `POST /run` (automation client) are refused with **503 `{ "error": "at capacity: max-jobs is N" }`** once that many jobs are held. Nothing is persisted; no schema change. The automation server and the qemu reverse proxy are untouched (the reverse proxy already passes a server's non-200 `/start` answer through verbatim).

## Why 503

RFC 9110 §15.6.4: 503 is "the server is currently unable to handle the request due to a temporary overload" — a server-side condition the caller places elsewhere or retries later. 429 (RFC 6585) is per-client rate limiting, and 402 is Payment Required. As a 5xx it is reported to Sentry by the boundary, like `NoServer`.

## How

- `Domain.MaxJobs`: an integer ≥ 1, the flag's schema (`max-jobs must be at least 1`).
- `Errors.AtCapacity { message, agentId? }`, `httpApiStatus: 503`, `AtCapacityWire`; declared on the `start` and `run` endpoints; attributed by the boundary like `NoServer` (process bucket, under the refused agent/ticket).
- **qemu-server**: `Sessions.layer(maxJobs)`; the slot is taken atomically (`Ref.modify`) at the top of `start` before the span, scope or row exist, so a refusal allocates nothing; released in `finishLiveSession`, the one place every admitted session ends (failed insert, failed boot, stop, timeout, drain). A booting session holds its slot. Listen line: `…; display none; automation; max jobs 2; announcing …`.
- **automation-client**: `Sessions.layer(maxJobs)`; the slot is the run's first scoped resource (`Effect.acquireRelease`), taken before the spawn so a refused run spawns nothing, released last after the child is reaped. Listen line: `…:54322; max jobs 1; announcing …`.
- `--max-jobs` is required (no default): capacity is the operator's knowledge of the host. The dev terminal in `.cursor/environment.json` passes `--max-jobs 2` (a session is 4G / 2 vCPU on this VM).
- `src/qemu-server/sessions.ts` is mostly a one-level re-indent (`make` became `(maxJobs) => Effect.gen(…)`); read it with `git diff -w`.

## Tests (written first)

- `errors.unit`: `AtCapacity` wire round trip, status 503, Sentry-ignored. `api.unit`: `/start` and `/run` declare 503.
- Both `command.unit`: missing `--max-jobs` is a usage error touching nothing; `0`, `-1`, `1.5`, `two` refused with the flag's rule; the value reaches `serve`; `--help` lists it.
- `qemu-server/sessions.unit`: refusal before anything is minted (no row, iso lookup, machine, span, colour or log line); a booting session holds its slot; stop, failed boot, failed insert and timeout free it.
- `automation-client/sessions.unit`: refusal spawns nothing and leaves nothing to abort; exit (0 or not), abort, interruption and a failed spawn free the slot.
- Both `http.unit`: 503 body, one boundary error line, nothing spawned; accepted again once a run ends.
- Integration: every spawn passes `--max-jobs`; missing/zero flag exit 1; listen lines updated; a DB-gated `POST /run` 503 case.
- Reverse proxy: `/start` now has two 503 codecs on one `{ error }` body (its own `NoServer`, a passed-through `AtCapacity`), so two tests pin status + message rather than the decoded tag (`./client` already maps non-2xx by status and message).

## Verification

- `npm run check:fast`: lint, format, types, **1012** unit tests green (992 on master).
- Integration: all 15 runnable cases green; 16 skip here (no Docker/QEMU on the VM).
- Real `./automation-client --max-jobs 1` against a local Postgres 16: listen line, heartbeat row, 503 while a run is in flight, abort → freed slot → next run 200, the persisted boundary log row, exit 0 and the row deleted on SIGTERM.
- Reviewed by a GPT-5.6 Sol subagent per `development.md`; its should-fix (share one bracket for slot acquisition and release) and nit (do not assert an indeterminate decoded tag) are applied.

<details><summary>End-to-end run</summary>

<pre>
=== listen line
[automation-client] automation-client: automation client listening on 127.0.0.1:55990; max jobs 1; announcing http://automation-client.test:55990

=== servers row after the first heartbeat
http://automation-client.test:55990|automation-client|1|0

=== POST /run OLI-42 (holds the one slot; opencode sleeps until aborted)
opencode is running under ticket OLI-42

=== POST /run OLI-99 while at capacity -> expect 503 at capacity
{"error":"at capacity: max-jobs is 1"}
HTTP 503

=== POST /abort OLI-42 -> expect 200
{"ok":"true"}
HTTP 200

=== the aborted run's own response (opencode died from SIGTERM -> 500)
{"error":"Process interrupted due to receipt of signal: 'SIGTERM'"}
HTTP 500

=== POST /run OLI-99 again, slot freed -> expect 200
{"ok":"true"}
HTTP 200

=== the boundary's error lines, as persisted in logs (location = automation-client)
error|OLI-99|POST /run failed: at capacity: max-jobs is 1
error|automation-client|POST /run failed: Process interrupted due to receipt of signal: 'SIGTERM'

=== SIGTERM -> expect exit 0 and the servers row gone
exit 0
servers rows for http://automation-client.test:55990: 0
</pre>
</details>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09364-687d-72eb-ab14-b894fa60cfe9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09364-687d-72eb-ab14-b894fa60cfe9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

