### PR TITLE
Require QEMU-first reserve before run; only /reserve answers 503

### DIFF
--- a/client.md
+++ b/client.md
@@ -71,7 +71,8 @@ CLIENT_IMAGE=screen.png ./client-with-image send-keys --agent-id OLI-42 --server
 ./client start --agent-id <agent> --server-url <url> [--iso <path|url>] [--disk <path>]
 ```
 
-Boots a QEMU session and prints its session id.
+Boots a QEMU session and prints its session id. Reserves a `--max-jobs` slot first; a full host
+answers 503 and the command fails. You cannot start without that reservation.
 
 - `--iso <path|url>` — the ISO. A local path must exist; an http(s) URL is downloaded and cached by the server. Default `omarchy.iso` in the current directory.
 - `--disk <path>` — an existing qcow2 disk. Omit it and the server creates a fresh one.

--- a/development.md
+++ b/development.md
@@ -964,12 +964,13 @@ const Fakes = Layer.mergeAll(
   FileSystem.layerNoop({}),
   Path.layer,
 );
-const SessionsLive = Sessions.Sessions.layer.pipe(Layer.provide(Fakes));
+const SessionsLive = Sessions.Sessions.layer(4).pipe(Layer.provide(Fakes));
 
 it.effect("refuses a foreign agent", () =>
   Effect.gen(function* () {
     const sessions = yield* Sessions.Sessions;
     const body = Contract.StartBody.make({ iso: "/isos/omarchy.iso", agent: "OLI-61" });
+    yield* sessions.reserve(body.agent);
     const id = yield* sessions.start(body, "none", false);
     const error = yield* Effect.flip(sessions.lookup(id, "OLI-62"));
     expect(error).toMatchObject({

--- a/drizzle/0012_mute_patriot.sql
+++ b/drizzle/0012_mute_patriot.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "agent_servers" (
+	"agent_id" text PRIMARY KEY NOT NULL,
+	"server_url" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1316 @@
+{
+  "id": "91bd71c4-6729-446b-b5e4-94a676ee0bc7",
+  "prevId": "c08369c0-745e-43b2-8290-1dd24d29ece4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actions": {
+      "name": "actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "actions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request": {
+          "name": "request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "action_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "actions_session_id_idx": {
+          "name": "actions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actions_session_id_sessions_id_fk": {
+          "name": "actions_session_id_sessions_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "actions_agent_id_agent_runs_agent_id_fk": {
+          "name": "actions_agent_id_agent_runs_agent_id_fk",
+          "tableFrom": "actions",
+          "tableTo": "agent_runs",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "agent_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_runs_session_id_idx": {
+          "name": "agent_runs_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_session_id_sessions_id_fk": {
+          "name": "agent_runs_session_id_sessions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_servers": {
+      "name": "agent_servers",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_jobs": {
+      "name": "automation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "automation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "automation_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_jobs_result_action_idx": {
+          "name": "automation_jobs_result_action_idx",
+          "columns": [
+            {
+              "expression": "result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_jobs_status_created_at_idx": {
+          "name": "automation_jobs_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_jobs_result_id_test_results_result_id_fk": {
+          "name": "automation_jobs_result_id_test_results_result_id_fk",
+          "tableFrom": "automation_jobs",
+          "tableTo": "test_results",
+          "columnsFrom": [
+            "result_id"
+          ],
+          "columnsTo": [
+            "result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.debug_logs": {
+      "name": "debug_logs",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sources": {
+          "name": "sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "debug_logs_session_id_sessions_id_fk": {
+          "name": "debug_logs_session_id_sessions_id_fk",
+          "tableFrom": "debug_logs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "action_id": {
+          "name": "action_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "images_id_idx": {
+          "name": "images_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_action_id_actions_id_fk": {
+          "name": "images_action_id_actions_id_fk",
+          "tableFrom": "images",
+          "tableTo": "actions",
+          "columnsFrom": [
+            "action_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "logs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "logs_location_idx": {
+          "name": "logs_location_idx",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_run_diagnosis": {
+      "name": "post_run_diagnosis",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "diagnosis_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "post_run_diagnosis_error_type_idx": {
+          "name": "post_run_diagnosis_error_type_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_run_diagnosis_session_id_sessions_id_fk": {
+          "name": "post_run_diagnosis_session_id_sessions_id_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "post_run_diagnosis_error_type_post_run_error_types_key_fk": {
+          "name": "post_run_diagnosis_error_type_post_run_error_types_key_fk",
+          "tableFrom": "post_run_diagnosis",
+          "tableTo": "post_run_error_types",
+          "columnsFrom": [
+            "error_type"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "post_run_diagnosis_verdict_error_type_check": {
+          "name": "post_run_diagnosis_verdict_error_type_check",
+          "value": "(\"post_run_diagnosis\".\"verdict\" = 'passed') = (\"post_run_diagnosis\".\"error_type\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.post_run_error_types": {
+      "name": "post_run_error_types",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servers": {
+      "name": "servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "server_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'qemu'"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation": {
+          "name": "generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "servers_id_unique": {
+          "name": "servers_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_servers": {
+      "name": "session_servers",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_servers_session_id_sessions_id_fk": {
+          "name": "session_servers_session_id_sessions_id_fk",
+          "tableFrom": "session_servers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_base_prompts": {
+      "name": "test_base_prompts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_base_prompts_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_base_prompts_name_idx": {
+          "name": "test_base_prompts_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_definitions": {
+      "name": "test_definitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "test_definitions_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "test_definitions_name_idx": {
+          "name": "test_definitions_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_results": {
+      "name": "test_results",
+      "schema": "",
+      "columns": {
+        "result_id": {
+          "name": "result_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linear_id": {
+          "name": "linear_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "test_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "test_results_run_definition_idx": {
+          "name": "test_results_run_definition_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_session_id_idx": {
+          "name": "test_results_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "test_results_linear_id_idx": {
+          "name": "test_results_linear_id_idx",
+          "columns": [
+            {
+              "expression": "linear_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_results_run_id_test_runs_id_fk": {
+          "name": "test_results_run_id_test_runs_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_definition_id_test_definitions_id_fk": {
+          "name": "test_results_definition_id_test_definitions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "test_definitions",
+          "columnsFrom": [
+            "definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_results_session_id_sessions_id_fk": {
+          "name": "test_results_session_id_sessions_id_fk",
+          "tableFrom": "test_results",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iso": {
+          "name": "iso",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "test_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.action_state": {
+      "name": "action_state",
+      "schema": "public",
+      "values": [
+        "completed",
+        "failed"
+      ]
+    },
+    "public.automation_action": {
+      "name": "automation_action",
+      "schema": "public",
+      "values": [
+        "drive",
+        "diagnose"
+      ]
+    },
+    "public.automation_job_status": {
+      "name": "automation_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.diagnosis_verdict": {
+      "name": "diagnosis_verdict",
+      "schema": "public",
+      "values": [
+        "passed",
+        "failed"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "info",
+        "warning",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.server_type": {
+      "name": "server_type",
+      "schema": "public",
+      "values": [
+        "qemu",
+        "automation-client"
+      ]
+    },
+    "public.session_status": {
+      "name": "session_status",
+      "schema": "public",
+      "values": [
+        "downloading",
+        "running",
+        "succeeded",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_result_status": {
+      "name": "test_result_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    },
+    "public.test_run_status": {
+      "name": "test_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "passed",
+        "failed",
+        "aborted",
+        "timed_out"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1789151887921,
       "tag": "0011_volatile_sersi",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1789187186485,
+      "tag": "0012_mute_patriot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/automation-client/command.ts
+++ b/src/automation-client/command.ts
@@ -83,6 +83,6 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
       }),
   ).pipe(
     Command.withDescription(
-      "The automation client: POST /run launches OpenCode with a prompt and waits until it finishes; POST /abort kills the matching run by ticket",
+      "The automation client: POST /reserve takes a --max-jobs slot for a ticket; POST /run launches OpenCode with a prompt and waits until it finishes; POST /abort kills the matching run by ticket",
     ),
   );

--- a/src/automation-client/command.ts
+++ b/src/automation-client/command.ts
@@ -35,7 +35,7 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
       maxJobs: Flag.integer("max-jobs").pipe(
         Flag.withSchema(Domain.MaxJobs),
         Flag.withDescription(
-          "How many runs this client carries at once; a run past it is refused with 503",
+          "How many runs this client carries at once; a reserve past it is refused with 503",
         ),
       ),
       port: Flag.integer("port").pipe(
@@ -83,6 +83,6 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
       }),
   ).pipe(
     Command.withDescription(
-      "The automation client: POST /reserve takes a --max-jobs slot for a ticket; POST /run launches OpenCode with a prompt and waits until it finishes; POST /abort kills the matching run by ticket",
+      "The automation client: POST /reserve reserves QEMU first, then takes a --max-jobs slot for a ticket; POST /run consumes that reservation and launches OpenCode with a prompt and waits until it finishes; POST /abort kills the matching run by ticket",
     ),
   );

--- a/src/automation-client/handlers.ts
+++ b/src/automation-client/handlers.ts
@@ -15,6 +15,16 @@ const uninterruptible = { uninterruptible: true } as const;
 export const RunsLive = HttpApiBuilder.group(Api.AutomationClientApi, "Runs", (handlers) =>
   handlers
     .handle(
+      "reserve",
+      ({ payload }) =>
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          yield* sessions.reserve(payload.ticket);
+          return ok;
+        }),
+      uninterruptible,
+    )
+    .handle(
       "run",
       ({ payload }) =>
         Effect.gen(function* () {

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -1,6 +1,15 @@
 import { createServer } from "node:http";
-import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
-import { Cause, Config as EffectConfig, Deferred, Effect, Exit, Layer, Option, type Runtime } from "effect";
+import { NodeHttpClient, NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
+import {
+  Cause,
+  Config as EffectConfig,
+  Deferred,
+  Effect,
+  Exit,
+  Layer,
+  Option,
+  type Runtime,
+} from "effect";
 import { Command } from "effect/unstable/cli";
 import { HttpMiddleware, HttpRouter, HttpServerError } from "effect/unstable/http";
 import * as Config from "../config.ts";
@@ -62,15 +71,17 @@ const ServerLive = (maxJobs: number, port: number, url: Option.Option<string>) =
         Effect.gen(function* () {
           const { token } = yield* Config.ProxyConfig;
           const serverUrl = yield* EffectConfig.string("SERVER_URL").pipe(
-            EffectConfig.withDefault(Config.DEFAULT_SERVER_URL),
+            Effect.orElseSucceed(() => Config.DEFAULT_SERVER_URL),
           );
           const proxy = yield* ProxyClient.connect({ serverUrl, token });
           return Sessions.Sessions.layer(maxJobs, (agent) =>
-            proxy.reserve(Contract.ReserveAgentBody.make({ agent })).pipe(
-              Effect.catch((error) =>
-                Errors.AtCapacity.make({ message: error.message, agentId: agent }),
+            proxy
+              .reserve(Contract.ReserveAgentBody.make({ agent }))
+              .pipe(
+                Effect.catch((error) =>
+                  Errors.AtCapacity.make({ message: error.message, agentId: agent }),
+                ),
               ),
-            ),
           );
         }),
       ),
@@ -91,6 +102,7 @@ const MainLive = Layer.mergeAll(Servers.ServerStore.layer, Log.Log.layer).pipe(
   Layer.provideMerge(Sentry.SentryLive),
   Layer.provideMerge(Layer.succeed(Log.ProcessAttribution)(Log.AutomationClientProcessAttribution)),
   Layer.provideMerge(Config.providerLayer),
+  Layer.provideMerge(NodeHttpClient.layerNodeHttp),
   Layer.provideMerge(NodeServices.layer),
 );
 

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -89,22 +89,19 @@ const ServerLive = (maxJobs: number, port: number, url: Option.Option<string>) =
               agentId: agent,
             });
           };
-          const asInternal = (
-            agent: string,
-            error: ProxyClient.Failure,
-          ): Effect.Effect<never, Errors.Internal> =>
-            Errors.Internal.make({
-              cause: new Error(error.message),
-              agentId: agent,
-            });
           const reserveQemu: Sessions.ReserveQemu = (agent) =>
             proxy
               .reserve(Contract.ReserveAgentBody.make({ agent }))
               .pipe(Effect.catch((error) => asQemuError(agent, error)));
           const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
-            proxy
-              .relinquish(Contract.ReserveAgentBody.make({ agent }))
-              .pipe(Effect.catch((error) => asInternal(agent, error)));
+            proxy.relinquish(Contract.ReserveAgentBody.make({ agent })).pipe(
+              Effect.catch((error: ProxyClient.Failure) =>
+                Errors.Internal.make({
+                  cause: new Error(error.message),
+                  agentId: agent,
+                }),
+              ),
+            );
           return Sessions.Sessions.layer(maxJobs, reserveQemu, relinquishQemu);
         }),
       ),

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -1,9 +1,10 @@
 import { createServer } from "node:http";
 import { NodeHttpServer, NodeRuntime, NodeServices } from "@effect/platform-node";
-import { Cause, Deferred, Effect, Exit, Layer, Option, type Runtime } from "effect";
+import { Cause, Config as EffectConfig, Deferred, Effect, Exit, Layer, Option, type Runtime } from "effect";
 import { Command } from "effect/unstable/cli";
 import { HttpMiddleware, HttpRouter, HttpServerError } from "effect/unstable/http";
 import * as Config from "../config.ts";
+import * as ProxyClient from "../client/proxy-client.ts";
 import * as Client from "../db/client.ts";
 import * as Logs from "../db/logs.ts";
 import * as Servers from "../db/servers.ts";
@@ -12,6 +13,8 @@ import * as Render from "../observability/render.ts";
 import * as Sentry from "../observability/sentry.ts";
 import * as Stats from "../qemu/stats.ts";
 import * as Api from "../shared/api.ts";
+import * as Contract from "../shared/contract.ts";
+import * as Errors from "../shared/errors.ts";
 import * as AutomationClientCommand from "./command.ts";
 import * as Handlers from "./handlers.ts";
 import * as Heartbeat from "./heartbeat.ts";
@@ -54,7 +57,24 @@ const ServerLive = (maxJobs: number, port: number, url: Option.Option<string>) =
         disableListenLog: true,
       }).pipe(Layer.provide(NodeHttpServer.layer(() => server, { host: HOST, port }))),
     ),
-    Layer.provide(Sessions.Sessions.layer(maxJobs)),
+    Layer.provide(
+      Layer.unwrap(
+        Effect.gen(function* () {
+          const { token } = yield* Config.ProxyConfig;
+          const serverUrl = yield* EffectConfig.string("SERVER_URL").pipe(
+            EffectConfig.withDefault(Config.DEFAULT_SERVER_URL),
+          );
+          const proxy = yield* ProxyClient.connect({ serverUrl, token });
+          return Sessions.Sessions.layer(maxJobs, (agent) =>
+            proxy.reserve(Contract.ReserveAgentBody.make({ agent })).pipe(
+              Effect.catch((error) =>
+                Errors.AtCapacity.make({ message: error.message, agentId: agent }),
+              ),
+            ),
+          );
+        }),
+      ),
+    ),
     Layer.provide(Stats.Stats.layer),
     Layer.provide(Layer.succeed(HttpMiddleware.TracerDisabledWhen)(() => true)),
   );

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -73,16 +73,27 @@ const ServerLive = (maxJobs: number, port: number, url: Option.Option<string>) =
           const serverUrl = yield* EffectConfig.string("SERVER_URL").pipe(
             Effect.orElseSucceed(() => Config.DEFAULT_SERVER_URL),
           );
-          const proxy = yield* ProxyClient.connect({ serverUrl, token });
-          return Sessions.Sessions.layer(maxJobs, (agent) =>
+          const proxy: ProxyClient.ProxyClientService = yield* ProxyClient.connect({
+            serverUrl,
+            token,
+          });
+          const asQemuError = (
+            agent: string,
+            error: ProxyClient.Failure,
+          ): Effect.Effect<never, Errors.AtCapacity | Errors.Internal> => {
+            if (error._tag === "ProxyRefusal" && error.status === 503) {
+              return Errors.AtCapacity.make({ message: error.message, agentId: agent });
+            }
+            return Errors.Internal.make({
+              cause: new Error(error.message),
+              agentId: agent,
+            });
+          };
+          const reserveQemu: Sessions.ReserveQemu = (agent) =>
             proxy
               .reserve(Contract.ReserveAgentBody.make({ agent }))
-              .pipe(
-                Effect.catch((error) =>
-                  Errors.AtCapacity.make({ message: error.message, agentId: agent }),
-                ),
-              ),
-          );
+              .pipe(Effect.catch((error) => asQemuError(agent, error)));
+          return Sessions.Sessions.layer(maxJobs, reserveQemu);
         }),
       ),
     ),

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -89,11 +89,23 @@ const ServerLive = (maxJobs: number, port: number, url: Option.Option<string>) =
               agentId: agent,
             });
           };
+          const asInternal = (
+            agent: string,
+            error: ProxyClient.Failure,
+          ): Effect.Effect<never, Errors.Internal> =>
+            Errors.Internal.make({
+              cause: new Error(error.message),
+              agentId: agent,
+            });
           const reserveQemu: Sessions.ReserveQemu = (agent) =>
             proxy
               .reserve(Contract.ReserveAgentBody.make({ agent }))
               .pipe(Effect.catch((error) => asQemuError(agent, error)));
-          return Sessions.Sessions.layer(maxJobs, reserveQemu);
+          const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
+            proxy
+              .relinquish(Contract.ReserveAgentBody.make({ agent }))
+              .pipe(Effect.catch((error) => asInternal(agent, error)));
+          return Sessions.Sessions.layer(maxJobs, reserveQemu, relinquishQemu);
         }),
       ),
     ),

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -13,36 +13,75 @@ const mapWithout = <V>(map: ReadonlyMap<string, V>, key: string): ReadonlyMap<st
   return next;
 };
 
+const withItem = <T>(set: ReadonlySet<T>, item: T): ReadonlySet<T> => new Set([...set, item]);
+
+const without = <T>(set: ReadonlySet<T>, item: T): ReadonlySet<T> => {
+  const next = new Set(set);
+  next.delete(item);
+  return next;
+};
+
 const make = (maxJobs: number) =>
   Effect.gen(function* () {
     const running = yield* Ref.make<ReadonlyMap<string, ChildProcessSpawner.ChildProcessHandle>>(
       new Map(),
     );
-    // How many runs are admitted against --max-jobs. `running` cannot count them: a run is only
-    // in it once OpenCode has spawned, and the slot must be taken before that, so a refused run
-    // spawns nothing.
-    const jobs = yield* Ref.make(0);
+    // How many runs are admitted against --max-jobs, and which tickets already hold a slot
+    // that run will consume. `running` cannot count them: a run is only in it once OpenCode
+    // has spawned, and the slot must be taken before that, so a refused run spawns nothing.
+    const slots = yield* Ref.make<{
+      readonly count: number;
+      readonly reserved: ReadonlySet<string>;
+    }>({ count: 0, reserved: new Set() });
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+    const atCapacity = (ticket: string): Errors.AtCapacity =>
+      Errors.AtCapacity.make({
+        message: `at capacity: max-jobs is ${String(maxJobs)}`,
+        agentId: ticket,
+      });
+
+    const reserve = Effect.fn("Sessions.reserve")(function* (ticket: string) {
+      const admitted = yield* Ref.modify(slots, (held) => {
+        if (held.reserved.has(ticket)) {
+          return [true, held] as const;
+        }
+        if (held.count >= maxJobs) {
+          return [false, held] as const;
+        }
+        return [
+          true,
+          { count: held.count + 1, reserved: withItem(held.reserved, ticket) },
+        ] as const;
+      });
+      if (!admitted) {
+        return yield* atCapacity(ticket);
+      }
+    });
 
     const admit = (ticket: string): Effect.Effect<void, Errors.AtCapacity> =>
       Effect.flatMap(
-        Ref.modify(jobs, (n) => (n < maxJobs ? [true, n + 1] : [false, n])),
-        (admitted) =>
-          admitted
-            ? Effect.void
-            : Errors.AtCapacity.make({
-                message: `at capacity: max-jobs is ${String(maxJobs)}`,
-                agentId: ticket,
-              }),
+        Ref.modify(slots, (held) => {
+          if (held.reserved.has(ticket)) {
+            return [true, { count: held.count, reserved: without(held.reserved, ticket) }] as const;
+          }
+          if (held.count >= maxJobs) {
+            return [false, held] as const;
+          }
+          return [true, { count: held.count + 1, reserved: held.reserved }] as const;
+        }),
+        (admitted) => (admitted ? Effect.void : atCapacity(ticket)),
       );
 
     const run = Effect.fn("Sessions.run")(function* (ticket: string, prompt: string) {
       return yield* Effect.scoped(
         Effect.gen(function* () {
-          // The slot is the run's first resource: taken and its release registered in one
-          // uninterruptible step, so it is given back however the run ends, and last, after the
-          // child is reaped and the ticket forgotten.
-          yield* Effect.acquireRelease(admit(ticket), () => Ref.update(jobs, (n) => n - 1));
+          // The slot is the run's first resource: taken (or consumed from reserve) and its
+          // release registered in one uninterruptible step, so it is given back however the
+          // run ends, and last, after the child is reaped and the ticket forgotten.
+          yield* Effect.acquireRelease(admit(ticket), () =>
+            Ref.update(slots, (held) => ({ ...held, count: held.count - 1 })),
+          );
           const handle = yield* Cli.spawn(OpenCode.BIN, OpenCode.args(prompt));
           const claimed = yield* Ref.modify(running, (map) =>
             map.has(ticket)
@@ -88,7 +127,7 @@ const make = (maxJobs: number) =>
         );
     });
 
-    return { run, abort };
+    return { reserve, run, abort };
   });
 
 export class Sessions extends Context.Service<Sessions>()("@oligarchy/automation-client/Sessions", {

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -56,7 +56,10 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: Relinqu
         Effect.gen(function* () {
           const held = yield* Ref.get(slots);
           if (held.reserved.has(ticket)) {
-            return yield* Effect.void;
+            return yield* Errors.BadRequest.make({
+              message: "already reserved",
+              agentId: ticket,
+            });
           }
           // QEMU first: this client cannot hold a slot until the guest host has one.
           // A full client still asks, then gives that slot back rather than leak it.

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Ref } from "effect";
+import { Context, Effect, Layer, Ref, Semaphore } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as Cli from "../cli.ts";
 import * as Errors from "../shared/errors.ts";
@@ -21,7 +21,9 @@ const without = <T>(set: ReadonlySet<T>, item: T): ReadonlySet<T> => {
   return next;
 };
 
-export type ReserveQemu = (agent: string) => Effect.Effect<void, Errors.AtCapacity>;
+export type ReserveQemu = (
+  agent: string,
+) => Effect.Effect<void, Errors.AtCapacity | Errors.Internal>;
 
 const make = (maxJobs: number, reserveQemu: ReserveQemu) =>
   Effect.gen(function* () {
@@ -43,30 +45,27 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu) =>
         agentId: ticket,
       });
 
+    // One reserve at a time: two tickets must not both pass the local check and reserve QEMU
+    // when only one slot remains.
+    const reserveGate = yield* Semaphore.make(1);
+
     const reserve = Effect.fn("Sessions.reserve")(function* (ticket: string) {
-      const held = yield* Ref.get(slots);
-      if (held.reserved.has(ticket)) {
-        return yield* Effect.void;
-      }
-      if (held.count >= maxJobs) {
-        return yield* atCapacity(ticket);
-      }
-      // QEMU first: this client cannot hold a slot until the guest host has one.
-      yield* reserveQemu(ticket);
-      return yield* Effect.flatMap(
-        Ref.modify(slots, (current) => {
-          if (current.reserved.has(ticket)) {
-            return [true, current] as const;
+      return yield* reserveGate.withPermits(1)(
+        Effect.gen(function* () {
+          const held = yield* Ref.get(slots);
+          if (held.reserved.has(ticket)) {
+            return yield* Effect.void;
           }
-          if (current.count >= maxJobs) {
-            return [false, current] as const;
+          if (held.count >= maxJobs) {
+            return yield* atCapacity(ticket);
           }
-          return [
-            true,
-            { count: current.count + 1, reserved: withItem(current.reserved, ticket) },
-          ] as const;
+          // QEMU first: this client cannot hold a slot until the guest host has one.
+          yield* reserveQemu(ticket);
+          return yield* Ref.update(slots, (current) => ({
+            count: current.count + 1,
+            reserved: withItem(current.reserved, ticket),
+          }));
         }),
-        (admitted) => (admitted ? Effect.void : atCapacity(ticket)),
       );
     });
 

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -42,21 +42,21 @@ const make = (maxJobs: number) =>
       });
 
     const reserve = Effect.fn("Sessions.reserve")(function* (ticket: string) {
-      const admitted = yield* Ref.modify(slots, (held) => {
-        if (held.reserved.has(ticket)) {
-          return [true, held] as const;
-        }
-        if (held.count >= maxJobs) {
-          return [false, held] as const;
-        }
-        return [
-          true,
-          { count: held.count + 1, reserved: withItem(held.reserved, ticket) },
-        ] as const;
-      });
-      if (!admitted) {
-        return yield* atCapacity(ticket);
-      }
+      return yield* Effect.flatMap(
+        Ref.modify(slots, (held) => {
+          if (held.reserved.has(ticket)) {
+            return [true, held] as const;
+          }
+          if (held.count >= maxJobs) {
+            return [false, held] as const;
+          }
+          return [
+            true,
+            { count: held.count + 1, reserved: withItem(held.reserved, ticket) },
+          ] as const;
+        }),
+        (admitted) => (admitted ? Effect.void : atCapacity(ticket)),
+      );
     });
 
     const admit = (ticket: string): Effect.Effect<void, Errors.AtCapacity> =>

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -74,6 +74,7 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: Relinqu
             yield* relinquishQemu(ticket);
             return yield* atCapacity(ticket);
           }
+          return yield* Effect.void;
         }),
       );
     });

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -25,7 +25,9 @@ export type ReserveQemu = (
   agent: string,
 ) => Effect.Effect<void, Errors.AtCapacity | Errors.Internal>;
 
-const make = (maxJobs: number, reserveQemu: ReserveQemu) =>
+export type RelinquishQemu = (agent: string) => Effect.Effect<void, Errors.Internal>;
+
+const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: RelinquishQemu) =>
   Effect.gen(function* () {
     const running = yield* Ref.make<ReadonlyMap<string, ChildProcessSpawner.ChildProcessHandle>>(
       new Map(),
@@ -45,8 +47,8 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu) =>
         agentId: ticket,
       });
 
-    // One reserve at a time: two tickets must not both pass the local check and reserve QEMU
-    // when only one slot remains.
+    // One reserve at a time: two tickets must not both reserve QEMU when only one local
+    // slot remains.
     const reserveGate = yield* Semaphore.make(1);
 
     const reserve = Effect.fn("Sessions.reserve")(function* (ticket: string) {
@@ -56,15 +58,22 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu) =>
           if (held.reserved.has(ticket)) {
             return yield* Effect.void;
           }
-          if (held.count >= maxJobs) {
+          // QEMU first: this client cannot hold a slot until the guest host has one.
+          // A full client still asks, then gives that slot back rather than leak it.
+          yield* reserveQemu(ticket);
+          const admitted = yield* Ref.modify(slots, (current) => {
+            if (current.count >= maxJobs) {
+              return [false, current] as const;
+            }
+            return [
+              true,
+              { count: current.count + 1, reserved: withItem(current.reserved, ticket) },
+            ] as const;
+          });
+          if (!admitted) {
+            yield* relinquishQemu(ticket);
             return yield* atCapacity(ticket);
           }
-          // QEMU first: this client cannot hold a slot until the guest host has one.
-          yield* reserveQemu(ticket);
-          return yield* Ref.update(slots, (current) => ({
-            count: current.count + 1,
-            reserved: withItem(current.reserved, ticket),
-          }));
         }),
       );
     });
@@ -145,6 +154,7 @@ export class Sessions extends Context.Service<Sessions>()("@oligarchy/automation
   static readonly layer = (
     maxJobs: number,
     reserveQemu: ReserveQemu,
+    relinquishQemu: RelinquishQemu,
   ): Layer.Layer<Sessions, never, ChildProcessSpawner.ChildProcessSpawner> =>
-    Layer.effect(this)(this.make(maxJobs, reserveQemu));
+    Layer.effect(this)(this.make(maxJobs, reserveQemu, relinquishQemu));
 }

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -21,7 +21,9 @@ const without = <T>(set: ReadonlySet<T>, item: T): ReadonlySet<T> => {
   return next;
 };
 
-const make = (maxJobs: number) =>
+export type ReserveQemu = (agent: string) => Effect.Effect<void, Errors.AtCapacity>;
+
+const make = (maxJobs: number, reserveQemu: ReserveQemu) =>
   Effect.gen(function* () {
     const running = yield* Ref.make<ReadonlyMap<string, ChildProcessSpawner.ChildProcessHandle>>(
       new Map(),
@@ -42,44 +44,52 @@ const make = (maxJobs: number) =>
       });
 
     const reserve = Effect.fn("Sessions.reserve")(function* (ticket: string) {
+      const held = yield* Ref.get(slots);
+      if (held.reserved.has(ticket)) {
+        return yield* Effect.void;
+      }
+      if (held.count >= maxJobs) {
+        return yield* atCapacity(ticket);
+      }
+      // QEMU first: this client cannot hold a slot until the guest host has one.
+      yield* reserveQemu(ticket);
       return yield* Effect.flatMap(
-        Ref.modify(slots, (held) => {
-          if (held.reserved.has(ticket)) {
-            return [true, held] as const;
+        Ref.modify(slots, (current) => {
+          if (current.reserved.has(ticket)) {
+            return [true, current] as const;
           }
-          if (held.count >= maxJobs) {
-            return [false, held] as const;
+          if (current.count >= maxJobs) {
+            return [false, current] as const;
           }
           return [
             true,
-            { count: held.count + 1, reserved: withItem(held.reserved, ticket) },
+            { count: current.count + 1, reserved: withItem(current.reserved, ticket) },
           ] as const;
         }),
         (admitted) => (admitted ? Effect.void : atCapacity(ticket)),
       );
     });
 
-    const admit = (ticket: string): Effect.Effect<void, Errors.AtCapacity> =>
+    const consume = (ticket: string): Effect.Effect<void, Errors.BadRequest> =>
       Effect.flatMap(
-        Ref.modify(slots, (held) => {
-          if (held.reserved.has(ticket)) {
-            return [true, { count: held.count, reserved: without(held.reserved, ticket) }] as const;
-          }
-          if (held.count >= maxJobs) {
-            return [false, held] as const;
-          }
-          return [true, { count: held.count + 1, reserved: held.reserved }] as const;
-        }),
-        (admitted) => (admitted ? Effect.void : atCapacity(ticket)),
+        Ref.modify(slots, (held) =>
+          held.reserved.has(ticket)
+            ? ([true, { count: held.count, reserved: without(held.reserved, ticket) }] as const)
+            : ([false, held] as const),
+        ),
+        (held) =>
+          held
+            ? Effect.void
+            : Errors.BadRequest.make({ message: "no reservation", agentId: ticket }),
       );
 
     const run = Effect.fn("Sessions.run")(function* (ticket: string, prompt: string) {
       return yield* Effect.scoped(
         Effect.gen(function* () {
-          // The slot is the run's first resource: taken (or consumed from reserve) and its
-          // release registered in one uninterruptible step, so it is given back however the
-          // run ends, and last, after the child is reaped and the ticket forgotten.
-          yield* Effect.acquireRelease(admit(ticket), () =>
+          // The reservation is the run's first resource: consumed and its release registered
+          // in one uninterruptible step, so the slot is given back however the run ends, and
+          // last, after the child is reaped and the ticket forgotten.
+          yield* Effect.acquireRelease(consume(ticket), () =>
             Ref.update(slots, (held) => ({ ...held, count: held.count - 1 })),
           );
           const handle = yield* Cli.spawn(OpenCode.BIN, OpenCode.args(prompt));
@@ -135,6 +145,7 @@ export class Sessions extends Context.Service<Sessions>()("@oligarchy/automation
 }) {
   static readonly layer = (
     maxJobs: number,
+    reserveQemu: ReserveQemu,
   ): Layer.Layer<Sessions, never, ChildProcessSpawner.ChildProcessSpawner> =>
-    Layer.effect(this)(this.make(maxJobs));
+    Layer.effect(this)(this.make(maxJobs, reserveQemu));
 }

--- a/src/automation-server/client.ts
+++ b/src/automation-server/client.ts
@@ -24,7 +24,7 @@ const bodyDetail = (text: string): string | undefined =>
 
 const failed = (
   url: string,
-  path: "/run" | "/abort",
+  path: "/reserve" | "/run" | "/abort",
   status: number | undefined,
   text: string,
   cause: unknown,
@@ -54,6 +54,28 @@ const makeClient = Effect.fn("makeClient")(function* (url: string) {
     baseUrl: url,
     transformClient: HttpClient.filterStatusOk,
   }).pipe(Effect.provide(middleware));
+});
+
+export const reserve = Effect.fn("reserve")(function* (url: string, ticket: string) {
+  const client = yield* makeClient(url);
+  return yield* client.Runs.reserve({ payload: Contract.ReserveBody.make({ ticket }) }).pipe(
+    Effect.catch((error) => {
+      if (error._tag === "HttpClientError") {
+        const response = error.response;
+        if (response === undefined) {
+          return Effect.fail(failed(url, "/reserve", undefined, "", error));
+        }
+        return response.text.pipe(
+          Effect.orElseSucceed(() => ""),
+          Effect.flatMap((text) =>
+            Effect.fail(failed(url, "/reserve", response.status, text, error)),
+          ),
+        );
+      }
+      return Effect.fail(failed(url, "/reserve", undefined, "", error));
+    }),
+    Effect.asVoid,
+  );
 });
 
 // POST /run and wait for the client to finish. node:http has no ceiling of its own; a drive or

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Option, Schedule, Schema } from "effect";
+import { Cause, Effect, Option, Result, Schedule, Schema } from "effect";
 import * as Automation from "../db/automation.ts";
 import * as Servers from "../db/servers.ts";
 import * as Tests from "../db/tests.ts";
@@ -12,6 +12,7 @@ import * as Prompts from "./prompts.ts";
 const DISPATCH_INTERVAL = "5 seconds";
 
 const isDatabaseError = Schema.is(Errors.DatabaseError);
+const isAtCapacity = Schema.is(Errors.AtCapacity);
 
 const detail = (error: unknown): string =>
   isDatabaseError(error)
@@ -33,8 +34,12 @@ const outcomeFrom = (cause: Cause.Cause<unknown>): Outcome =>
     ? aborted
     : { status: "failed", reason: Render.errorDetail(Cause.squash(cause)) };
 
-const execute = Effect.fn("execute")(function* (job: Automation.AutomationJobRow, url: string) {
+const execute = Effect.fn("execute")(function* (
+  job: Automation.AutomationJobRow,
+  clients: ReadonlyArray<Servers.LiveServer>,
+) {
   const tests = yield* Tests.TestStore;
+  const store = yield* Automation.AutomationStore;
   const log = yield* Log.Log;
   const result = yield* tests.findResult(job.resultId);
   if (Option.isNone(result) || result.value.linearId === null) {
@@ -45,11 +50,29 @@ const execute = Effect.fn("execute")(function* (job: Automation.AutomationJobRow
     job.action === "drive"
       ? yield* Prompts.drive(ticket)
       : yield* Prompts.diagnose(ticket, job.resultId);
-  yield* log.info(`dispatching ${job.action}; ${url}`, {
-    location: Log.Locations.automation,
+  let lastCapacity: string | undefined;
+  for (const client of clients) {
+    const reserved = yield* Effect.result(AutomationClient.reserve(client.url, ticket));
+    if (Result.isSuccess(reserved)) {
+      if (client.id !== job.serverId) {
+        yield* store.assign(job.id, client.id);
+      }
+      yield* log.info(`dispatching ${job.action}; ${client.url}`, {
+        location: Log.Locations.automation,
+        agentId: ticket,
+      });
+      return yield* AutomationClient.run(client.url, prompt, ticket);
+    }
+    if (reserved.failure.status === 503) {
+      lastCapacity = reserved.failure.message;
+      continue;
+    }
+    return yield* Effect.fail(reserved.failure);
+  }
+  return yield* Errors.AtCapacity.make({
+    message: lastCapacity ?? "at capacity",
     agentId: ticket,
   });
-  return yield* AutomationClient.run(url, prompt, ticket);
 });
 
 const logOutcome = Effect.fn("logOutcome")(function* (
@@ -69,10 +92,11 @@ const logOutcome = Effect.fn("logOutcome")(function* (
   yield* log.error(`${job.action} failed; ${outcome.reason}`, attr);
 });
 
-// One job at a time, to the first live automation-client. A tick with no live client does not
-// claim. Claim is uninterruptible so a shutdown cannot leave a pending row half-taken; the HTTP
-// wait is restored so SIGTERM aborts an in-flight job; finish is uninterruptible so the write
-// lands. A tick that fails is one error line; the next tick runs.
+// One job at a time. A tick with no live client does not claim. Reserve runs against every
+// live client; a 503 from all of them puts the row back to pending so the queue is unchanged.
+// Claim is uninterruptible so a shutdown cannot leave a pending row half-taken; the HTTP wait
+// is restored so SIGTERM aborts an in-flight job; finish and unclaim are uninterruptible so
+// the write lands. A tick that fails is one error line; the next tick runs.
 export const dispatch = Effect.fn("dispatch")(function* () {
   const servers = yield* Servers.ServerStore;
   const store = yield* Automation.AutomationStore;
@@ -91,13 +115,35 @@ export const dispatch = Effect.fn("dispatch")(function* () {
             return Effect.void;
           }
           const job = maybe.value;
-          return restore(execute(job, chosen.url)).pipe(
+          return restore(execute(job, live)).pipe(
             Effect.matchCause({
-              onSuccess: (): Outcome => ({ status: "succeeded", reason: null }),
-              onFailure: outcomeFrom,
+              onSuccess: (): Outcome | { readonly deferred: true; readonly agentId?: string } => ({
+                status: "succeeded",
+                reason: null,
+              }),
+              onFailure: (
+                cause,
+              ): Outcome | { readonly deferred: true; readonly agentId?: string } => {
+                const error = Cause.squash(cause);
+                return isAtCapacity(error)
+                  ? { deferred: true, agentId: error.agentId }
+                  : outcomeFrom(cause);
+              },
             }),
             Effect.flatMap((outcome) =>
               Effect.gen(function* () {
+                if ("deferred" in outcome) {
+                  const restored = yield* store.unclaim(job.id);
+                  if (restored) {
+                    yield* log.info(
+                      "deferred; at capacity",
+                      outcome.agentId === undefined
+                        ? { location: Log.Locations.automation }
+                        : { location: Log.Locations.automation, agentId: outcome.agentId },
+                    );
+                  }
+                  return;
+                }
                 const closed = yield* store.finish(job.id, outcome.status, outcome.reason);
                 // abort may have closed the row first
                 if (closed) {

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -61,17 +61,7 @@ const execute = Effect.fn("execute")(function* (
         location: Log.Locations.automation,
         agentId: ticket,
       });
-      const ran = yield* Effect.result(AutomationClient.run(client.url, prompt, ticket));
-      if (Result.isFailure(ran)) {
-        if (ran.failure.status === 503) {
-          return yield* Errors.AtCapacity.make({
-            message: ran.failure.message,
-            agentId: ticket,
-          });
-        }
-        return yield* Effect.fail(ran.failure);
-      }
-      return yield* Effect.void;
+      return yield* AutomationClient.run(client.url, prompt, ticket);
     }
     if (reserved.failure.status === 503) {
       lastCapacity = reserved.failure.message;
@@ -103,8 +93,7 @@ const logOutcome = Effect.fn("logOutcome")(function* (
 });
 
 // One job at a time. A tick with no live client does not claim. Reserve runs against every
-// live client; a 503 from all of them, or from /run after a reserve, puts the row back to
-// pending so the queue is unchanged.
+// live client; a 503 from all of them puts the row back to pending so the queue is unchanged.
 // Claim is uninterruptible so a shutdown cannot leave a pending row half-taken; the HTTP wait
 // is restored so SIGTERM aborts an in-flight job; finish and unclaim are uninterruptible so
 // the write lands. A tick that fails is one error line; the next tick runs.

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -126,7 +126,10 @@ export const dispatch = Effect.fn("dispatch")(function* () {
               ): Outcome | { readonly deferred: true; readonly agentId?: string } => {
                 const error = Cause.squash(cause);
                 return isAtCapacity(error)
-                  ? { deferred: true, agentId: error.agentId }
+                  ? Object.assign(
+                      { deferred: true as const },
+                      error.agentId === undefined ? undefined : { agentId: error.agentId },
+                    )
                   : outcomeFrom(cause);
               },
             }),

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -61,7 +61,17 @@ const execute = Effect.fn("execute")(function* (
         location: Log.Locations.automation,
         agentId: ticket,
       });
-      return yield* AutomationClient.run(client.url, prompt, ticket);
+      const ran = yield* Effect.result(AutomationClient.run(client.url, prompt, ticket));
+      if (Result.isFailure(ran)) {
+        if (ran.failure.status === 503) {
+          return yield* Errors.AtCapacity.make({
+            message: ran.failure.message,
+            agentId: ticket,
+          });
+        }
+        return yield* Effect.fail(ran.failure);
+      }
+      return yield* Effect.void;
     }
     if (reserved.failure.status === 503) {
       lastCapacity = reserved.failure.message;
@@ -93,7 +103,8 @@ const logOutcome = Effect.fn("logOutcome")(function* (
 });
 
 // One job at a time. A tick with no live client does not claim. Reserve runs against every
-// live client; a 503 from all of them puts the row back to pending so the queue is unchanged.
+// live client; a 503 from all of them, or from /run after a reserve, puts the row back to
+// pending so the queue is unchanged.
 // Claim is uninterruptible so a shutdown cannot leave a pending row half-taken; the HTTP wait
 // is restored so SIGTERM aborts an in-flight job; finish and unclaim are uninterruptible so
 // the write lands. A tick that fails is one error line; the next tick runs.

--- a/src/client/command.ts
+++ b/src/client/command.ts
@@ -59,6 +59,7 @@ const start = Command.make(
       onSome: (disk) =>
         Contract.StartBody.make({ iso, disk: path.resolve(disk), agent: input.agentId }),
     });
+    yield* proxy.reserve(Contract.ReserveAgentBody.make({ agent: input.agentId }));
     const started = yield* proxy.start(body);
     yield* Console.log(started.id);
   }),

--- a/src/client/proxy-client.ts
+++ b/src/client/proxy-client.ts
@@ -15,6 +15,7 @@ export type Failure = Errors.ProxyRefusal | Errors.ProxyUnreachable;
 
 export type ProxyClientService = {
   readonly reserve: (body: Contract.ReserveAgentBody) => Effect.Effect<void, Failure>;
+  readonly relinquish: (body: Contract.ReserveAgentBody) => Effect.Effect<void, Failure>;
   readonly start: (body: Contract.StartBody) => Effect.Effect<Contract.StartResponse, Failure>;
   readonly image: (id: string, agent: string) => Effect.Effect<Uint8Array, Failure>;
   readonly serial: (id: string, agent: string) => Effect.Effect<Uint8Array, Failure>;
@@ -118,6 +119,11 @@ export const connect = Effect.fn("ProxyClient.connect")(function* (options: Conn
   const reserve = (body: Contract.ReserveAgentBody) =>
     run(label("POST", "/reserve"), client.Sessions.reserve({ payload: body })).pipe(Effect.asVoid);
 
+  const relinquish = (body: Contract.ReserveAgentBody) =>
+    run(label("POST", "/relinquish"), client.Sessions.relinquish({ payload: body })).pipe(
+      Effect.asVoid,
+    );
+
   const start = (body: Contract.StartBody) =>
     run(label("POST", "/start"), client.Sessions.start({ payload: body })).pipe(
       Effect.timeoutOrElse({
@@ -179,6 +185,7 @@ export const connect = Effect.fn("ProxyClient.connect")(function* (options: Conn
 
   const service: ProxyClientService = {
     reserve,
+    relinquish,
     start,
     image,
     serial,

--- a/src/client/proxy-client.ts
+++ b/src/client/proxy-client.ts
@@ -14,6 +14,7 @@ import * as Errors from "../shared/errors.ts";
 export type Failure = Errors.ProxyRefusal | Errors.ProxyUnreachable;
 
 export type ProxyClientService = {
+  readonly reserve: (body: Contract.ReserveAgentBody) => Effect.Effect<void, Failure>;
   readonly start: (body: Contract.StartBody) => Effect.Effect<Contract.StartResponse, Failure>;
   readonly image: (id: string, agent: string) => Effect.Effect<Uint8Array, Failure>;
   readonly serial: (id: string, agent: string) => Effect.Effect<Uint8Array, Failure>;
@@ -114,6 +115,9 @@ export const connect = Effect.fn("ProxyClient.connect")(function* (options: Conn
   }).pipe(Effect.provide(middleware));
   const label = (method: string, path: string) => `${method} ${serverUrl}${path} failed`;
 
+  const reserve = (body: Contract.ReserveAgentBody) =>
+    run(label("POST", "/reserve"), client.Sessions.reserve({ payload: body })).pipe(Effect.asVoid);
+
   const start = (body: Contract.StartBody) =>
     run(label("POST", "/start"), client.Sessions.start({ payload: body })).pipe(
       Effect.timeoutOrElse({
@@ -174,6 +178,7 @@ export const connect = Effect.fn("ProxyClient.connect")(function* (options: Conn
   });
 
   const service: ProxyClientService = {
+    reserve,
     start,
     image,
     serial,

--- a/src/db/automation.ts
+++ b/src/db/automation.ts
@@ -95,6 +95,38 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
       });
 
       // Only a running row closes. reason is omitted when null so a previous value stays.
+      // A running row the fleet could not take: back to pending, as it was, so the queue
+      // order (created_at) is unchanged and the next tick can try again.
+      const unclaim = Effect.fn("db.unclaimAutomationJob")(function* (id: string) {
+        const rows = yield* database.run("unclaimAutomationJob", (db) =>
+          db
+            .update(DbSchema.automationJobs)
+            .set({ status: "pending", startedAt: null, serverId: null })
+            .where(
+              and(
+                eq(DbSchema.automationJobs.id, id),
+                eq(DbSchema.automationJobs.status, "running"),
+              ),
+            )
+            .returning({ id: DbSchema.automationJobs.id }),
+        );
+        return rows.length > 0;
+      });
+
+      const assign = Effect.fn("db.assignAutomationJob")(function* (id: string, serverId: string) {
+        yield* database.run("assignAutomationJob", (db) =>
+          db
+            .update(DbSchema.automationJobs)
+            .set({ serverId })
+            .where(
+              and(
+                eq(DbSchema.automationJobs.id, id),
+                eq(DbSchema.automationJobs.status, "running"),
+              ),
+            ),
+        );
+      });
+
       const finish = Effect.fn("db.finishAutomationJob")(function* (
         id: string,
         status: FinishStatus,
@@ -170,7 +202,7 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
         return { running, pending, completed };
       });
 
-      return { enqueue, claim, findRunning, finish, listJobs };
+      return { enqueue, claim, findRunning, unclaim, assign, finish, listJobs };
     }),
   },
 ) {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -229,7 +229,7 @@ export const sessionServers = pgTable("session_servers", {
 });
 
 // Which server reserved a slot for an agent, so start finds that machine before a session id
-// exists. agent_id is the ticket. A second reserve for the same agent is one row.
+// exists. agent_id is the ticket. A racing second insert is one row.
 export const agentServers = pgTable("agent_servers", {
   agentId: text("agent_id").primaryKey(),
   serverUrl: text("server_url").notNull(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -228,6 +228,14 @@ export const sessionServers = pgTable("session_servers", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
+// Which server reserved a slot for an agent, so start finds that machine before a session id
+// exists. agent_id is the ticket. A second reserve for the same agent is one row.
+export const agentServers = pgTable("agent_servers", {
+  agentId: text("agent_id").primaryKey(),
+  serverUrl: text("server_url").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 // A definition is the stored mission an agent is handed — what it is about, what to
 // do, and the proof that closes it. A row is never updated: an edit is a new row with
 // the same name and a higher id, so a result's definition_id names the exact wording

--- a/src/db/servers.ts
+++ b/src/db/servers.ts
@@ -116,7 +116,7 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       return Option.map(Arr.head(rows), (row) => row.serverUrl);
     });
 
-    // One row per agent: a second reserve keeps the first server.
+    // One row per agent: a racing second insert keeps the first server.
     const routeAgent = Effect.fn("db.routeAgent")(function* (agentId: string, url: string) {
       yield* database.run("routeAgent", (db) =>
         db.insert(DbSchema.agentServers).values({ agentId, serverUrl: url }).onConflictDoNothing(),

--- a/src/db/servers.ts
+++ b/src/db/servers.ts
@@ -116,6 +116,23 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       return Option.map(Arr.head(rows), (row) => row.serverUrl);
     });
 
+    // One row per agent: a second reserve keeps the first server.
+    const routeAgent = Effect.fn("db.routeAgent")(function* (agentId: string, url: string) {
+      yield* database.run("routeAgent", (db) =>
+        db.insert(DbSchema.agentServers).values({ agentId, serverUrl: url }).onConflictDoNothing(),
+      );
+    });
+
+    const serverForAgent = Effect.fn("db.serverForAgent")(function* (agentId: string) {
+      const rows = yield* database.run("serverForAgent", (db) =>
+        db
+          .select({ serverUrl: DbSchema.agentServers.serverUrl })
+          .from(DbSchema.agentServers)
+          .where(eq(DbSchema.agentServers.agentId, agentId)),
+      );
+      return Option.map(Arr.head(rows), (row) => row.serverUrl);
+    });
+
     return {
       addServer,
       heartbeat,
@@ -125,6 +142,8 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       findServer,
       routeSession,
       serverForSession,
+      routeAgent,
+      serverForAgent,
     };
   }),
 }) {

--- a/src/db/servers.ts
+++ b/src/db/servers.ts
@@ -133,6 +133,13 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       return Option.map(Arr.head(rows), (row) => row.serverUrl);
     });
 
+    // Start consumed the reservation; the next reserve may place again.
+    const clearAgent = Effect.fn("db.clearAgent")(function* (agentId: string) {
+      yield* database.run("clearAgent", (db) =>
+        db.delete(DbSchema.agentServers).where(eq(DbSchema.agentServers.agentId, agentId)),
+      );
+    });
+
     return {
       addServer,
       heartbeat,
@@ -144,6 +151,7 @@ export class ServerStore extends Context.Service<ServerStore>()("@oligarchy/db/S
       serverForSession,
       routeAgent,
       serverForAgent,
+      clearAgent,
     };
   }),
 }) {

--- a/src/qemu-reverse-proxy/handlers.ts
+++ b/src/qemu-reverse-proxy/handlers.ts
@@ -15,6 +15,15 @@ const uninterruptible = { uninterruptible: true } as const;
 export const SessionsLive = HttpApiBuilder.group(Api.QemuReverseProxyApi, "Sessions", (handlers) =>
   handlers
     .handle(
+      "reserve",
+      ({ payload, request }) =>
+        Effect.gen(function* () {
+          const router = yield* Router.Router;
+          return yield* router.reserve(request, payload.agent);
+        }),
+      uninterruptible,
+    )
+    .handle(
       "start",
       ({ payload, request }) =>
         Effect.gen(function* () {

--- a/src/qemu-reverse-proxy/handlers.ts
+++ b/src/qemu-reverse-proxy/handlers.ts
@@ -24,6 +24,15 @@ export const SessionsLive = HttpApiBuilder.group(Api.QemuReverseProxyApi, "Sessi
       uninterruptible,
     )
     .handle(
+      "relinquish",
+      ({ payload, request }) =>
+        Effect.gen(function* () {
+          const router = yield* Router.Router;
+          return yield* router.relinquish(request, payload.agent);
+        }),
+      uninterruptible,
+    )
+    .handle(
       "start",
       ({ payload, request }) =>
         Effect.gen(function* () {

--- a/src/qemu-reverse-proxy/router.ts
+++ b/src/qemu-reverse-proxy/router.ts
@@ -44,7 +44,16 @@ export type RouterService = {
   readonly unregister: (url: string) => Effect.Effect<void, Errors.NotFound | Errors.Internal>;
   // Every registered server with its stats, null for one whose probe failed.
   readonly servers: Effect.Effect<Contract.Servers, Errors.Internal>;
-  // Places the start on the answering server with the fewest qemus and routes the id it mints.
+  // Places a reserve on an answering server with a free slot and remembers the agent.
+  readonly reserve: (
+    request: HttpServerRequest.HttpServerRequest,
+    agent: string,
+  ) => Effect.Effect<
+    HttpServerResponse.HttpServerResponse,
+    Errors.NoServer | Errors.ServerFailed | Errors.Internal
+  >;
+  // Places the start on the answering server with the fewest qemus — or the one that reserved
+  // this agent — and routes the id it mints.
   readonly start: (
     request: HttpServerRequest.HttpServerRequest,
     agent: string,
@@ -263,31 +272,129 @@ const make = Effect.gen(function* () {
       return chosen.url;
     });
 
+  const commitStart = (
+    url: string,
+    request: HttpServerRequest.HttpServerRequest,
+    agent: string,
+  ): Effect.Effect<HttpServerResponse.HttpServerResponse, Errors.ServerFailed | Errors.Internal> =>
+    Effect.gen(function* () {
+      const who = { agentId: agent };
+      const response = yield* send(url, request).pipe(
+        Effect.mapError((error) => unreachable(url, error, who)),
+      );
+      const text = yield* response.text.pipe(
+        Effect.mapError((error) => unreachable(url, error, who)),
+      );
+      const headers = forwardedHeaders(response.headers);
+      if (response.status !== 200) {
+        // The server refused the start and has logged why; its answer is the client's.
+        return HttpServerResponse.text(text, { status: response.status, headers });
+      }
+      const { id } = yield* decodeStartAnswer(text).pipe(
+        Effect.mapError((cause) =>
+          serverFailed(url, `server ${url} answered 200 without an id`, cause, who),
+        ),
+      );
+      yield* store
+        .routeSession(id, url)
+        .pipe(Effect.mapError((cause) => internal(cause, id, agent)));
+      yield* log.info(`routed; ${url}`, { location: id, agentId: agent });
+      return HttpServerResponse.text(text, { status: 200, headers });
+    });
+
   const start = Effect.fn("Router.start")(function* (
     request: HttpServerRequest.HttpServerRequest,
     agent: string,
   ) {
-    const url = yield* place(agent);
+    const reserved = yield* store
+      .serverForAgent(agent)
+      .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
+    const url = Option.isSome(reserved) ? reserved.value : yield* place(agent);
+    return yield* commitStart(url, request, agent);
+  });
+
+  const reserve = Effect.fn("Router.reserve")(function* (
+    request: HttpServerRequest.HttpServerRequest,
+    agent: string,
+  ) {
+    const existing = yield* store
+      .serverForAgent(agent)
+      .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
     const who = { agentId: agent };
-    const response = yield* send(url, request).pipe(
-      Effect.mapError((error) => unreachable(url, error, who)),
+    const attempt = (
+      url: string,
+    ): Effect.Effect<
+      HttpServerResponse.HttpServerResponse,
+      Errors.ServerFailed | Errors.Internal
+    > =>
+      Effect.gen(function* () {
+        const response = yield* send(url, request).pipe(
+          Effect.mapError((error) => unreachable(url, error, who)),
+        );
+        const text = yield* response.text.pipe(
+          Effect.mapError((error) => unreachable(url, error, who)),
+        );
+        const headers = forwardedHeaders(response.headers);
+        return HttpServerResponse.text(text, { status: response.status, headers });
+      });
+    if (Option.isSome(existing)) {
+      return yield* attempt(existing.value);
+    }
+    const urls = yield* store
+      .listServers(SERVER_TYPE)
+      .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
+    if (urls.length === 0) {
+      return yield* Errors.NoServer.make({ message: "no server registered", agentId: agent });
+    }
+    const probed = yield* Effect.forEach(
+      urls,
+      (url) =>
+        Effect.map(Effect.result(probe(url, { agentId: agent })), (result) => ({ url, result })),
+      { concurrency: "unbounded" },
     );
-    const text = yield* response.text.pipe(
-      Effect.mapError((error) => unreachable(url, error, who)),
-    );
-    const headers = forwardedHeaders(response.headers);
-    if (response.status !== 200) {
-      // The server refused the start and has logged why; its answer is the client's.
+    const ranked: Array<{ readonly url: string; readonly qemus: number }> = [];
+    for (const { url, result } of probed) {
+      if (Result.isFailure(result)) {
+        yield* log.warning(`server skipped; ${result.failure.message}`, {
+          location: Log.Locations.server,
+          agentId: agent,
+        });
+        continue;
+      }
+      ranked.push({ url, qemus: result.success.qemus });
+    }
+    ranked.sort((left, right) => left.qemus - right.qemus);
+    let lastCapacity:
+      | { readonly status: number; readonly text: string; readonly headers: Headers.Input }
+      | undefined;
+    for (const { url } of ranked) {
+      const response = yield* send(url, request).pipe(
+        Effect.mapError((error) => unreachable(url, error, who)),
+      );
+      const text = yield* response.text.pipe(
+        Effect.mapError((error) => unreachable(url, error, who)),
+      );
+      const headers = forwardedHeaders(response.headers);
+      if (response.status === 200) {
+        yield* store
+          .routeAgent(agent, url)
+          .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
+        yield* log.info(`reserved; ${url}`, { location: Log.Locations.server, agentId: agent });
+        return HttpServerResponse.text(text, { status: 200, headers });
+      }
+      if (response.status === 503) {
+        lastCapacity = { status: response.status, text, headers };
+        continue;
+      }
       return HttpServerResponse.text(text, { status: response.status, headers });
     }
-    const { id } = yield* decodeStartAnswer(text).pipe(
-      Effect.mapError((cause) =>
-        serverFailed(url, `server ${url} answered 200 without an id`, cause, who),
-      ),
-    );
-    yield* store.routeSession(id, url).pipe(Effect.mapError((cause) => internal(cause, id, agent)));
-    yield* log.info(`routed; ${url}`, { location: id, agentId: agent });
-    return HttpServerResponse.text(text, { status: 200, headers });
+    if (lastCapacity !== undefined) {
+      return HttpServerResponse.text(lastCapacity.text, {
+        status: lastCapacity.status,
+        headers: lastCapacity.headers,
+      });
+    }
+    return yield* Errors.NoServer.make({ message: "no server available", agentId: agent });
   });
 
   const forward = Effect.fn("Router.forward")(function* (
@@ -311,7 +418,7 @@ const make = Effect.gen(function* () {
     return passthrough(route.value, response, who);
   });
 
-  const service: RouterService = { register, unregister, servers, start, forward };
+  const service: RouterService = { register, unregister, servers, reserve, start, forward };
   return service;
 });
 

--- a/src/qemu-reverse-proxy/router.ts
+++ b/src/qemu-reverse-proxy/router.ts
@@ -50,7 +50,7 @@ export type RouterService = {
     agent: string,
   ) => Effect.Effect<
     HttpServerResponse.HttpServerResponse,
-    Errors.NoServer | Errors.ServerFailed | Errors.Internal
+    Errors.BadRequest | Errors.NoServer | Errors.ServerFailed | Errors.Internal
   >;
   // Forwards relinquish to the server that reserved this agent and forgets the agent
   // when that server accepts it. There is no placement here: /reserve already chose.
@@ -299,24 +299,8 @@ const make = Effect.gen(function* () {
       .serverForAgent(agent)
       .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
     const who = { agentId: agent };
-    const attempt = (
-      url: string,
-    ): Effect.Effect<
-      HttpServerResponse.HttpServerResponse,
-      Errors.ServerFailed | Errors.Internal
-    > =>
-      Effect.gen(function* () {
-        const response = yield* send(url, request).pipe(
-          Effect.mapError((error) => unreachable(url, error, who)),
-        );
-        const text = yield* response.text.pipe(
-          Effect.mapError((error) => unreachable(url, error, who)),
-        );
-        const headers = forwardedHeaders(response.headers);
-        return HttpServerResponse.text(text, { status: response.status, headers });
-      });
     if (Option.isSome(existing)) {
-      return yield* attempt(existing.value);
+      return yield* Errors.BadRequest.make({ message: "already reserved", agentId: agent });
     }
     const urls = yield* store
       .listServers(SERVER_TYPE)

--- a/src/qemu-reverse-proxy/router.ts
+++ b/src/qemu-reverse-proxy/router.ts
@@ -395,7 +395,9 @@ const make = Effect.gen(function* () {
     );
     const headers = forwardedHeaders(response.headers);
     if (response.status === 200) {
-      yield* store.clearAgent(agent).pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
+      yield* store
+        .clearAgent(agent)
+        .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
       yield* log.info(`relinquished; ${url}`, { location: Log.Locations.server, agentId: agent });
     }
     return HttpServerResponse.text(text, { status: response.status, headers });

--- a/src/qemu-reverse-proxy/router.ts
+++ b/src/qemu-reverse-proxy/router.ts
@@ -264,6 +264,7 @@ const make = Effect.gen(function* () {
       yield* store
         .routeSession(id, url)
         .pipe(Effect.mapError((cause) => internal(cause, id, agent)));
+      yield* store.clearAgent(agent).pipe(Effect.mapError((cause) => internal(cause, id, agent)));
       yield* log.info(`routed; ${url}`, { location: id, agentId: agent });
       return HttpServerResponse.text(text, { status: 200, headers });
     });

--- a/src/qemu-reverse-proxy/router.ts
+++ b/src/qemu-reverse-proxy/router.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Option, Result, Schema, Stream } from "effect";
+import { Context, Effect, Layer, Option, Result, Schema, Semaphore, Stream } from "effect";
 import {
   type Headers,
   HttpBody,
@@ -127,6 +127,8 @@ const make = Effect.gen(function* () {
   const log = yield* Log.Log;
   const http = yield* HttpClient.HttpClient;
   const { token } = yield* Config.ProxyConfig;
+  // One reserve at a time: two requests for the same agent must not both place.
+  const reserveGate = yield* Semaphore.make(1);
 
   // prependUrl joins with exactly one slash, so `http://host/` and `http://host` reach the same
   // /stats, as the generated client's baseUrl does.
@@ -295,68 +297,75 @@ const make = Effect.gen(function* () {
     request: HttpServerRequest.HttpServerRequest,
     agent: string,
   ) {
-    const existing = yield* store
-      .serverForAgent(agent)
-      .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
-    const who = { agentId: agent };
-    if (Option.isSome(existing)) {
-      return yield* Errors.BadRequest.make({ message: "already reserved", agentId: agent });
-    }
-    const urls = yield* store
-      .listServers(SERVER_TYPE)
-      .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
-    if (urls.length === 0) {
-      return yield* Errors.NoServer.make({ message: "no server registered", agentId: agent });
-    }
-    const probed = yield* Effect.forEach(
-      urls,
-      (url) =>
-        Effect.map(Effect.result(probe(url, { agentId: agent })), (result) => ({ url, result })),
-      { concurrency: "unbounded" },
-    );
-    const ranked: Array<{ readonly url: string; readonly qemus: number }> = [];
-    for (const { url, result } of probed) {
-      if (Result.isFailure(result)) {
-        yield* log.warning(`server skipped; ${result.failure.message}`, {
-          location: Log.Locations.server,
-          agentId: agent,
-        });
-        continue;
-      }
-      ranked.push({ url, qemus: result.success.qemus });
-    }
-    ranked.sort((left, right) => left.qemus - right.qemus);
-    let lastCapacity:
-      | { readonly status: number; readonly text: string; readonly headers: Headers.Input }
-      | undefined;
-    for (const { url } of ranked) {
-      const response = yield* send(url, request).pipe(
-        Effect.mapError((error) => unreachable(url, error, who)),
-      );
-      const text = yield* response.text.pipe(
-        Effect.mapError((error) => unreachable(url, error, who)),
-      );
-      const headers = forwardedHeaders(response.headers);
-      if (response.status === 200) {
-        yield* store
-          .routeAgent(agent, url)
+    return yield* reserveGate.withPermits(1)(
+      Effect.gen(function* () {
+        const existing = yield* store
+          .serverForAgent(agent)
           .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
-        yield* log.info(`reserved; ${url}`, { location: Log.Locations.server, agentId: agent });
-        return HttpServerResponse.text(text, { status: 200, headers });
-      }
-      if (response.status === 503) {
-        lastCapacity = { status: response.status, text, headers };
-        continue;
-      }
-      return HttpServerResponse.text(text, { status: response.status, headers });
-    }
-    if (lastCapacity !== undefined) {
-      return HttpServerResponse.text(lastCapacity.text, {
-        status: lastCapacity.status,
-        headers: lastCapacity.headers,
-      });
-    }
-    return yield* Errors.NoServer.make({ message: "no server available", agentId: agent });
+        const who = { agentId: agent };
+        if (Option.isSome(existing)) {
+          return yield* Errors.BadRequest.make({ message: "already reserved", agentId: agent });
+        }
+        const urls = yield* store
+          .listServers(SERVER_TYPE)
+          .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
+        if (urls.length === 0) {
+          return yield* Errors.NoServer.make({ message: "no server registered", agentId: agent });
+        }
+        const probed = yield* Effect.forEach(
+          urls,
+          (url) =>
+            Effect.map(Effect.result(probe(url, { agentId: agent })), (result) => ({
+              url,
+              result,
+            })),
+          { concurrency: "unbounded" },
+        );
+        const ranked: Array<{ readonly url: string; readonly qemus: number }> = [];
+        for (const { url, result } of probed) {
+          if (Result.isFailure(result)) {
+            yield* log.warning(`server skipped; ${result.failure.message}`, {
+              location: Log.Locations.server,
+              agentId: agent,
+            });
+            continue;
+          }
+          ranked.push({ url, qemus: result.success.qemus });
+        }
+        ranked.sort((left, right) => left.qemus - right.qemus);
+        let lastCapacity:
+          | { readonly status: number; readonly text: string; readonly headers: Headers.Input }
+          | undefined;
+        for (const { url } of ranked) {
+          const response = yield* send(url, request).pipe(
+            Effect.mapError((error) => unreachable(url, error, who)),
+          );
+          const text = yield* response.text.pipe(
+            Effect.mapError((error) => unreachable(url, error, who)),
+          );
+          const headers = forwardedHeaders(response.headers);
+          if (response.status === 200) {
+            yield* store
+              .routeAgent(agent, url)
+              .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
+            yield* log.info(`reserved; ${url}`, { location: Log.Locations.server, agentId: agent });
+            return HttpServerResponse.text(text, { status: 200, headers });
+          }
+          if (response.status === 503) {
+            lastCapacity = { status: response.status, text, headers };
+            continue;
+          }
+          return HttpServerResponse.text(text, { status: response.status, headers });
+        }
+        if (lastCapacity !== undefined) {
+          return HttpServerResponse.text(lastCapacity.text, {
+            status: lastCapacity.status,
+            headers: lastCapacity.headers,
+          });
+        }
+        return yield* Errors.NoServer.make({ message: "no server available", agentId: agent });
+      }),
+    );
   });
 
   const relinquish = Effect.fn("Router.relinquish")(function* (

--- a/src/qemu-reverse-proxy/router.ts
+++ b/src/qemu-reverse-proxy/router.ts
@@ -390,17 +390,15 @@ const make = Effect.gen(function* () {
     const response = yield* send(url, request).pipe(
       Effect.mapError((error) => unreachable(url, error, who)),
     );
-    const text = yield* response.text.pipe(
-      Effect.mapError((error) => unreachable(url, error, who)),
-    );
-    const headers = forwardedHeaders(response.headers);
+    // Status is on the wire before the body: a 200 means the slot is already free, even if
+    // the stream then dies. Forget the agent before passing the answer through.
     if (response.status === 200) {
       yield* store
         .clearAgent(agent)
         .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
       yield* log.info(`relinquished; ${url}`, { location: Log.Locations.server, agentId: agent });
     }
-    return HttpServerResponse.text(text, { status: response.status, headers });
+    return passthrough(url, response, who);
   });
 
   const forward = Effect.fn("Router.forward")(function* (

--- a/src/qemu-reverse-proxy/router.ts
+++ b/src/qemu-reverse-proxy/router.ts
@@ -19,7 +19,7 @@ import * as Contract from "../shared/contract.ts";
 import * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 
-// A server that has not answered its /stats in this long is skipped for the start that asked and
+// A server that has not answered its /stats in this long is skipped for the reserve that asked and
 // is null in GET /servers; the request that probed it does not wait longer.
 export const PROBE_TIMEOUT = "10 seconds";
 
@@ -52,14 +52,14 @@ export type RouterService = {
     HttpServerResponse.HttpServerResponse,
     Errors.NoServer | Errors.ServerFailed | Errors.Internal
   >;
-  // Places the start on the answering server with the fewest qemus — or the one that reserved
-  // this agent — and routes the id it mints.
+  // Forwards start to the server that reserved this agent. There is no placement here:
+  // /reserve already chose.
   readonly start: (
     request: HttpServerRequest.HttpServerRequest,
     agent: string,
   ) => Effect.Effect<
     HttpServerResponse.HttpServerResponse,
-    Errors.NoServer | Errors.ServerFailed | Errors.Internal
+    Errors.BadRequest | Errors.ServerFailed | Errors.Internal
   >;
   // Sends the request as it came to the server that started the session; the answer as it came.
   readonly forward: (
@@ -238,40 +238,6 @@ const make = Effect.gen(function* () {
     return Contract.Servers.make({ servers: probed });
   });
 
-  // The answering server with the fewest machines, ties to the earliest registered.
-  const place = (agent: string): Effect.Effect<string, Errors.NoServer | Errors.Internal> =>
-    Effect.gen(function* () {
-      const urls = yield* store
-        .listServers(SERVER_TYPE)
-        .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
-      if (urls.length === 0) {
-        return yield* Errors.NoServer.make({ message: "no server registered", agentId: agent });
-      }
-      const probed = yield* Effect.forEach(
-        urls,
-        (url) =>
-          Effect.map(Effect.result(probe(url, { agentId: agent })), (result) => ({ url, result })),
-        { concurrency: "unbounded" },
-      );
-      let chosen: { readonly url: string; readonly qemus: number } | undefined;
-      for (const { url, result } of probed) {
-        if (Result.isFailure(result)) {
-          yield* log.warning(`server skipped; ${result.failure.message}`, {
-            location: Log.Locations.server,
-            agentId: agent,
-          });
-          continue;
-        }
-        if (chosen === undefined || result.success.qemus < chosen.qemus) {
-          chosen = { url, qemus: result.success.qemus };
-        }
-      }
-      if (chosen === undefined) {
-        return yield* Errors.NoServer.make({ message: "no server available", agentId: agent });
-      }
-      return chosen.url;
-    });
-
   const commitStart = (
     url: string,
     request: HttpServerRequest.HttpServerRequest,
@@ -309,8 +275,10 @@ const make = Effect.gen(function* () {
     const reserved = yield* store
       .serverForAgent(agent)
       .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
-    const url = Option.isSome(reserved) ? reserved.value : yield* place(agent);
-    return yield* commitStart(url, request, agent);
+    if (Option.isNone(reserved)) {
+      return yield* Errors.BadRequest.make({ message: "no reservation", agentId: agent });
+    }
+    return yield* commitStart(reserved.value, request, agent);
   });
 
   const reserve = Effect.fn("Router.reserve")(function* (

--- a/src/qemu-reverse-proxy/router.ts
+++ b/src/qemu-reverse-proxy/router.ts
@@ -52,6 +52,15 @@ export type RouterService = {
     HttpServerResponse.HttpServerResponse,
     Errors.NoServer | Errors.ServerFailed | Errors.Internal
   >;
+  // Forwards relinquish to the server that reserved this agent and forgets the agent
+  // when that server accepts it. There is no placement here: /reserve already chose.
+  readonly relinquish: (
+    request: HttpServerRequest.HttpServerRequest,
+    agent: string,
+  ) => Effect.Effect<
+    HttpServerResponse.HttpServerResponse,
+    Errors.BadRequest | Errors.ServerFailed | Errors.Internal
+  >;
   // Forwards start to the server that reserved this agent. There is no placement here:
   // /reserve already chose.
   readonly start: (
@@ -366,6 +375,32 @@ const make = Effect.gen(function* () {
     return yield* Errors.NoServer.make({ message: "no server available", agentId: agent });
   });
 
+  const relinquish = Effect.fn("Router.relinquish")(function* (
+    request: HttpServerRequest.HttpServerRequest,
+    agent: string,
+  ) {
+    const reserved = yield* store
+      .serverForAgent(agent)
+      .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
+    if (Option.isNone(reserved)) {
+      return yield* Errors.BadRequest.make({ message: "no reservation", agentId: agent });
+    }
+    const who = { agentId: agent };
+    const url = reserved.value;
+    const response = yield* send(url, request).pipe(
+      Effect.mapError((error) => unreachable(url, error, who)),
+    );
+    const text = yield* response.text.pipe(
+      Effect.mapError((error) => unreachable(url, error, who)),
+    );
+    const headers = forwardedHeaders(response.headers);
+    if (response.status === 200) {
+      yield* store.clearAgent(agent).pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
+      yield* log.info(`relinquished; ${url}`, { location: Log.Locations.server, agentId: agent });
+    }
+    return HttpServerResponse.text(text, { status: response.status, headers });
+  });
+
   const forward = Effect.fn("Router.forward")(function* (
     request: HttpServerRequest.HttpServerRequest,
     id: string,
@@ -387,7 +422,15 @@ const make = Effect.gen(function* () {
     return passthrough(route.value, response, who);
   });
 
-  const service: RouterService = { register, unregister, servers, reserve, start, forward };
+  const service: RouterService = {
+    register,
+    unregister,
+    servers,
+    reserve,
+    relinquish,
+    start,
+    forward,
+  };
   return service;
 });
 

--- a/src/qemu-server/command.ts
+++ b/src/qemu-server/command.ts
@@ -56,7 +56,7 @@ export const makeQemuServerCommand = <RHost, RServe>(server: QemuServer<RHost, R
       maxJobs: Flag.integer("max-jobs").pipe(
         Flag.withSchema(Domain.MaxJobs),
         Flag.withDescription(
-          "How many sessions this server runs at once; a start past it is refused with 503",
+          "How many sessions this server runs at once; a reserve past it is refused with 503",
         ),
       ),
       port: Flag.integer("port").pipe(

--- a/src/qemu-server/handlers.ts
+++ b/src/qemu-server/handlers.ts
@@ -24,7 +24,7 @@ export const SessionsLive = (display: Domain.QemuDisplay, automation: boolean) =
         ({ payload }) =>
           Effect.gen(function* () {
             const sessions = yield* Sessions.Sessions;
-            yield* sessions.reserve(payload);
+            yield* sessions.reserve(payload.agent);
             return ok;
           }),
         uninterruptible,

--- a/src/qemu-server/handlers.ts
+++ b/src/qemu-server/handlers.ts
@@ -30,6 +30,16 @@ export const SessionsLive = (display: Domain.QemuDisplay, automation: boolean) =
         uninterruptible,
       )
       .handle(
+        "relinquish",
+        ({ payload }) =>
+          Effect.gen(function* () {
+            const sessions = yield* Sessions.Sessions;
+            yield* sessions.relinquish(payload.agent);
+            return ok;
+          }),
+        uninterruptible,
+      )
+      .handle(
         "start",
         ({ payload }) =>
           Effect.gen(function* () {

--- a/src/qemu-server/handlers.ts
+++ b/src/qemu-server/handlers.ts
@@ -20,6 +20,16 @@ export const SessionsLive = (display: Domain.QemuDisplay, automation: boolean) =
   HttpApiBuilder.group(Api.QemuServerApi, "Sessions", (handlers) =>
     handlers
       .handle(
+        "reserve",
+        ({ payload }) =>
+          Effect.gen(function* () {
+            const sessions = yield* Sessions.Sessions;
+            yield* sessions.reserve(payload);
+            return ok;
+          }),
+        uninterruptible,
+      )
+      .handle(
         "start",
         ({ payload }) =>
           Effect.gen(function* () {

--- a/src/qemu-server/middleware.ts
+++ b/src/qemu-server/middleware.ts
@@ -114,13 +114,17 @@ const detail = (error: Errors.ApiError): string =>
     : error.message;
 
 // A refusal (< 500) is the caller's problem and skips Sentry; a failure carries its cause there.
-const report = (error: Errors.ApiError, fallback: Log.ProcessAttribution): Log.Report =>
-  Errors.apiStatus(error) < 500
-    ? { ...attribution(error, fallback), skipSentry: true }
-    : {
-        ...attribution(error, fallback),
-        cause: "cause" in error ? error.cause : undefined,
-      };
+// A second reserve for an id that already holds one is this process breaking its own contract,
+// so that 400 is reported.
+const report = (error: Errors.ApiError, fallback: Log.ProcessAttribution): Log.Report => {
+  const who = attribution(error, fallback);
+  if (error._tag === "BadRequest" && error.message === "already reserved") {
+    return who;
+  }
+  return Errors.apiStatus(error) < 500
+    ? { ...who, skipSentry: true }
+    : { ...who, cause: "cause" in error ? error.cause : undefined };
+};
 
 // The one boundary: schema errors to 400, defects to 500, one log line per failed request. The
 // qemu server and the qemu reverse proxy wrap it in their own middleware tags, which differ only in the error

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -73,7 +73,11 @@ export type LiveSession = {
 type OpenSession = Omit<LiveSession, "qemu">;
 
 export type SessionsService = {
-  // Fails AtCapacity, before anything is minted or written, once --max-jobs sessions are held.
+  // Takes a --max-jobs slot for this agent, before anything is minted or written. A second
+  // reserve for the same agent is the same slot. Start consumes it and does not increment again.
+  readonly reserve: (body: Contract.StartBody) => Effect.Effect<void, Errors.AtCapacity>;
+  // Fails AtCapacity, before anything is minted or written, once --max-jobs sessions are held,
+  // unless this agent already reserved.
   readonly start: (
     body: Contract.StartBody,
     display: Domain.QemuDisplay,
@@ -200,10 +204,14 @@ const make = (maxJobs: number) =>
     // Running machines, by id; and every session this qemu server holds, booting ones included.
     const sessions = yield* Ref.make<ReadonlyMap<string, LiveSession>>(new Map());
     const openSessions = yield* Ref.make<ReadonlyMap<string, OpenSession>>(new Map());
-    // How many sessions are admitted against --max-jobs. Taken at the top of start, before the
-    // span, scope or row exist, so a refusal allocates nothing; given back in finishLiveSession,
-    // the one place every admitted session ends.
-    const jobs = yield* Ref.make(0);
+    // How many sessions are admitted against --max-jobs, and which agents already hold a slot
+    // that start will consume. Taken at reserve (or at start when there is no reservation),
+    // before the span, scope or row exist, so a refusal allocates nothing; given back in
+    // finishLiveSession, the one place every admitted session ends.
+    const slots = yield* Ref.make<{
+      readonly count: number;
+      readonly reserved: ReadonlySet<string>;
+    }>({ count: 0, reserved: new Set() });
 
     const elapsed = (started: number) =>
       Effect.map(Clock.currentTimeMillis, (now) => String(now - started));
@@ -340,7 +348,7 @@ const make = (maxJobs: number) =>
     ): Effect.Effect<void> =>
       Effect.gen(function* () {
         yield* Ref.update(openSessions, (map) => mapWithout(map, [live.id]));
-        yield* Ref.update(jobs, (n) => n - 1);
+        yield* Ref.update(slots, (held) => ({ ...held, count: held.count - 1 }));
         yield* log.releaseColor(live.agent);
         for (const span of yield* Ref.get(live.actionSpans)) {
           yield* settleActionSpan(live, span, "failed");
@@ -426,13 +434,40 @@ const make = (maxJobs: number) =>
         ),
       );
 
+    const reserve = Effect.fn("Sessions.reserve")(function* (body: Contract.StartBody) {
+      const agent = body.agent;
+      const admitted = yield* Ref.modify(slots, (held) => {
+        if (held.reserved.has(agent)) {
+          return [true, held] as const;
+        }
+        if (held.count >= maxJobs) {
+          return [false, held] as const;
+        }
+        return [true, { count: held.count + 1, reserved: withItem(held.reserved, agent) }] as const;
+      });
+      if (!admitted) {
+        return yield* Errors.AtCapacity.make({
+          message: `at capacity: max-jobs is ${String(maxJobs)}`,
+          agentId: agent,
+        });
+      }
+    });
+
     const start = Effect.fn("Sessions.start")(function* (
       body: Contract.StartBody,
       display: Domain.QemuDisplay,
       automation: boolean,
     ) {
       const agent = body.agent;
-      const admitted = yield* Ref.modify(jobs, (n) => (n < maxJobs ? [true, n + 1] : [false, n]));
+      const admitted = yield* Ref.modify(slots, (held) => {
+        if (held.reserved.has(agent)) {
+          return [true, { count: held.count, reserved: without(held.reserved, agent) }] as const;
+        }
+        if (held.count >= maxJobs) {
+          return [false, held] as const;
+        }
+        return [true, { count: held.count + 1, reserved: held.reserved }] as const;
+      });
       if (!admitted) {
         return yield* Errors.AtCapacity.make({
           message: `at capacity: max-jobs is ${String(maxJobs)}`,
@@ -955,6 +990,7 @@ const make = (maxJobs: number) =>
     yield* Effect.addFinalizer(() => drain);
 
     const service: SessionsService = {
+      reserve,
       start,
       lookup,
       image,

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -75,14 +75,14 @@ type OpenSession = Omit<LiveSession, "qemu">;
 export type SessionsService = {
   // Takes a --max-jobs slot for this agent, before anything is minted or written. A second
   // reserve for the same agent is the same slot. Start consumes it and does not increment again.
-  readonly reserve: (body: Contract.StartBody) => Effect.Effect<void, Errors.AtCapacity>;
-  // Fails AtCapacity, before anything is minted or written, once --max-jobs sessions are held,
-  // unless this agent already reserved.
+  readonly reserve: (agent: string) => Effect.Effect<void, Errors.AtCapacity>;
+  // Consumes this agent's reservation. Fails BadRequest, before anything is minted or written,
+  // when there is none.
   readonly start: (
     body: Contract.StartBody,
     display: Domain.QemuDisplay,
     automation: boolean,
-  ) => Effect.Effect<string, Errors.AtCapacity | Errors.StartFailed | Errors.Internal>;
+  ) => Effect.Effect<string, Errors.BadRequest | Errors.StartFailed | Errors.Internal>;
   // Resets lastCommandAt before returning: a valid request counts as activity.
   readonly lookup: (
     id: string,
@@ -205,9 +205,9 @@ const make = (maxJobs: number) =>
     const sessions = yield* Ref.make<ReadonlyMap<string, LiveSession>>(new Map());
     const openSessions = yield* Ref.make<ReadonlyMap<string, OpenSession>>(new Map());
     // How many sessions are admitted against --max-jobs, and which agents already hold a slot
-    // that start will consume. Taken at reserve (or at start when there is no reservation),
-    // before the span, scope or row exist, so a refusal allocates nothing; given back in
-    // finishLiveSession, the one place every admitted session ends.
+    // that start will consume. Taken at reserve, before the span, scope or row exist, so a
+    // refusal allocates nothing; given back in finishLiveSession, the one place every admitted
+    // session ends.
     const slots = yield* Ref.make<{
       readonly count: number;
       readonly reserved: ReadonlySet<string>;
@@ -434,8 +434,7 @@ const make = (maxJobs: number) =>
         ),
       );
 
-    const reserve = Effect.fn("Sessions.reserve")(function* (body: Contract.StartBody) {
-      const agent = body.agent;
+    const reserve = Effect.fn("Sessions.reserve")(function* (agent: string) {
       return yield* Effect.flatMap(
         Ref.modify(slots, (held) => {
           if (held.reserved.has(agent)) {
@@ -465,18 +464,14 @@ const make = (maxJobs: number) =>
       automation: boolean,
     ) {
       const agent = body.agent;
-      const admitted = yield* Ref.modify(slots, (held) => {
-        if (held.reserved.has(agent)) {
-          return [true, { count: held.count, reserved: without(held.reserved, agent) }] as const;
-        }
-        if (held.count >= maxJobs) {
-          return [false, held] as const;
-        }
-        return [true, { count: held.count + 1, reserved: held.reserved }] as const;
-      });
-      if (!admitted) {
-        return yield* Errors.AtCapacity.make({
-          message: `at capacity: max-jobs is ${String(maxJobs)}`,
+      const reserved = yield* Ref.modify(slots, (held) =>
+        held.reserved.has(agent)
+          ? ([true, { count: held.count, reserved: without(held.reserved, agent) }] as const)
+          : ([false, held] as const),
+      );
+      if (!reserved) {
+        return yield* Errors.BadRequest.make({
+          message: "no reservation",
           agentId: agent,
         });
       }

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -465,10 +465,7 @@ const make = (maxJobs: number) =>
       return yield* Effect.flatMap(
         Ref.modify(slots, (held) =>
           held.reserved.has(agent)
-            ? ([
-                true,
-                { count: held.count - 1, reserved: without(held.reserved, agent) },
-              ] as const)
+            ? ([true, { count: held.count - 1, reserved: without(held.reserved, agent) }] as const)
             : ([false, held] as const),
         ),
         (released) =>

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -76,6 +76,9 @@ export type SessionsService = {
   // Takes a --max-jobs slot for this agent, before anything is minted or written. A second
   // reserve for the same agent is the same slot. Start consumes it and does not increment again.
   readonly reserve: (agent: string) => Effect.Effect<void, Errors.AtCapacity>;
+  // Gives back an unused reservation. Fails BadRequest when there is none, including after
+  // start has already consumed it: a running session keeps its slot.
+  readonly relinquish: (agent: string) => Effect.Effect<void, Errors.BadRequest>;
   // Consumes this agent's reservation. Fails BadRequest, before anything is minted or written,
   // when there is none.
   readonly start: (
@@ -453,6 +456,26 @@ const make = (maxJobs: number) =>
             ? Effect.void
             : Errors.AtCapacity.make({
                 message: `at capacity: max-jobs is ${String(maxJobs)}`,
+                agentId: agent,
+              }),
+      );
+    });
+
+    const relinquish = Effect.fn("Sessions.relinquish")(function* (agent: string) {
+      return yield* Effect.flatMap(
+        Ref.modify(slots, (held) =>
+          held.reserved.has(agent)
+            ? ([
+                true,
+                { count: held.count - 1, reserved: without(held.reserved, agent) },
+              ] as const)
+            : ([false, held] as const),
+        ),
+        (released) =>
+          released
+            ? Effect.void
+            : Errors.BadRequest.make({
+                message: "no reservation",
                 agentId: agent,
               }),
       );
@@ -992,6 +1015,7 @@ const make = (maxJobs: number) =>
 
     const service: SessionsService = {
       reserve,
+      relinquish,
       start,
       lookup,
       image,

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -74,8 +74,9 @@ type OpenSession = Omit<LiveSession, "qemu">;
 
 export type SessionsService = {
   // Takes a --max-jobs slot for this agent, before anything is minted or written. A second
-  // reserve for the same agent is the same slot. Start consumes it and does not increment again.
-  readonly reserve: (agent: string) => Effect.Effect<void, Errors.AtCapacity>;
+  // reserve for the same agent is BadRequest: one id, one unused reservation. Start consumes
+  // it and does not increment again.
+  readonly reserve: (agent: string) => Effect.Effect<void, Errors.AtCapacity | Errors.BadRequest>;
   // Gives back an unused reservation. Fails BadRequest when there is none, including after
   // start has already consumed it: a running session keeps its slot.
   readonly relinquish: (agent: string) => Effect.Effect<void, Errors.BadRequest>;
@@ -437,27 +438,40 @@ const make = (maxJobs: number) =>
         ),
       );
 
+    const admit = (
+      outcome: "ok" | "held" | "full",
+      agent: string,
+    ): Effect.Effect<void, Errors.AtCapacity | Errors.BadRequest> => {
+      if (outcome === "ok") {
+        return Effect.void;
+      }
+      if (outcome === "held") {
+        return Errors.BadRequest.make({
+          message: "already reserved",
+          agentId: agent,
+        });
+      }
+      return Errors.AtCapacity.make({
+        message: `at capacity: max-jobs is ${String(maxJobs)}`,
+        agentId: agent,
+      });
+    };
+
     const reserve = Effect.fn("Sessions.reserve")(function* (agent: string) {
       return yield* Effect.flatMap(
         Ref.modify(slots, (held) => {
           if (held.reserved.has(agent)) {
-            return [true, held] as const;
+            return ["held", held] as const;
           }
           if (held.count >= maxJobs) {
-            return [false, held] as const;
+            return ["full", held] as const;
           }
           return [
-            true,
+            "ok",
             { count: held.count + 1, reserved: withItem(held.reserved, agent) },
           ] as const;
         }),
-        (admitted) =>
-          admitted
-            ? Effect.void
-            : Errors.AtCapacity.make({
-                message: `at capacity: max-jobs is ${String(maxJobs)}`,
-                agentId: agent,
-              }),
+        (outcome) => admit(outcome, agent),
       );
     });
 

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -436,21 +436,27 @@ const make = (maxJobs: number) =>
 
     const reserve = Effect.fn("Sessions.reserve")(function* (body: Contract.StartBody) {
       const agent = body.agent;
-      const admitted = yield* Ref.modify(slots, (held) => {
-        if (held.reserved.has(agent)) {
-          return [true, held] as const;
-        }
-        if (held.count >= maxJobs) {
-          return [false, held] as const;
-        }
-        return [true, { count: held.count + 1, reserved: withItem(held.reserved, agent) }] as const;
-      });
-      if (!admitted) {
-        return yield* Errors.AtCapacity.make({
-          message: `at capacity: max-jobs is ${String(maxJobs)}`,
-          agentId: agent,
-        });
-      }
+      return yield* Effect.flatMap(
+        Ref.modify(slots, (held) => {
+          if (held.reserved.has(agent)) {
+            return [true, held] as const;
+          }
+          if (held.count >= maxJobs) {
+            return [false, held] as const;
+          }
+          return [
+            true,
+            { count: held.count + 1, reserved: withItem(held.reserved, agent) },
+          ] as const;
+        }),
+        (admitted) =>
+          admitted
+            ? Effect.void
+            : Errors.AtCapacity.make({
+                message: `at capacity: max-jobs is ${String(maxJobs)}`,
+                agentId: agent,
+              }),
+      );
     });
 
     const start = Effect.fn("Sessions.start")(function* (

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -43,6 +43,12 @@ export class RouteBoundary extends HttpApiMiddleware.Service<RouteBoundary>()(
 const png = Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array({ contentType: "image/png" }));
 
 // Sessions group: bearer required
+export const reserve = HttpApiEndpoint.post("reserve", "/reserve", {
+  payload: Contract.StartBody,
+  success: Contract.Ok,
+  error: [Errors.AtCapacityWire],
+});
+
 export const start = HttpApiEndpoint.post("start", "/start", {
   payload: Contract.StartBody,
   success: Contract.StartResponse,
@@ -105,6 +111,7 @@ export const intentEnd = HttpApiEndpoint.post("intentEnd", "/intent/end", {
 // BearerAuth first, ApiBoundary second: middlewares wrap successively, so ApiBoundary is
 // outermost and sees an Unauthorized on its way out.
 export class Sessions extends HttpApiGroup.make("Sessions")
+  .add(reserve)
   .add(start)
   .add(image)
   .add(serial)
@@ -124,6 +131,7 @@ export class QemuServerApi extends HttpApi.make("OligarchyQemuServer").add(Sessi
 // The qemu reverse proxy: the qemu server's own endpoints, so the client that speaks to a server speaks to
 // it, minus /stats (a fleet has no one cpu), behind the routing boundary.
 export class RoutedSessions extends HttpApiGroup.make("Sessions")
+  .add(reserve)
   .add(start)
   .add(image)
   .add(serial)
@@ -173,6 +181,12 @@ export const linear = HttpApiEndpoint.post("linear", "/linear", {
 
 export class Linear extends HttpApiGroup.make("Linear").add(linear).middleware(ApiBoundary) {}
 
+export const reserveRun = HttpApiEndpoint.post("reserve", "/reserve", {
+  payload: Contract.ReserveBody,
+  success: Contract.Ok,
+  error: [Errors.AtCapacityWire],
+});
+
 export const run = HttpApiEndpoint.post("run", "/run", {
   payload: Contract.RunBody,
   success: Contract.Ok,
@@ -195,6 +209,7 @@ export class AutomationServerApi extends HttpApi.make("OligarchyAutomationServer
   .add(Abort) {}
 
 export class Runs extends HttpApiGroup.make("Runs")
+  .add(reserveRun)
   .add(run)
   .add(abort)
   .middleware(BearerAuth)

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -44,7 +44,7 @@ const png = Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array({ contentType: "im
 
 // Sessions group: bearer required
 export const reserve = HttpApiEndpoint.post("reserve", "/reserve", {
-  payload: Contract.StartBody,
+  payload: Contract.ReserveAgentBody,
   success: Contract.Ok,
   error: [Errors.AtCapacityWire],
 });
@@ -52,7 +52,7 @@ export const reserve = HttpApiEndpoint.post("reserve", "/reserve", {
 export const start = HttpApiEndpoint.post("start", "/start", {
   payload: Contract.StartBody,
   success: Contract.StartResponse,
-  error: [Errors.StartFailedWire, Errors.AtCapacityWire],
+  error: [Errors.StartFailedWire],
 });
 
 export const image = HttpApiEndpoint.get("image", "/image", {
@@ -190,7 +190,7 @@ export const reserveRun = HttpApiEndpoint.post("reserve", "/reserve", {
 export const run = HttpApiEndpoint.post("run", "/run", {
   payload: Contract.RunBody,
   success: Contract.Ok,
-  error: [Errors.RunFailedWire, Errors.AtCapacityWire],
+  error: [Errors.RunFailedWire],
 });
 
 export const abort = HttpApiEndpoint.post("abort", "/abort", {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -49,6 +49,11 @@ export const reserve = HttpApiEndpoint.post("reserve", "/reserve", {
   error: [Errors.AtCapacityWire],
 });
 
+export const relinquish = HttpApiEndpoint.post("relinquish", "/relinquish", {
+  payload: Contract.ReserveAgentBody,
+  success: Contract.Ok,
+});
+
 export const start = HttpApiEndpoint.post("start", "/start", {
   payload: Contract.StartBody,
   success: Contract.StartResponse,
@@ -112,6 +117,7 @@ export const intentEnd = HttpApiEndpoint.post("intentEnd", "/intent/end", {
 // outermost and sees an Unauthorized on its way out.
 export class Sessions extends HttpApiGroup.make("Sessions")
   .add(reserve)
+  .add(relinquish)
   .add(start)
   .add(image)
   .add(serial)
@@ -132,6 +138,7 @@ export class QemuServerApi extends HttpApi.make("OligarchyQemuServer").add(Sessi
 // it, minus /stats (a fleet has no one cpu), behind the routing boundary.
 export class RoutedSessions extends HttpApiGroup.make("Sessions")
   .add(reserve)
+  .add(relinquish)
   .add(start)
   .add(image)
   .add(serial)

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -117,6 +117,12 @@ export class ReserveBody extends Schema.Class<ReserveBody>(
   ticket: Schema.NonEmptyString,
 }) {}
 
+export class ReserveAgentBody extends Schema.Class<ReserveAgentBody>(
+  "@oligarchy/shared/contract/ReserveAgentBody",
+)({
+  agent: Schema.NonEmptyString,
+}) {}
+
 export class AbortBody extends Schema.Class<AbortBody>("@oligarchy/shared/contract/AbortBody")({
   ticket: Schema.NonEmptyString,
 }) {}

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -111,6 +111,12 @@ export class RunBody extends Schema.Class<RunBody>("@oligarchy/shared/contract/R
   ticket: Schema.NonEmptyString,
 }) {}
 
+export class ReserveBody extends Schema.Class<ReserveBody>(
+  "@oligarchy/shared/contract/ReserveBody",
+)({
+  ticket: Schema.NonEmptyString,
+}) {}
+
 export class AbortBody extends Schema.Class<AbortBody>("@oligarchy/shared/contract/AbortBody")({
   ticket: Schema.NonEmptyString,
 }) {}

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -150,7 +150,8 @@ export const ServerUrl = Schema.String.check(
 export type ServerUrl = typeof ServerUrl.Type;
 
 // How many jobs a qemu server or automation client runs at once, as --max-jobs names it: a
-// reserve, start or run past it is refused. A host that takes no jobs is not a server.
+// reserve past it is refused. Start and run consume a reservation. A host that takes no jobs
+// is not a server.
 export const MaxJobs = Schema.Int.check(
   Schema.isGreaterThanOrEqualTo(1, { message: "max-jobs must be at least 1" }),
 ).annotate({ identifier: "@oligarchy/shared/domain/MaxJobs" });

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -150,7 +150,7 @@ export const ServerUrl = Schema.String.check(
 export type ServerUrl = typeof ServerUrl.Type;
 
 // How many jobs a qemu server or automation client runs at once, as --max-jobs names it: a
-// start or run past it is refused. A host that takes no jobs is not a server.
+// reserve, start or run past it is refused. A host that takes no jobs is not a server.
 export const MaxJobs = Schema.Int.check(
   Schema.isGreaterThanOrEqualTo(1, { message: "max-jobs must be at least 1" }),
 ).annotate({ identifier: "@oligarchy/shared/domain/MaxJobs" });

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -156,9 +156,10 @@ export class RunFailed extends Schema.TaggedError<RunFailed>("@oligarchy/shared/
   override readonly [ErrorReporter.ignore] = true;
 }
 
-// A reserve, start or run refused because the process already runs --max-jobs jobs. 503: the
-// server is temporarily unable to take the work (RFC 9110 §15.6.4), not the caller's mistake;
-// the caller places it elsewhere or retries later.
+// A reserve refused because the process already holds --max-jobs jobs. 503: the server is
+// temporarily unable to take the work (RFC 9110 §15.6.4), not the caller's mistake; the caller
+// places it elsewhere or retries later. Start and run do not answer this: they consume a
+// reservation.
 export class AtCapacity extends Schema.TaggedError<AtCapacity>(
   "@oligarchy/shared/errors/AtCapacity",
 )(

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -156,9 +156,9 @@ export class RunFailed extends Schema.TaggedError<RunFailed>("@oligarchy/shared/
   override readonly [ErrorReporter.ignore] = true;
 }
 
-// A start or run refused because the process already runs --max-jobs jobs. 503: the server is
-// temporarily unable to take the work (RFC 9110 §15.6.4), not the caller's mistake; the caller
-// places it elsewhere or retries later.
+// A reserve, start or run refused because the process already runs --max-jobs jobs. 503: the
+// server is temporarily unable to take the work (RFC 9110 §15.6.4), not the caller's mistake;
+// the caller places it elsewhere or retries later.
 export class AtCapacity extends Schema.TaggedError<AtCapacity>(
   "@oligarchy/shared/errors/AtCapacity",
 )(

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -44,7 +44,7 @@ const qemuOk = (): Sessions.ReserveQemu => () => Effect.void;
 
 const serve = (fixed: Fixture) =>
   HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
-    Layer.provide(Sessions.Sessions.layer(fixed.maxJobs, qemuOk())),
+    Layer.provide(Sessions.Sessions.layer(fixed.maxJobs, qemuOk(), () => Effect.void)),
     Layer.provide(Layer.mergeAll(fixed.spawner.layer, fixed.log.layer, ProxyConfigLive)),
     Layer.provide(Layer.succeed(Log.ProcessAttribution)(Log.AutomationClientProcessAttribution)),
     Layer.provideMerge(NodeHttpServer.layerTest),

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -53,6 +53,16 @@ const headers = { authorization: `Bearer ${TOKEN}`, "content-type": "application
 
 const decodeErrorBody = Schema.decodeUnknownSync(Schema.Struct({ error: Schema.String }));
 
+const reserve = (
+  http: HttpClient.HttpClient,
+  ticket = TICKET,
+  extraHeaders: Record<string, string> = headers,
+) =>
+  http.post("/reserve", {
+    headers: extraHeaders,
+    body: HttpBody.text(JSON.stringify({ ticket }), "application/json"),
+  });
+
 const run = (
   http: HttpClient.HttpClient,
   prompt = "do the work",
@@ -73,6 +83,22 @@ const abort = (
     headers: extraHeaders,
     body: HttpBody.text(JSON.stringify({ ticket }), "application/json"),
   });
+
+describe("POST /reserve happy path", () => {
+  it.effect("answers ok and does not spawn opencode", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({ exitCode: 0 }));
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* reserve(http);
+        expect(response.status).toBe(200);
+        expect(yield* response.json).toEqual({ ok: "true" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.spawner.spawned).toEqual([]);
+      expect(fixed.log.lines).toEqual([]);
+    }),
+  );
+});
 
 describe("POST /run happy path", () => {
   it.effect("answers ok after opencode exits 0 and ignores its printout", () =>
@@ -212,6 +238,31 @@ describe("POST /run unhappy path", () => {
         expect(response.status).toBe(500);
         expect(yield* response.json).toEqual({ error: "out of token credits" });
       }).pipe(Effect.provide(serve(fixed)));
+    }),
+  );
+
+  it.effect("a reserve past --max-jobs is 503 at capacity and spawns nothing", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({}), 1);
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        expect((yield* reserve(http)).status).toBe(200);
+        const refused = yield* reserve(http, "OLI-99");
+        expect(refused.status).toBe(503);
+        expect(yield* refused.json).toEqual({ error: "at capacity: max-jobs is 1" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.spawner.spawned).toEqual([]);
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /reserve failed: at capacity: max-jobs is 1",
+          location: "automation-client",
+          agentId: "OLI-99",
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
     }),
   );
 

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -40,9 +40,11 @@ const fixture = (
   maxJobs,
 });
 
+const qemuOk = (): Sessions.ReserveQemu => () => Effect.void;
+
 const serve = (fixed: Fixture) =>
   HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
-    Layer.provide(Sessions.Sessions.layer(fixed.maxJobs)),
+    Layer.provide(Sessions.Sessions.layer(fixed.maxJobs, qemuOk())),
     Layer.provide(Layer.mergeAll(fixed.spawner.layer, fixed.log.layer, ProxyConfigLive)),
     Layer.provide(Layer.succeed(Log.ProcessAttribution)(Log.AutomationClientProcessAttribution)),
     Layer.provideMerge(NodeHttpServer.layerTest),
@@ -84,6 +86,18 @@ const abort = (
     body: HttpBody.text(JSON.stringify({ ticket }), "application/json"),
   });
 
+const reservedRun = (
+  http: HttpClient.HttpClient,
+  prompt = "do the work",
+  extraHeaders: Record<string, string> = headers,
+  ticket = TICKET,
+) =>
+  Effect.gen(function* () {
+    const reserved = yield* reserve(http, ticket, extraHeaders);
+    expect(reserved.status).toBe(200);
+    return yield* run(http, prompt, extraHeaders, ticket);
+  });
+
 describe("POST /reserve happy path", () => {
   it.effect("answers ok and does not spawn opencode", () =>
     Effect.gen(function* () {
@@ -106,7 +120,7 @@ describe("POST /run happy path", () => {
       const fixed = fixture(() => ({ exitCode: 0, stdout: "the written result" }));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
-        const response = yield* run(http, "fix the bug");
+        const response = yield* reservedRun(http, "fix the bug");
         expect(response.status).toBe(200);
         expect(yield* response.json).toEqual({ ok: "true" });
       }).pipe(Effect.provide(serve(fixed)));
@@ -122,6 +136,7 @@ describe("POST /run happy path", () => {
       const fixed = fixture(() => ({}));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
+        expect((yield* reserve(http)).status).toBe(200);
         const pending = yield* Effect.forkChild(run(http));
         for (let i = 0; i < 100 && fixed.spawner.spawned[0] === undefined; i++) {
           yield* Effect.yieldNow;
@@ -219,7 +234,7 @@ describe("POST /run unhappy path", () => {
       const fixed = fixture(() => ({ spawnError: "spawn opencode ENOENT" }));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
-        const response = yield* run(http);
+        const response = yield* reservedRun(http);
         expect(response.status).toBe(500);
         expect(yield* response.json).toEqual({ error: "spawn opencode ENOENT" });
       }).pipe(Effect.provide(serve(fixed)));
@@ -234,7 +249,7 @@ describe("POST /run unhappy path", () => {
       const fixed = fixture(() => ({ exitCode: 1, stderr: "out of token credits\n" }));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
-        const response = yield* run(http);
+        const response = yield* reservedRun(http);
         expect(response.status).toBe(500);
         expect(yield* response.json).toEqual({ error: "out of token credits" });
       }).pipe(Effect.provide(serve(fixed)));
@@ -266,23 +281,49 @@ describe("POST /run unhappy path", () => {
     }),
   );
 
+  it.effect("a run without a reservation is 400 no reservation and spawns nothing", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({}), 1);
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const refused = yield* run(http, "first");
+        expect(refused.status).toBe(400);
+        expect(yield* refused.json).toEqual({ error: "no reservation" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.spawner.spawned).toEqual([]);
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /run failed: no reservation",
+          location: "automation-client",
+          agentId: TICKET,
+          skipSentry: true,
+          cause: undefined,
+        },
+      ]);
+    }),
+  );
+
   it.effect(
-    "a run past --max-jobs is 503 at capacity, spawns nothing, and is taken once a run ends",
+    "a reserve past --max-jobs is 503 at capacity while a reserved run is in flight, and is taken once it ends",
     () =>
       Effect.gen(function* () {
         const fixed = fixture(() => ({}), 1);
         yield* Effect.gen(function* () {
           const http = yield* HttpClient.HttpClient;
+          expect((yield* reserve(http)).status).toBe(200);
           const pending = yield* Effect.forkChild(run(http, "first"));
           for (let i = 0; i < 100 && fixed.spawner.spawned[0] === undefined; i++) {
             yield* Effect.yieldNow;
           }
-          const refused = yield* run(http, "second", headers, "OLI-99");
+          const refused = yield* reserve(http, "OLI-99");
           expect(refused.status).toBe(503);
           expect(yield* refused.json).toEqual({ error: "at capacity: max-jobs is 1" });
+          expect((yield* run(http, "second", headers, "OLI-99")).status).toBe(400);
           expect(fixed.spawner.spawned).toHaveLength(1);
           yield* fixed.spawner.spawned[0]?.exit(0) ?? Effect.void;
           expect((yield* Fiber.join(pending)).status).toBe(200);
+          expect((yield* reserve(http, "OLI-99")).status).toBe(200);
           const accepted = yield* Effect.forkChild(run(http, "second", headers, "OLI-99"));
           for (let i = 0; i < 100 && fixed.spawner.spawned.length < 2; i++) {
             yield* Effect.yieldNow;
@@ -299,10 +340,18 @@ describe("POST /run unhappy path", () => {
         expect(fixed.log.lines).toEqual([
           {
             level: "error",
-            text: "POST /run failed: at capacity: max-jobs is 1",
+            text: "POST /reserve failed: at capacity: max-jobs is 1",
             location: "automation-client",
             agentId: "OLI-99",
             skipSentry: false,
+            cause: undefined,
+          },
+          {
+            level: "error",
+            text: "POST /run failed: no reservation",
+            location: "automation-client",
+            agentId: "OLI-99",
+            skipSentry: true,
             cause: undefined,
           },
         ]);
@@ -317,6 +366,7 @@ describe("interruption", () => {
       const fixed = fixture(() => ({}));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
+        expect((yield* reserve(http)).status).toBe(200);
         const pending = yield* Effect.forkChild(run(http));
         for (let i = 0; i < 100 && fixed.spawner.spawned[0] === undefined; i++) {
           yield* Effect.yieldNow;
@@ -344,6 +394,7 @@ describe("POST /abort happy path", () => {
       const fixed = fixture(() => ({}));
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
+        expect((yield* reserve(http)).status).toBe(200);
         const pending = yield* Effect.forkChild(run(http));
         for (let i = 0; i < 100 && fixed.spawner.spawned[0] === undefined; i++) {
           yield* Effect.yieldNow;
@@ -425,6 +476,7 @@ describe("POST /abort unhappy path", () => {
         const fixed = fixture(() => ({ killError: "Failed to kill child process" }));
         yield* Effect.gen(function* () {
           const http = yield* HttpClient.HttpClient;
+          expect((yield* reserve(http)).status).toBe(200);
           const pending = yield* Effect.forkChild(run(http));
           for (let i = 0; i < 100 && fixed.spawner.spawned[0] === undefined; i++) {
             yield* Effect.yieldNow;

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -256,6 +256,30 @@ describe("POST /run unhappy path", () => {
     }),
   );
 
+  it.effect("a second reserve for the same ticket is 400 already reserved and reaches Sentry", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        expect((yield* reserve(http)).status).toBe(200);
+        const refused = yield* reserve(http);
+        expect(refused.status).toBe(400);
+        expect(yield* refused.json).toEqual({ error: "already reserved" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.spawner.spawned).toEqual([]);
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /reserve failed: already reserved",
+          location: "automation-client",
+          agentId: TICKET,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+    }),
+  );
+
   it.effect("a reserve past --max-jobs is 503 at capacity and spawns nothing", () =>
     Effect.gen(function* () {
       const fixed = fixture(() => ({}), 1);

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -21,8 +21,9 @@ const layer = (
   reserveQemu: Sessions.ReserveQemu = qemuOk(),
 ) => Sessions.Sessions.layer(maxJobs, reserveQemu).pipe(Layer.provide(spawner.layer));
 
-const reservedRun = (sessions: Sessions.Sessions, ticket: string, prompt: string) =>
+const reservedRun = (ticket: string, prompt: string) =>
   Effect.gen(function* () {
+    const sessions = yield* Sessions.Sessions;
     yield* sessions.reserve(ticket);
     return yield* sessions.run(ticket, prompt);
   });
@@ -34,8 +35,7 @@ describe("Sessions.run happy path", () => {
       stdout: "the written result",
     }));
     return Effect.gen(function* () {
-      const sessions = yield* Sessions.Sessions;
-      yield* reservedRun(sessions, TICKET, "do the work");
+      yield* reservedRun(TICKET, "do the work");
       expect(spawner.spawned).toMatchObject([
         { command: OpenCode.BIN, args: ["run", "--", "do the work"] },
       ]);
@@ -176,7 +176,7 @@ describe("Sessions.abort unhappy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* reservedRun(sessions, TICKET, "do the work");
+      yield* reservedRun(TICKET, "do the work");
       const error = yield* Effect.flip(sessions.abort(TICKET));
       expect(error).toMatchObject({
         _tag: "UnknownSession",
@@ -294,10 +294,9 @@ describe("capacity", () => {
     const exits = [0, 1];
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: exits.shift() ?? 0 }));
     return Effect.gen(function* () {
-      const sessions = yield* Sessions.Sessions;
-      yield* reservedRun(sessions, TICKET, "first");
-      expect((yield* Effect.flip(reservedRun(sessions, OTHER, "second")))._tag).toBe("RunFailed");
-      yield* reservedRun(sessions, "OLI-7", "third");
+      yield* reservedRun(TICKET, "first");
+      expect((yield* Effect.flip(reservedRun(OTHER, "second")))._tag).toBe("RunFailed");
+      yield* reservedRun("OLI-7", "third");
       expect(spawner.spawned.map((spawned) => spawned.args[2])).toEqual([
         "first",
         "second",
@@ -347,7 +346,7 @@ describe("capacity", () => {
       // Leaving the scope killed the child before the slot came back.
       expect(spawner.spawned[0]?.kills).toEqual(["SIGTERM"]);
       expect(yield* spawner.spawned[0]?.isRunning ?? Effect.succeed(true)).toBe(false);
-      yield* reservedRun(sessions, OTHER, "second");
+      yield* reservedRun(OTHER, "second");
       expect(spawner.spawned.map((spawned) => spawned.args[2])).toEqual(["first", "second"]);
     }).pipe(Effect.provide(layer(spawner, 1)));
   });
@@ -358,10 +357,9 @@ describe("capacity", () => {
       ++spawns === 1 ? { spawnError: "spawn opencode ENOENT" } : { exitCode: 0 },
     );
     return Effect.gen(function* () {
-      const sessions = yield* Sessions.Sessions;
-      const error = yield* Effect.flip(reservedRun(sessions, TICKET, "first"));
+      const error = yield* Effect.flip(reservedRun(TICKET, "first"));
       expect(error).toMatchObject({ _tag: "RunFailed", message: "spawn opencode ENOENT" });
-      yield* reservedRun(sessions, OTHER, "second");
+      yield* reservedRun(OTHER, "second");
       // A spawn that failed is no process; only the second run's is recorded.
       expect(spawner.spawned.map((spawned) => spawned.args[2])).toEqual(["second"]);
     }).pipe(Effect.provide(layer(spawner, 1)));

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -419,6 +419,31 @@ describe("QEMU-first reserve", () => {
     }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
   });
 
+  it.effect("a QEMU failure that is not 503 takes no local slot and is Internal", () => {
+    const qemu: Array<string> = [];
+    const reserveQemu: Sessions.ReserveQemu = (agent) =>
+      Effect.gen(function* () {
+        qemu.push(agent);
+        return yield* Errors.Internal.make({
+          cause: new Error("qemu unreachable"),
+          agentId: agent,
+        });
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      const error = yield* Effect.flip(sessions.reserve(TICKET));
+      expect(error).toMatchObject({
+        _tag: "Internal",
+        message: "internal error",
+        agentId: TICKET,
+      });
+      expect(qemu).toEqual([TICKET]);
+      expect((yield* Effect.flip(sessions.run(TICKET, "first")))._tag).toBe("BadRequest");
+      expect(spawner.spawned).toHaveLength(0);
+    }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
+  });
+
   it.effect("a second reserve for the same ticket does not ask QEMU again", () => {
     let qemu = 0;
     const reserveQemu: Sessions.ReserveQemu = () =>

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -15,11 +15,15 @@ const MAX_JOBS = 2;
 
 const qemuOk = (): Sessions.ReserveQemu => () => Effect.void;
 
+const qemuRelinquishOk = (): Sessions.RelinquishQemu => () => Effect.void;
+
 const layer = (
   spawner: FakeSpawner.FakeSpawner,
   maxJobs = MAX_JOBS,
   reserveQemu: Sessions.ReserveQemu = qemuOk(),
-) => Sessions.Sessions.layer(maxJobs, reserveQemu).pipe(Layer.provide(spawner.layer));
+  relinquishQemu: Sessions.RelinquishQemu = qemuRelinquishOk(),
+) =>
+  Sessions.Sessions.layer(maxJobs, reserveQemu, relinquishQemu).pipe(Layer.provide(spawner.layer));
 
 const reservedRun = (ticket: string, prompt: string) =>
   Effect.gen(function* () {
@@ -404,19 +408,75 @@ describe("QEMU-first reserve", () => {
     }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
   });
 
-  it.effect("a full client does not ask QEMU", () => {
-    let qemu = 0;
-    const reserveQemu: Sessions.ReserveQemu = () =>
+  it.effect("a QEMU reservation the client cannot take is relinquished and is AtCapacity", () => {
+    const qemu: Array<string> = [];
+    const givenBack: Array<string> = [];
+    const reserveQemu: Sessions.ReserveQemu = (agent) =>
       Effect.sync(() => {
-        qemu += 1;
+        qemu.push(`reserve ${agent}`);
+      });
+    const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
+      Effect.sync(() => {
+        givenBack.push(agent);
       });
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
       yield* sessions.reserve(TICKET);
-      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
-      expect(qemu).toBe(1);
-    }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
+      const error = yield* Effect.flip(sessions.reserve(OTHER));
+      expect(error).toMatchObject({
+        _tag: "AtCapacity",
+        message: "at capacity: max-jobs is 1",
+        agentId: OTHER,
+      });
+      expect(qemu).toEqual([`reserve ${TICKET}`, `reserve ${OTHER}`]);
+      expect(givenBack).toEqual([OTHER]);
+      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("BadRequest");
+      expect(spawner.spawned).toHaveLength(0);
+      // The first ticket still holds the only slot.
+      expect((yield* Effect.flip(sessions.reserve("OLI-7")))._tag).toBe("AtCapacity");
+      expect(givenBack).toEqual([OTHER, "OLI-7"]);
+    }).pipe(Effect.provide(layer(spawner, 1, reserveQemu, relinquishQemu)));
+  });
+
+  it.effect("a successful reserve does not relinquish", () => {
+    let givenBack = 0;
+    const relinquishQemu: Sessions.RelinquishQemu = () =>
+      Effect.sync(() => {
+        givenBack += 1;
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
+      expect(givenBack).toBe(0);
+    }).pipe(Effect.provide(layer(spawner, 1, qemuOk(), relinquishQemu)));
+  });
+
+  it.effect("a relinquish that fails after a full local reserve is Internal", () => {
+    const givenBack: Array<string> = [];
+    const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
+      Effect.gen(function* () {
+        givenBack.push(agent);
+        return yield* Errors.Internal.make({
+          cause: new Error("qemu unreachable"),
+          agentId: agent,
+        });
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
+      const error = yield* Effect.flip(sessions.reserve(OTHER));
+      expect(error).toMatchObject({
+        _tag: "Internal",
+        message: "internal error",
+        agentId: OTHER,
+      });
+      expect(givenBack).toEqual([OTHER]);
+      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("BadRequest");
+      expect(spawner.spawned).toHaveLength(0);
+    }).pipe(Effect.provide(layer(spawner, 1, qemuOk(), relinquishQemu)));
   });
 
   it.effect("a QEMU failure that is not 503 takes no local slot and is Internal", () => {

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -252,12 +252,17 @@ describe("capacity", () => {
     }).pipe(Effect.provide(layer(spawner, 1)));
   });
 
-  it.effect("a second reserve for the same ticket is the same slot", () => {
+  it.effect("a second reserve for the same ticket is already reserved", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
       yield* sessions.reserve(TICKET);
-      yield* sessions.reserve(TICKET);
+      const error = yield* Effect.flip(sessions.reserve(TICKET));
+      expect(error).toMatchObject({
+        _tag: "BadRequest",
+        message: "already reserved",
+        agentId: TICKET,
+      });
       expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
     }).pipe(Effect.provide(layer(spawner, 1)));
   });
@@ -514,7 +519,7 @@ describe("QEMU-first reserve", () => {
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
       yield* sessions.reserve(TICKET);
-      yield* sessions.reserve(TICKET);
+      expect((yield* Effect.flip(sessions.reserve(TICKET)))._tag).toBe("BadRequest");
       expect(qemu).toBe(1);
     }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
   });

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -211,6 +211,47 @@ describe("Sessions.abort unhappy path", () => {
 });
 
 describe("capacity", () => {
+  it.effect("a reserve past --max-jobs is AtCapacity and spawns nothing", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
+      const error = yield* Effect.flip(sessions.reserve(OTHER));
+      expect(error).toMatchObject({
+        _tag: "AtCapacity",
+        message: "at capacity: max-jobs is 1",
+        agentId: OTHER,
+      });
+      expect(spawner.spawned).toHaveLength(0);
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
+
+  it.effect("a second reserve for the same ticket is the same slot", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET);
+      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
+
+  it.effect("run after reserve does not take a second slot", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
+      const running = yield* Effect.forkChild(sessions.run(TICKET, "first"));
+      for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
+        yield* Effect.yieldNow;
+      }
+      expect(spawner.spawned).toHaveLength(1);
+      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("AtCapacity");
+      yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
+      yield* Fiber.join(running);
+    }).pipe(Effect.provide(layer(spawner, 1)));
+  });
+
   it.effect("a run past --max-jobs is AtCapacity and spawns nothing", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -5,6 +5,7 @@ import { TestClock } from "effect/testing";
 import * as OpenCode from "../../src/automation-client/opencode.ts";
 import * as Sessions from "../../src/automation-client/sessions.ts";
 import * as Cli from "../../src/cli.ts";
+import * as Errors from "../../src/shared/errors.ts";
 import * as FakeSpawner from "../support/fake-spawner.ts";
 
 const TICKET = "OLI-42";
@@ -12,8 +13,19 @@ const OTHER = "OLI-99";
 // Room for the two runs the tests above capacity start at once; the capacity tests pass 1.
 const MAX_JOBS = 2;
 
-const layer = (spawner: FakeSpawner.FakeSpawner, maxJobs = MAX_JOBS) =>
-  Sessions.Sessions.layer(maxJobs).pipe(Layer.provide(spawner.layer));
+const qemuOk = (): Sessions.ReserveQemu => () => Effect.void;
+
+const layer = (
+  spawner: FakeSpawner.FakeSpawner,
+  maxJobs = MAX_JOBS,
+  reserveQemu: Sessions.ReserveQemu = qemuOk(),
+) => Sessions.Sessions.layer(maxJobs, reserveQemu).pipe(Layer.provide(spawner.layer));
+
+const reservedRun = (sessions: Sessions.Sessions, ticket: string, prompt: string) =>
+  Effect.gen(function* () {
+    yield* sessions.reserve(ticket);
+    return yield* sessions.run(ticket, prompt);
+  });
 
 describe("Sessions.run happy path", () => {
   it.effect("launches opencode with the prompt and succeeds when it exits 0", () => {
@@ -23,7 +35,7 @@ describe("Sessions.run happy path", () => {
     }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.run(TICKET, "do the work");
+      yield* reservedRun(sessions, TICKET, "do the work");
       expect(spawner.spawned).toMatchObject([
         { command: OpenCode.BIN, args: ["run", "--", "do the work"] },
       ]);
@@ -38,6 +50,7 @@ describe("Sessions.run unhappy path", () => {
     }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
       const error = yield* Effect.flip(sessions.run(TICKET, "do the work"));
       expect(error._tag).toBe("RunFailed");
       expect(error.message).toBe("spawn opencode ENOENT");
@@ -51,6 +64,7 @@ describe("Sessions.run unhappy path", () => {
     }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
       const error = yield* Effect.flip(sessions.run(TICKET, "do the work"));
       expect(error._tag).toBe("RunFailed");
       expect(error.message).toBe("out of token credits");
@@ -63,6 +77,7 @@ describe("Sessions.abort happy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
       const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work"));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
@@ -83,6 +98,8 @@ describe("Sessions.abort happy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(OTHER);
       const first = yield* Effect.forkChild(sessions.run(TICKET, "first"));
       const second = yield* Effect.forkChild(sessions.run(OTHER, "second"));
       for (let i = 0; i < 100 && spawner.spawned.length < 2; i++) {
@@ -103,6 +120,7 @@ describe("Sessions.abort happy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ ignoreTerm: true }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
       const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work"));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
@@ -128,6 +146,7 @@ describe("Sessions.abort happy path", () => {
     }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
       const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work"));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
@@ -157,7 +176,7 @@ describe("Sessions.abort unhappy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.run(TICKET, "do the work");
+      yield* reservedRun(sessions, TICKET, "do the work");
       const error = yield* Effect.flip(sessions.abort(TICKET));
       expect(error).toMatchObject({
         _tag: "UnknownSession",
@@ -172,6 +191,7 @@ describe("Sessions.abort unhappy path", () => {
     }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
       const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work"));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
@@ -193,10 +213,12 @@ describe("Sessions.abort unhappy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
       const first = yield* Effect.forkChild(sessions.run(TICKET, "first"));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
       }
+      yield* sessions.reserve(TICKET);
       const second = yield* Effect.forkChild(sessions.run(TICKET, "second"));
       for (let i = 0; i < 100 && spawner.spawned.length < 2; i++) {
         yield* Effect.yieldNow;
@@ -246,32 +268,25 @@ describe("capacity", () => {
         yield* Effect.yieldNow;
       }
       expect(spawner.spawned).toHaveLength(1);
-      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("BadRequest");
       yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
       yield* Fiber.join(running);
     }).pipe(Effect.provide(layer(spawner, 1)));
   });
 
-  it.effect("a run past --max-jobs is AtCapacity and spawns nothing", () => {
-    const spawner = FakeSpawner.fakeSpawner(() => ({}));
+  it.effect("a run without a reservation is BadRequest and spawns nothing", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      const running = yield* Effect.forkChild(sessions.run(TICKET, "first"));
-      for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
-        yield* Effect.yieldNow;
-      }
-      expect(spawner.spawned).toHaveLength(1);
-      const error = yield* Effect.flip(sessions.run(OTHER, "second"));
+      const error = yield* Effect.flip(sessions.run(TICKET, "first"));
       expect(error).toMatchObject({
-        _tag: "AtCapacity",
-        message: "at capacity: max-jobs is 1",
-        agentId: OTHER,
+        _tag: "BadRequest",
+        message: "no reservation",
+        agentId: TICKET,
       });
-      expect(spawner.spawned).toHaveLength(1);
-      // The refused ticket was never registered: nothing to abort.
-      expect((yield* Effect.flip(sessions.abort(OTHER)))._tag).toBe("UnknownSession");
-      yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
-      yield* Fiber.join(running);
+      expect(spawner.spawned).toHaveLength(0);
+      expect((yield* Effect.flip(sessions.abort(TICKET)))._tag).toBe("UnknownSession");
     }).pipe(Effect.provide(layer(spawner, 1)));
   });
 
@@ -280,9 +295,9 @@ describe("capacity", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: exits.shift() ?? 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.run(TICKET, "first");
-      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("RunFailed");
-      yield* sessions.run("OLI-7", "third");
+      yield* reservedRun(sessions, TICKET, "first");
+      expect((yield* Effect.flip(reservedRun(sessions, OTHER, "second")))._tag).toBe("RunFailed");
+      yield* reservedRun(sessions, "OLI-7", "third");
       expect(spawner.spawned.map((spawned) => spawned.args[2])).toEqual([
         "first",
         "second",
@@ -295,13 +310,15 @@ describe("capacity", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
       const running = yield* Effect.forkChild(sessions.run(TICKET, "first"));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
       }
-      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
       yield* sessions.abort(TICKET);
       expect((yield* Effect.flip(Fiber.join(running)))._tag).toBe("RunFailed");
+      yield* sessions.reserve(OTHER);
       const next = yield* Effect.forkChild(sessions.run(OTHER, "second"));
       for (let i = 0; i < 100 && spawner.spawned.length < 2; i++) {
         yield* Effect.yieldNow;
@@ -318,18 +335,19 @@ describe("capacity", () => {
     const spawner = FakeSpawner.fakeSpawner(() => (++spawns === 1 ? {} : { exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
       const running = yield* Effect.forkChild(sessions.run(TICKET, "first"));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
       }
-      expect((yield* Effect.flip(sessions.run(OTHER, "second")))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
       yield* Fiber.interrupt(running);
       const exit = yield* Fiber.await(running);
       expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
       // Leaving the scope killed the child before the slot came back.
       expect(spawner.spawned[0]?.kills).toEqual(["SIGTERM"]);
       expect(yield* spawner.spawned[0]?.isRunning ?? Effect.succeed(true)).toBe(false);
-      yield* sessions.run(OTHER, "second");
+      yield* reservedRun(sessions, OTHER, "second");
       expect(spawner.spawned.map((spawned) => spawned.args[2])).toEqual(["first", "second"]);
     }).pipe(Effect.provide(layer(spawner, 1)));
   });
@@ -341,11 +359,80 @@ describe("capacity", () => {
     );
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      const error = yield* Effect.flip(sessions.run(TICKET, "first"));
+      const error = yield* Effect.flip(reservedRun(sessions, TICKET, "first"));
       expect(error).toMatchObject({ _tag: "RunFailed", message: "spawn opencode ENOENT" });
-      yield* sessions.run(OTHER, "second");
+      yield* reservedRun(sessions, OTHER, "second");
       // A spawn that failed is no process; only the second run's is recorded.
       expect(spawner.spawned.map((spawned) => spawned.args[2])).toEqual(["second"]);
     }).pipe(Effect.provide(layer(spawner, 1)));
+  });
+});
+
+describe("QEMU-first reserve", () => {
+  it.effect("asks QEMU before taking a local slot", () => {
+    const order: Array<string> = [];
+    const reserveQemu: Sessions.ReserveQemu = (agent) =>
+      Effect.sync(() => {
+        order.push(`qemu ${agent}`);
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
+      order.push("returned");
+      expect(order).toEqual([`qemu ${TICKET}`, "returned"]);
+    }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
+  });
+
+  it.effect("a QEMU 503 takes no local slot and is AtCapacity", () => {
+    const qemu: Array<string> = [];
+    const reserveQemu: Sessions.ReserveQemu = (agent) =>
+      Effect.gen(function* () {
+        qemu.push(agent);
+        return yield* Errors.AtCapacity.make({ message: "qemu full", agentId: agent });
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      const error = yield* Effect.flip(sessions.reserve(TICKET));
+      expect(error).toMatchObject({
+        _tag: "AtCapacity",
+        message: "qemu full",
+        agentId: TICKET,
+      });
+      expect(qemu).toEqual([TICKET]);
+      expect((yield* Effect.flip(sessions.run(TICKET, "first")))._tag).toBe("BadRequest");
+      expect(spawner.spawned).toHaveLength(0);
+    }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
+  });
+
+  it.effect("a full client does not ask QEMU", () => {
+    let qemu = 0;
+    const reserveQemu: Sessions.ReserveQemu = () =>
+      Effect.sync(() => {
+        qemu += 1;
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
+      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
+      expect(qemu).toBe(1);
+    }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
+  });
+
+  it.effect("a second reserve for the same ticket does not ask QEMU again", () => {
+    let qemu = 0;
+    const reserveQemu: Sessions.ReserveQemu = () =>
+      Effect.sync(() => {
+        qemu += 1;
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET);
+      expect(qemu).toBe(1);
+    }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
   });
 });

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -237,7 +237,7 @@ describe("capacity", () => {
   });
 
   it.effect("run after reserve does not take a second slot", () => {
-    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
       yield* sessions.reserve(TICKET);

--- a/test/automation-server/client.unit.test.ts
+++ b/test/automation-server/client.unit.test.ts
@@ -15,11 +15,44 @@ const token = Layer.succeed(AutomationClient.OligarchyToken)(
   AutomationClient.OligarchyToken.of(Redacted.make(TOKEN)),
 );
 
+const reserve = (http: Layer.Layer<HttpClient.HttpClient>) =>
+  AutomationClient.reserve(URL, TICKET).pipe(Effect.provide(Layer.mergeAll(token, http)));
+
 const run = (http: Layer.Layer<HttpClient.HttpClient>) =>
   AutomationClient.run(URL, PROMPT, TICKET).pipe(Effect.provide(Layer.mergeAll(token, http)));
 
 const abort = (http: Layer.Layer<HttpClient.HttpClient>) =>
   AutomationClient.abort(URL, TICKET).pipe(Effect.provide(Layer.mergeAll(token, http)));
+
+describe("automation client POST /reserve happy path", () => {
+  it.effect("posts the ticket with the bearer token and succeeds on 200", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      yield* reserve(recorder.layer);
+      expect(recorder.requests).toHaveLength(1);
+      expect(recorder.requests[0]?.method).toBe("POST");
+      expect(recorder.requests[0]?.url).toBe(`${URL}/reserve`);
+      expect(recorder.requests[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
+      expect(JSON.parse(recorder.requests[0]?.body ?? "")).toEqual({ ticket: TICKET });
+    }),
+  );
+});
+
+describe("automation client POST /reserve unhappy path", () => {
+  it.effect("a 503 is AutomationClientError with the body's error and status 503", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(() =>
+        FakeHttp.json({ error: "at capacity: max-jobs is 1" }, 503),
+      );
+      const error = yield* Effect.flip(reserve(recorder.layer));
+      expect(error).toMatchObject({
+        _tag: "AutomationClientError",
+        status: 503,
+        message: `automation client: POST ${URL}/reserve failed: at capacity: max-jobs is 1`,
+      });
+    }),
+  );
+});
 
 describe("automation client POST /run happy path", () => {
   it.effect("posts the prompt with the bearer token and succeeds on 200", () =>

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -156,10 +156,7 @@ describe("dispatch happy path", () => {
       yield* Deferred.await(started);
       expect(fixed.automation.jobs[0]?.status).toBe("running");
       expect(fixed.automation.jobs[0]?.serverId).toBe(clientId);
-      expect(http.requests.map((request) => new URL(request.url).pathname)).toEqual([
-        "/reserve",
-        "/run",
-      ]);
+      expect(http.requests.map((request) => request.url)).toEqual([`${URL}/reserve`, `${URL}/run`]);
       yield* Deferred.succeed(release, undefined);
       yield* settle(fixed.automation.jobs, "succeeded");
       expect(fixed.automation.jobs[0]?.status).toBe("succeeded");
@@ -486,9 +483,9 @@ describe("dispatch unhappy path", () => {
       });
       expect(fixed.automation.jobs[0]?.createdAt).toBe(queued[0]?.createdAt);
       expect(fixed.automation.jobs[1]?.createdAt).toBe(queued[1]?.createdAt);
-      expect(http.requests.map((request) => new URL(request.url).pathname)).toEqual([
-        "/reserve",
-        "/reserve",
+      expect(http.requests.map((request) => request.url)).toEqual([
+        `${URL}/reserve`,
+        `${OTHER_URL}/reserve`,
       ]);
       expect(FakeLog.texts(fixed.log)).toEqual(["deferred; at capacity"]);
       expect(fixed.log.lines[0]?.agentId).toBe(TICKET);
@@ -505,7 +502,7 @@ describe("dispatch unhappy path", () => {
       const first = seedLiveClient(fixed.servers);
       const second = seedLiveClient(fixed.servers, OTHER_URL);
       const http = FakeHttp.recordRequests((request, url) => {
-        if (url.pathname === "/reserve" && url.origin === new URL(URL).origin) {
+        if (url.pathname === "/reserve" && url.href.startsWith(URL)) {
           return FakeHttp.json({ error: "at capacity: max-jobs is 1" }, 503);
         }
         return FakeHttp.json({ ok: "true" });
@@ -517,10 +514,11 @@ describe("dispatch unhappy path", () => {
         serverId: second,
       });
       expect(fixed.automation.jobs[0]?.serverId).not.toBe(first);
-      expect(
-        http.requests.map((request) => `${request.method} ${new URL(request.url).pathname}`),
-      ).toEqual(["POST /reserve", "POST /reserve", "POST /run"]);
-      expect(http.requests[2]?.url).toBe(`${OTHER_URL}/run`);
+      expect(http.requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+        `POST ${URL}/reserve`,
+        `POST ${OTHER_URL}/reserve`,
+        `POST ${OTHER_URL}/run`,
+      ]);
     }),
   );
 });

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -494,41 +494,6 @@ describe("dispatch unhappy path", () => {
     }),
   );
 
-  it.effect("a 503 from /run after reserve leaves the job pending", () =>
-    Effect.gen(function* () {
-      const fixed = harness();
-      seedResult(fixed.tests);
-      seedJob(fixed.automation);
-      seedLiveClient(fixed.servers);
-      const createdAt = fixed.automation.jobs[0]?.createdAt;
-      const http = FakeHttp.recordRequests((_request, url) =>
-        url.pathname === "/reserve"
-          ? FakeHttp.json({ ok: "true" })
-          : FakeHttp.json({ error: "at capacity: max-jobs is 1" }, 503),
-      );
-      yield* start(fixed, http.layer);
-      for (let i = 0; i < 200; i++) {
-        if (FakeLog.texts(fixed.log).includes("deferred; at capacity")) {
-          break;
-        }
-        yield* Effect.yieldNow;
-      }
-      expect(fixed.automation.jobs[0]).toMatchObject({
-        status: "pending",
-        serverId: null,
-        startedAt: null,
-        finishedAt: null,
-        reason: null,
-      });
-      expect(fixed.automation.jobs[0]?.createdAt).toBe(createdAt);
-      expect(http.requests.map((request) => request.url)).toEqual([`${URL}/reserve`, `${URL}/run`]);
-      expect(FakeLog.texts(fixed.log)).toEqual([
-        `dispatching drive; ${URL}`,
-        "deferred; at capacity",
-      ]);
-    }),
-  );
-
   it.effect("a 503 from the first client places the job on the next", () =>
     Effect.gen(function* () {
       const fixed = harness();

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -494,6 +494,41 @@ describe("dispatch unhappy path", () => {
     }),
   );
 
+  it.effect("a 503 from /run after reserve leaves the job pending", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      seedLiveClient(fixed.servers);
+      const createdAt = fixed.automation.jobs[0]?.createdAt;
+      const http = FakeHttp.recordRequests((_request, url) =>
+        url.pathname === "/reserve"
+          ? FakeHttp.json({ ok: "true" })
+          : FakeHttp.json({ error: "at capacity: max-jobs is 1" }, 503),
+      );
+      yield* start(fixed, http.layer);
+      for (let i = 0; i < 200; i++) {
+        if (FakeLog.texts(fixed.log).includes("deferred; at capacity")) {
+          break;
+        }
+        yield* Effect.yieldNow;
+      }
+      expect(fixed.automation.jobs[0]).toMatchObject({
+        status: "pending",
+        serverId: null,
+        startedAt: null,
+        finishedAt: null,
+        reason: null,
+      });
+      expect(fixed.automation.jobs[0]?.createdAt).toBe(createdAt);
+      expect(http.requests.map((request) => request.url)).toEqual([`${URL}/reserve`, `${URL}/run`]);
+      expect(FakeLog.texts(fixed.log)).toEqual([
+        `dispatching drive; ${URL}`,
+        "deferred; at capacity",
+      ]);
+    }),
+  );
+
   it.effect("a 503 from the first client places the job on the next", () =>
     Effect.gen(function* () {
       const fixed = harness();

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -41,6 +41,7 @@ const scriptsFs = FileSystem.layerNoop({
 
 const DRIVE_PROMPT = `drive ${TICKET} as ${Prompts.MODEL}`;
 const DIAGNOSE_PROMPT = `diagnose ${TICKET} ${RESULT_ID} ${Prompts.MODEL}\n# Control`;
+const OTHER_URL = "http://127.0.0.1:55334";
 
 const seedResult = (tests: Stores.FakeTestStore, linearId: string | null = TICKET) => {
   tests.results.push({
@@ -141,18 +142,24 @@ describe("dispatch happy path", () => {
       const clientId = seedLiveClient(fixed.servers);
       const started = yield* Deferred.make<void>();
       const release = yield* Deferred.make<void>();
-      const http = FakeHttp.recordRequests(() =>
-        Effect.gen(function* () {
+      const http = FakeHttp.recordRequests((request, url) => {
+        if (url.pathname === "/reserve") {
+          return FakeHttp.json({ ok: "true" });
+        }
+        return Effect.gen(function* () {
           yield* Deferred.succeed(started, undefined);
           yield* Deferred.await(release);
           return FakeHttp.json({ ok: "true" });
-        }),
-      );
+        });
+      });
       yield* start(fixed, http.layer);
       yield* Deferred.await(started);
       expect(fixed.automation.jobs[0]?.status).toBe("running");
       expect(fixed.automation.jobs[0]?.serverId).toBe(clientId);
-      expect(http.requests).toHaveLength(1);
+      expect(http.requests.map((request) => new URL(request.url).pathname)).toEqual([
+        "/reserve",
+        "/run",
+      ]);
       yield* Deferred.succeed(release, undefined);
       yield* settle(fixed.automation.jobs, "succeeded");
       expect(fixed.automation.jobs[0]?.status).toBe("succeeded");
@@ -173,7 +180,8 @@ describe("dispatch happy path", () => {
         reason: null,
         finishedAt: expect.any(Date),
       });
-      expect(JSON.parse(http.requests[0]?.body ?? "")).toEqual({
+      expect(JSON.parse(http.requests[0]?.body ?? "")).toEqual({ ticket: TICKET });
+      expect(JSON.parse(http.requests[1]?.body ?? "")).toEqual({
         prompt: DRIVE_PROMPT,
         ticket: TICKET,
       });
@@ -192,7 +200,7 @@ describe("dispatch happy path", () => {
       yield* start(fixed, http.layer);
       yield* settle(fixed.automation.jobs, "succeeded");
       expect(fixed.automation.jobs[0]?.status).toBe("succeeded");
-      expect(JSON.parse(http.requests[0]?.body ?? "")).toEqual({
+      expect(JSON.parse(http.requests[1]?.body ?? "")).toEqual({
         prompt: DIAGNOSE_PROMPT,
         ticket: TICKET,
       });
@@ -217,7 +225,7 @@ describe("dispatch happy path", () => {
       yield* TestClock.adjust("5 seconds");
       yield* settle(fixed.automation.jobs, "succeeded");
       expect(fixed.automation.jobs.every((job) => job.status === "succeeded")).toBe(true);
-      expect(http.requests).toHaveLength(2);
+      expect(http.requests.filter((request) => request.url.endsWith("/run"))).toHaveLength(2);
     }),
   );
 
@@ -229,13 +237,16 @@ describe("dispatch happy path", () => {
       seedLiveClient(fixed.servers);
       const started = yield* Deferred.make<void>();
       const release = yield* Deferred.make<void>();
-      const http = FakeHttp.recordRequests(() =>
-        Effect.gen(function* () {
+      const http = FakeHttp.recordRequests((request, url) => {
+        if (url.pathname === "/reserve") {
+          return FakeHttp.json({ ok: "true" });
+        }
+        return Effect.gen(function* () {
           yield* Deferred.succeed(started, undefined);
           yield* Deferred.await(release);
           return FakeHttp.json({ ok: "true" });
-        }),
-      );
+        });
+      });
       yield* start(fixed, http.layer);
       yield* Deferred.await(started);
       yield* TestClock.adjust("2 hours");
@@ -254,8 +265,10 @@ describe("dispatch unhappy path", () => {
       seedResult(fixed.tests);
       seedJob(fixed.automation);
       seedLiveClient(fixed.servers);
-      const http = FakeHttp.recordRequests(() =>
-        FakeHttp.json({ error: "opencode exited 1" }, 500),
+      const http = FakeHttp.recordRequests((request, url) =>
+        url.pathname === "/reserve"
+          ? FakeHttp.json({ ok: "true" })
+          : FakeHttp.json({ error: "opencode exited 1" }, 500),
       );
       yield* start(fixed, http.layer);
       yield* settle(fixed.automation.jobs, "failed");
@@ -277,12 +290,15 @@ describe("dispatch unhappy path", () => {
       seedJob(fixed.automation);
       seedLiveClient(fixed.servers);
       const started = yield* Deferred.make<void>();
-      const http = FakeHttp.recordRequests(() =>
-        Effect.gen(function* () {
+      const http = FakeHttp.recordRequests((request, url) => {
+        if (url.pathname === "/reserve") {
+          return FakeHttp.json({ ok: "true" });
+        }
+        return Effect.gen(function* () {
           yield* Deferred.succeed(started, undefined);
           return yield* Effect.never;
-        }),
-      );
+        });
+      });
       const scope = yield* start(fixed, http.layer);
       yield* Deferred.await(started);
       expect(fixed.automation.jobs[0]?.status).toBe("running");
@@ -352,7 +368,7 @@ describe("dispatch unhappy path", () => {
       yield* settle(fixed.automation.jobs, "failed");
       expect(fixed.automation.jobs[0]).toMatchObject({
         status: "failed",
-        reason: `automation client: POST ${URL}/run failed`,
+        reason: `automation client: POST ${URL}/reserve failed`,
       });
     }),
   );
@@ -397,13 +413,16 @@ describe("dispatch unhappy path", () => {
       seedLiveClient(fixed.servers);
       const started = yield* Deferred.make<void>();
       const release = yield* Deferred.make<void>();
-      const http = FakeHttp.recordRequests(() =>
-        Effect.gen(function* () {
+      const http = FakeHttp.recordRequests((request, url) => {
+        if (url.pathname === "/reserve") {
+          return FakeHttp.json({ ok: "true" });
+        }
+        return Effect.gen(function* () {
           yield* Deferred.succeed(started, undefined);
           yield* Deferred.await(release);
           return FakeHttp.json({ ok: "true" });
-        }),
-      );
+        });
+      });
       yield* start(fixed, http.layer);
       yield* Deferred.await(started);
       const job = fixed.automation.jobs[0];
@@ -423,6 +442,85 @@ describe("dispatch unhappy path", () => {
       expect(FakeLog.texts(fixed.log).some((text) => text.includes("dispatch tick failed"))).toBe(
         false,
       );
+    }),
+  );
+
+  it.effect("a 503 from every client leaves the job pending and does not POST /run", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      seedJob(fixed.automation, "diagnose");
+      const first = seedLiveClient(fixed.servers);
+      const second = seedLiveClient(fixed.servers, OTHER_URL);
+      const queued = fixed.automation.jobs.map((job) => ({
+        id: job.id,
+        createdAt: job.createdAt,
+      }));
+      const http = FakeHttp.recordRequests(() =>
+        FakeHttp.json({ error: "at capacity: max-jobs is 1" }, 503),
+      );
+      yield* start(fixed, http.layer);
+      for (let i = 0; i < 200; i++) {
+        if (FakeLog.texts(fixed.log).includes("deferred; at capacity")) {
+          break;
+        }
+        yield* Effect.yieldNow;
+      }
+      expect(fixed.automation.jobs).toHaveLength(2);
+      expect(fixed.automation.jobs.map((job) => job.id)).toEqual(queued.map((job) => job.id));
+      expect(fixed.automation.jobs.every((job) => job.status === "pending")).toBe(true);
+      expect(fixed.automation.jobs[0]).toMatchObject({
+        status: "pending",
+        serverId: null,
+        startedAt: null,
+        finishedAt: null,
+        reason: null,
+      });
+      expect(fixed.automation.jobs[1]).toMatchObject({
+        status: "pending",
+        serverId: null,
+        startedAt: null,
+        finishedAt: null,
+        reason: null,
+      });
+      expect(fixed.automation.jobs[0]?.createdAt).toBe(queued[0]?.createdAt);
+      expect(fixed.automation.jobs[1]?.createdAt).toBe(queued[1]?.createdAt);
+      expect(http.requests.map((request) => new URL(request.url).pathname)).toEqual([
+        "/reserve",
+        "/reserve",
+      ]);
+      expect(FakeLog.texts(fixed.log)).toEqual(["deferred; at capacity"]);
+      expect(fixed.log.lines[0]?.agentId).toBe(TICKET);
+      expect(first).toBeDefined();
+      expect(second).toBeDefined();
+    }),
+  );
+
+  it.effect("a 503 from the first client places the job on the next", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation);
+      const first = seedLiveClient(fixed.servers);
+      const second = seedLiveClient(fixed.servers, OTHER_URL);
+      const http = FakeHttp.recordRequests((request, url) => {
+        if (url.pathname === "/reserve" && url.origin === new URL(URL).origin) {
+          return FakeHttp.json({ error: "at capacity: max-jobs is 1" }, 503);
+        }
+        return FakeHttp.json({ ok: "true" });
+      });
+      yield* start(fixed, http.layer);
+      yield* settle(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs[0]).toMatchObject({
+        status: "succeeded",
+        serverId: second,
+      });
+      expect(fixed.automation.jobs[0]?.serverId).not.toBe(first);
+      expect(
+        http.requests.map((request) => `${request.method} ${new URL(request.url).pathname}`),
+      ).toEqual(["POST /reserve", "POST /reserve", "POST /run"]);
+      expect(http.requests[2]?.url).toBe(`${OTHER_URL}/run`);
     }),
   );
 });

--- a/test/client/command.unit.test.ts
+++ b/test/client/command.unit.test.ts
@@ -59,6 +59,9 @@ const run = (args: ReadonlyArray<string>, options: Options = {}) =>
 
 const ok = () => FakeHttp.json({ ok: "true" });
 
+const startRespond: FakeHttp.Respond = (_request, url) =>
+  url.pathname === "/reserve" ? FakeHttp.json({ ok: "true" }) : FakeHttp.json({ id: ID });
+
 const parsed = (body: string): unknown => JSON.parse(body);
 
 const showHelp = (error: unknown): CliError.ShowHelp => {
@@ -114,13 +117,16 @@ describe("client requests", () => {
 
   it.effect("start posts a url iso and the agent, omits the disk, and prints only the id", () =>
     Effect.gen(function* () {
-      const recorder = FakeHttp.recordRequests(() => FakeHttp.json({ id: ID }));
+      const recorder = FakeHttp.recordRequests(startRespond);
       yield* run(["start", ...shared, "--iso", "https://example.com/omarchy.iso"], {
         http: recorder.layer,
       });
-      expect(recorder.requests[0]?.method).toBe("POST");
-      expect(recorder.requests[0]?.url).toBe(`${SERVER}/start`);
-      expect(parsed(recorder.requests[0]?.body ?? "")).toEqual({
+      expect(recorder.requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+        `POST ${SERVER}/reserve`,
+        `POST ${SERVER}/start`,
+      ]);
+      expect(parsed(recorder.requests[0]?.body ?? "")).toEqual({ agent: AGENT });
+      expect(parsed(recorder.requests[1]?.body ?? "")).toEqual({
         iso: "https://example.com/omarchy.iso",
         agent: AGENT,
       });
@@ -135,11 +141,12 @@ describe("client requests", () => {
       const dir = yield* fs.makeTempDirectoryScoped();
       const iso = path.join(dir, "omarchy.iso");
       yield* fs.writeFileString(iso, "iso");
-      const recorder = FakeHttp.recordRequests(() => FakeHttp.json({ id: ID }));
+      const recorder = FakeHttp.recordRequests(startRespond);
       yield* run(["start", ...shared, "--iso", iso, "--disk", "relative/disk.qcow2"], {
         http: recorder.layer,
       });
-      expect(parsed(recorder.requests[0]?.body ?? "")).toEqual({
+      expect(parsed(recorder.requests[0]?.body ?? "")).toEqual({ agent: AGENT });
+      expect(parsed(recorder.requests[1]?.body ?? "")).toEqual({
         iso,
         disk: path.resolve("relative/disk.qcow2"),
         agent: AGENT,

--- a/test/client/proxy-client.unit.test.ts
+++ b/test/client/proxy-client.unit.test.ts
@@ -68,6 +68,16 @@ describe("ProxyClient requests", () => {
     }),
   );
 
+  it.effect("relinquish posts the agent", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(ok);
+      const proxy = yield* connect.pipe(Effect.provide(recorder.layer));
+      yield* proxy.relinquish(Contract.ReserveAgentBody.make({ agent: AGENT }));
+      expectJsonPost(recorder.requests[0], "/relinquish", { agent: AGENT });
+      expect(recorder.requests).toHaveLength(1);
+    }),
+  );
+
   it.effect("start posts iso and agent and leaves an absent disk out of the body", () =>
     Effect.gen(function* () {
       const recorder = FakeHttp.recordRequests(() =>

--- a/test/client/proxy-client.unit.test.ts
+++ b/test/client/proxy-client.unit.test.ts
@@ -58,6 +58,16 @@ describe("ProxyClient requests", () => {
     }),
   );
 
+  it.effect("reserve posts the agent", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(ok);
+      const proxy = yield* connect.pipe(Effect.provide(recorder.layer));
+      yield* proxy.reserve(Contract.ReserveAgentBody.make({ agent: AGENT }));
+      expectJsonPost(recorder.requests[0], "/reserve", { agent: AGENT });
+      expect(recorder.requests).toHaveLength(1);
+    }),
+  );
+
   it.effect("start posts iso and agent and leaves an absent disk out of the body", () =>
     Effect.gen(function* () {
       const recorder = FakeHttp.recordRequests(() =>

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { createServer as createHttpServer } from "node:http";
 import { env as processEnv } from "node:process";
 import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
@@ -154,6 +155,32 @@ const lines = (output: string): ReadonlyArray<string> =>
 const request = (port: number, path: string, headers: Record<string, string>, body: string) =>
   fetch(`http://127.0.0.1:${String(port)}${path}`, { method: "POST", headers, body });
 
+const AUTH_JSON = { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" };
+
+// The client reserves QEMU first; these process tests stub that host so /reserve can succeed.
+const stubQemuReserve = async (): Promise<{
+  readonly url: string;
+  readonly close: () => Promise<void>;
+}> => {
+  const server = createHttpServer((req, res) => {
+    if (req.method === "POST" && req.url === "/reserve") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: "true" }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  return {
+    url: `http://127.0.0.1:${String(portOf(server.address()))}`,
+    close: () => new Promise((done) => server.close(() => done())),
+  };
+};
+
 const logsForClient = async () => {
   const client = new Client({ connectionString: Postgres.getDbUrl() });
   await client.connect();
@@ -287,21 +314,32 @@ describeWithDatabase("automation client startup refusals with a database", () =>
 describeWithDatabase("automation client POST /run", () => {
   it.live("answers 200 when opencode exits 0", () =>
     Effect.promise(async () => {
+      const qemu = await stubQemuReserve();
       const bin = installOpencode("exit 0");
       const port = await freePort();
       const process = spawnAutomationClient(
         [...MAX_JOBS, "--port", String(port)],
-        {},
+        { SERVER_URL: qemu.url },
         `${bin}:${processEnv.PATH ?? ""}`,
       );
       try {
         await process.waitFor(
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
         );
+        expect(
+          (
+            await request(
+              port,
+              "/reserve",
+              AUTH_JSON,
+              JSON.stringify({ ticket: "OLI-42" }),
+            )
+          ).status,
+        ).toBe(200);
         const response = await request(
           port,
           "/run",
-          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          AUTH_JSON,
           JSON.stringify({ prompt: "do the work", ticket: "OLI-42" }),
         );
         expect(response.status).toBe(200);
@@ -310,27 +348,39 @@ describeWithDatabase("automation client POST /run", () => {
         process.child.kill("SIGTERM");
         await process.exited;
         rmSync(bin, { recursive: true, force: true });
+        await qemu.close();
       }
     }),
   );
 
   it.live("answers 500 with opencode's error when it exits non-zero", () =>
     Effect.promise(async () => {
+      const qemu = await stubQemuReserve();
       const bin = installOpencode("echo out of token credits >&2; exit 1");
       const port = await freePort();
       const process = spawnAutomationClient(
         [...MAX_JOBS, "--port", String(port)],
-        {},
+        { SERVER_URL: qemu.url },
         `${bin}:${processEnv.PATH ?? ""}`,
       );
       try {
         await process.waitFor(
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
         );
+        expect(
+          (
+            await request(
+              port,
+              "/reserve",
+              AUTH_JSON,
+              JSON.stringify({ ticket: "OLI-42" }),
+            )
+          ).status,
+        ).toBe(200);
         const response = await request(
           port,
           "/run",
-          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          AUTH_JSON,
           JSON.stringify({ prompt: "do the work", ticket: "OLI-42" }),
         );
         expect(response.status).toBe(500);
@@ -339,6 +389,7 @@ describeWithDatabase("automation client POST /run", () => {
         process.child.kill("SIGTERM");
         await process.exited;
         rmSync(bin, { recursive: true, force: true });
+        await qemu.close();
       }
     }),
   );
@@ -374,25 +425,29 @@ describeWithDatabase("automation client POST /run", () => {
     }),
   );
 
-  it.live("answers 503 at capacity while --max-jobs runs are in flight", () =>
+  it.live("answers 503 at capacity on a second reserve while --max-jobs runs are in flight", () =>
     Effect.promise(async () => {
+      const qemu = await stubQemuReserve();
       const startedDir = mkdtempSync(join(tmpdir(), "oligarchy-opencode-started-"));
       const started = join(startedDir, "ready");
       const bin = installOpencode(`touch "${started}"; sleep 60`);
       const port = await freePort();
       const process = spawnAutomationClient(
         [...MAX_JOBS, "--port", String(port)],
-        {},
+        { SERVER_URL: qemu.url },
         `${bin}:${processEnv.PATH ?? ""}`,
       );
       try {
         await process.waitFor(
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}; max jobs 1`),
         );
+        expect(
+          (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" }))).status,
+        ).toBe(200);
         const running = request(
           port,
           "/run",
-          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          AUTH_JSON,
           JSON.stringify({ prompt: "do the work", ticket: "OLI-42" }),
         );
         const began = Date.now();
@@ -404,23 +459,23 @@ describeWithDatabase("automation client POST /run", () => {
         }
         const refused = await request(
           port,
-          "/run",
-          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
-          JSON.stringify({ prompt: "more work", ticket: "OLI-99" }),
+          "/reserve",
+          AUTH_JSON,
+          JSON.stringify({ ticket: "OLI-99" }),
         );
         expect(refused.status).toBe(503);
         expect(await refused.json()).toEqual({ error: "at capacity: max-jobs is 1" });
         const aborted = await request(
           port,
           "/abort",
-          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          AUTH_JSON,
           JSON.stringify({ ticket: "OLI-42" }),
         );
         expect(aborted.status).toBe(200);
         expect((await running).status).toBe(500);
         expect(
           lines(process.stdout()).some((line) =>
-            line.includes("POST /run failed: at capacity: max-jobs is 1"),
+            line.includes("POST /reserve failed: at capacity: max-jobs is 1"),
           ),
         ).toBe(true);
       } finally {
@@ -428,6 +483,7 @@ describeWithDatabase("automation client POST /run", () => {
         await process.exited;
         rmSync(bin, { recursive: true, force: true });
         rmSync(startedDir, { recursive: true, force: true });
+        await qemu.close();
       }
     }),
   );
@@ -436,23 +492,27 @@ describeWithDatabase("automation client POST /run", () => {
 describeWithDatabase("automation client POST /abort", () => {
   it.live("kills a running opencode and answers 200", () =>
     Effect.promise(async () => {
+      const qemu = await stubQemuReserve();
       const startedDir = mkdtempSync(join(tmpdir(), "oligarchy-opencode-started-"));
       const started = join(startedDir, "ready");
       const bin = installOpencode(`touch "${started}"; sleep 60`);
       const port = await freePort();
       const process = spawnAutomationClient(
         [...MAX_JOBS, "--port", String(port)],
-        {},
+        { SERVER_URL: qemu.url },
         `${bin}:${processEnv.PATH ?? ""}`,
       );
       try {
         await process.waitFor(
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
         );
+        expect(
+          (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" }))).status,
+        ).toBe(200);
         const running = request(
           port,
           "/run",
-          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          AUTH_JSON,
           JSON.stringify({ prompt: "do the work", ticket: "OLI-42" }),
         );
         const began = Date.now();
@@ -477,29 +537,34 @@ describeWithDatabase("automation client POST /abort", () => {
         await process.exited;
         rmSync(bin, { recursive: true, force: true });
         rmSync(startedDir, { recursive: true, force: true });
+        await qemu.close();
       }
     }),
   );
 
   it.live("kills a SIGTERM-resistant opencode after the force-kill deadline", () =>
     Effect.promise(async () => {
+      const qemu = await stubQemuReserve();
       const startedDir = mkdtempSync(join(tmpdir(), "oligarchy-opencode-started-"));
       const started = join(startedDir, "ready");
       const bin = installOpencode(`trap "" TERM; touch "${started}"; sleep 60`);
       const port = await freePort();
       const process = spawnAutomationClient(
         [...MAX_JOBS, "--port", String(port)],
-        {},
+        { SERVER_URL: qemu.url },
         `${bin}:${processEnv.PATH ?? ""}`,
       );
       try {
         await process.waitFor(
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
         );
+        expect(
+          (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" }))).status,
+        ).toBe(200);
         const running = request(
           port,
           "/run",
-          { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+          AUTH_JSON,
           JSON.stringify({ prompt: "do the work", ticket: "OLI-42" }),
         );
         const began = Date.now();
@@ -524,6 +589,7 @@ describeWithDatabase("automation client POST /abort", () => {
         await process.exited;
         rmSync(bin, { recursive: true, force: true });
         rmSync(startedDir, { recursive: true, force: true });
+        await qemu.close();
       }
     }),
   );

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -327,14 +327,7 @@ describeWithDatabase("automation client POST /run", () => {
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
         );
         expect(
-          (
-            await request(
-              port,
-              "/reserve",
-              AUTH_JSON,
-              JSON.stringify({ ticket: "OLI-42" }),
-            )
-          ).status,
+          (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" }))).status,
         ).toBe(200);
         const response = await request(
           port,
@@ -368,14 +361,7 @@ describeWithDatabase("automation client POST /run", () => {
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
         );
         expect(
-          (
-            await request(
-              port,
-              "/reserve",
-              AUTH_JSON,
-              JSON.stringify({ ticket: "OLI-42" }),
-            )
-          ).status,
+          (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" }))).status,
         ).toBe(200);
         const response = await request(
           port,

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -163,7 +163,7 @@ const stubQemuReserve = async (): Promise<{
   readonly close: () => Promise<void>;
 }> => {
   const server = createHttpServer((req, res) => {
-    if (req.method === "POST" && req.url === "/reserve") {
+    if (req.method === "POST" && (req.url === "/reserve" || req.url === "/relinquish")) {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: "true" }));
       return;

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -1550,6 +1550,8 @@ Postgres.describeWithDatabase("database", () => {
         expect(yield* store.serverForAgent("OLI-61")).toEqual(Option.some("http://10.0.0.5:42069"));
         yield* store.routeAgent("OLI-61", "http://10.0.0.6:42069");
         expect(yield* store.serverForAgent("OLI-61")).toEqual(Option.some("http://10.0.0.5:42069"));
+        yield* store.clearAgent("OLI-61");
+        expect(yield* store.serverForAgent("OLI-61")).toEqual(Option.none());
       }),
     );
 

--- a/test/integration/db.integration.test.ts
+++ b/test/integration/db.integration.test.ts
@@ -1146,6 +1146,43 @@ Postgres.describeWithDatabase("database", () => {
       }),
     );
 
+    scoped.effect("AutomationStore unclaim returns a running job to pending as it was", () =>
+      Effect.gen(function* () {
+        const tests = yield* Tests.TestStore;
+        const automation = yield* Automation.AutomationStore;
+        const database = yield* Client.Database;
+        const definition = Option.getOrThrow(yield* tests.findTestDefinition("lock-screen"));
+        const created = yield* tests.createRun({
+          iso: "https://example.com/omarchy.iso",
+          serverUrl: "http://127.0.0.1:42069",
+          definitions: [{ id: definition.id }],
+        });
+        const enqueued = yield* automation.enqueue({
+          resultId: created.results[0].id,
+          action: "drive",
+        });
+        const createdAt = enqueued.createdAt;
+        const serverId = crypto.randomUUID();
+        yield* automation.claim(serverId);
+        expect(yield* automation.unclaim(enqueued.id)).toBe(true);
+        const [row] = yield* database.run("select", (db) =>
+          db
+            .select()
+            .from(DbSchema.automationJobs)
+            .where(eq(DbSchema.automationJobs.id, enqueued.id)),
+        );
+        expect(row).toMatchObject({
+          status: "pending",
+          serverId: null,
+          startedAt: null,
+          finishedAt: null,
+          reason: null,
+        });
+        expect(row?.createdAt).toEqual(createdAt);
+        expect(yield* automation.unclaim(enqueued.id)).toBe(false);
+      }),
+    );
+
     scoped.effect("AutomationStore finish closes a running job and refuses a second close", () =>
       Effect.gen(function* () {
         const tests = yield* Tests.TestStore;
@@ -1502,6 +1539,17 @@ Postgres.describeWithDatabase("database", () => {
         expect(twice).toMatchObject({ _tag: "DatabaseError", operation: "routeSession" });
         expect(String(twice.cause)).toContain("duplicate key");
         expect(yield* store.serverForSession(id)).toEqual(Option.some("http://10.0.0.5:42069"));
+      }),
+    );
+
+    scoped.effect("ServerStore routes an agent once and answers where it went", () =>
+      Effect.gen(function* () {
+        const store = yield* Servers.ServerStore;
+        expect(yield* store.serverForAgent("OLI-61")).toEqual(Option.none());
+        yield* store.routeAgent("OLI-61", "http://10.0.0.5:42069");
+        expect(yield* store.serverForAgent("OLI-61")).toEqual(Option.some("http://10.0.0.5:42069"));
+        yield* store.routeAgent("OLI-61", "http://10.0.0.6:42069");
+        expect(yield* store.serverForAgent("OLI-61")).toEqual(Option.some("http://10.0.0.5:42069"));
       }),
     );
 

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -722,6 +722,59 @@ describe("placement", () => {
     }),
   );
 
+  it.effect("POST /relinquish after reserve forwards to the reserved server and forgets the agent", () =>
+    Effect.gen(function* () {
+      const fixed = fixture((request, url) =>
+        url.pathname === "/relinquish" || url.pathname === "/reserve"
+          ? FakeHttp.json({ ok: "true" })
+          : fleet(request, url),
+      );
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+      yield* Effect.gen(function* () {
+        const api = yield* qemuServerClient;
+        yield* api.Sessions.reserve({ payload: reserveBody });
+        const ok = yield* api.Sessions.relinquish({ payload: reserveBody });
+        expect(ok).toEqual(Contract.Ok.make({}));
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.store.agents.has(AGENT_ID)).toBe(false);
+      expect(
+        fixed.upstream.requests
+          .filter((request) => request.url.endsWith("/relinquish"))
+          .map((request) => request.url),
+      ).toEqual([`${SERVER_B}/relinquish`]);
+      expect(fixed.log.lines.filter((line) => line.text.startsWith("relinquished"))).toEqual([
+        {
+          level: "info",
+          text: `relinquished; ${SERVER_B}`,
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+    }),
+  );
+
+  it.effect("POST /relinquish without a reservation is 400 no reservation", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      fixed.store.servers.push(qemu(SERVER_A));
+      yield* Effect.gen(function* () {
+        const api = yield* qemuServerClient;
+        const error = yield* Effect.flip(api.Sessions.relinquish({ payload: reserveBody }));
+        expect(error).toMatchObject({ _tag: "BadRequest", message: "no reservation" });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/relinquish", {
+          headers: { authorization: AUTHORIZATION },
+          body: HttpBody.jsonUnsafe(reserveBody),
+        });
+        expect(raw.status).toBe(400);
+        expect(yield* raw.json).toEqual({ error: "no reservation" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.upstream.requests).toEqual([]);
+    }),
+  );
+
   it.effect("POST /start after reserve forwards to the reserved server", () =>
     Effect.gen(function* () {
       const fixed = fixture((request, url) =>
@@ -1399,6 +1452,7 @@ describe("forwarding refusals", () => {
 
   const everyRoute: ReadonlyArray<readonly [string, string, boolean]> = [
     ["POST", "/reserve", true],
+    ["POST", "/relinquish", true],
     ["POST", "/start", true],
     ["GET", `/image?id=${SESSION_ID}&agent=${AGENT_ID}`, false],
     ["GET", `/serial?id=${SESSION_ID}&agent=${AGENT_ID}`, false],

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -676,6 +676,50 @@ describe("placement", () => {
       }),
   );
 
+  it.effect("a second reserve for the same agent is 400 already reserved and reaches Sentry", () =>
+    Effect.gen(function* () {
+      const fixed = fixture((request, url) =>
+        url.pathname === "/reserve" ? FakeHttp.json({ ok: "true" }) : fleet(request, url),
+      );
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+      yield* Effect.gen(function* () {
+        const api = yield* qemuServerClient;
+        yield* api.Sessions.reserve({ payload: reserveBody });
+        const error = yield* Effect.flip(api.Sessions.reserve({ payload: reserveBody }));
+        expect(error).toMatchObject({ _tag: "BadRequest", message: "already reserved" });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/reserve", {
+          headers: { authorization: AUTHORIZATION },
+          body: HttpBody.jsonUnsafe(reserveBody),
+        });
+        expect(raw.status).toBe(400);
+        expect(yield* raw.json).toEqual({ error: "already reserved" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_B);
+      expect(
+        fixed.upstream.requests.filter((request) => request.url.endsWith("/reserve")),
+      ).toHaveLength(1);
+      expect(fixed.log.lines.filter((line) => line.text.includes("already reserved"))).toEqual([
+        {
+          level: "error",
+          text: "POST /reserve failed: already reserved",
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: false,
+          cause: undefined,
+        },
+        {
+          level: "error",
+          text: "POST /reserve failed: already reserved",
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+    }),
+  );
+
   it.effect("a reserve the first server refuses with 503 is placed on the next", () =>
     Effect.gen(function* () {
       const fixed = fixture((request, url) => {

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -488,6 +488,7 @@ describe("registration refusals", () => {
 
 describe("placement", () => {
   const startBody = Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID });
+  const reserveBody = Contract.ReserveAgentBody.make({ agent: AGENT_ID });
 
   // Servers answer a start with the id they minted; `null` scripts one that answers without it.
   const placing =
@@ -497,76 +498,38 @@ describe("placement", () => {
         ? FakeHttp.json(started === null ? { ok: "true" } : { id: started })
         : fleet(request, url);
 
-  it.effect(
-    "POST /start probes every qemu server, picks the fewest qemus, forwards the body with the bearer, records the route and logs it",
-    () =>
-      Effect.gen(function* () {
-        const fixed = fixture(placing());
-        fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
-        yield* Effect.gen(function* () {
-          const api = yield* qemuServerClient;
-          const [started, response] = yield* api.Sessions.start({
-            payload: startBody,
-            responseMode: "decoded-and-response",
-          });
-          expect(started.id).toBe(STARTED_ID);
-          expect(response.headers["content-type"]).toContain("application/json");
-          expect(yield* response.text).toBe(`{"id":"${STARTED_ID}"}`);
-        }).pipe(Effect.provide(serve(fixed)));
-        expect(upstreamCalls(fixed).slice(0, 2).sort()).toEqual([
-          `GET ${SERVER_A}/stats`,
-          `GET ${SERVER_B}/stats`,
-        ]);
-        expect(fixed.upstream.requests[2]).toEqual({
-          method: "POST",
-          url: `${SERVER_B}/start`,
-          headers: expect.objectContaining({
-            authorization: AUTHORIZATION,
-            "content-type": "application/json",
-          }),
-          body: '{"iso":"omarchy.iso","agent":"OLI-61"}',
-        });
-        expect(fixed.store.routes.get(STARTED_ID)).toBe(SERVER_B);
-        expect(fixed.log.lines).toEqual([
-          {
-            level: "info",
-            text: `routed; ${SERVER_B}`,
-            location: STARTED_ID,
-            agentId: AGENT_ID,
-            skipSentry: false,
-            cause: undefined,
-          },
-        ]);
-      }),
-  );
-
   it.effect("ties go to the first registered server", () =>
     Effect.gen(function* () {
       const fixed = fixture((request, url) =>
-        url.pathname === "/stats" ? FakeHttp.json(stats(1)) : placing()(request, url),
+        url.pathname === "/stats"
+          ? FakeHttp.json(stats(1))
+          : url.pathname === "/reserve"
+            ? FakeHttp.json({ ok: "true" })
+            : placing()(request, url),
       );
       fixed.store.servers.push(qemu(SERVER_B), qemu(SERVER_A));
       yield* Effect.gen(function* () {
         const api = yield* qemuServerClient;
-        yield* api.Sessions.start({ payload: startBody });
+        yield* api.Sessions.reserve({ payload: reserveBody });
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.store.routes.get(STARTED_ID)).toBe(SERVER_B);
+      expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_B);
     }),
   );
 
   it.effect("a server whose probe fails is skipped with a warning and the rest are placed on", () =>
     Effect.gen(function* () {
-      const fixed = fixture((request, url) =>
-        url.origin === SERVER_A && url.pathname === "/stats"
-          ? refused(request, url)
-          : placing()(request, url),
-      );
+      const fixed = fixture((request, url) => {
+        if (url.origin === SERVER_A && url.pathname === "/stats") {
+          return refused(request, url);
+        }
+        return url.pathname === "/reserve" ? FakeHttp.json({ ok: "true" }) : placing()(request, url);
+      });
       fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
       yield* Effect.gen(function* () {
         const api = yield* qemuServerClient;
-        yield* api.Sessions.start({ payload: startBody });
+        yield* api.Sessions.reserve({ payload: reserveBody });
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.store.routes.get(STARTED_ID)).toBe(SERVER_B);
+      expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_B);
       expect(fixed.log.lines).toEqual([
         {
           level: "warning",
@@ -578,8 +541,8 @@ describe("placement", () => {
         },
         {
           level: "info",
-          text: `routed; ${SERVER_B}`,
-          location: STARTED_ID,
+          text: `reserved; ${SERVER_B}`,
+          location: "server",
           agentId: AGENT_ID,
           skipSentry: false,
           cause: undefined,
@@ -592,17 +555,17 @@ describe("placement", () => {
     Effect.gen(function* () {
       const fixed = fixture();
       yield* Effect.gen(function* () {
-        // /start answers 503 twice over — the reverse proxy's own NoServer and a server's
+        // /reserve answers 503 twice over — the reverse proxy's own NoServer and a server's
         // AtCapacity passed through — on one `{ error }` body, so the generated client cannot
         // tell them apart by tag; the status and the message are the contract, as ./client's
         // ProxyRefusal 503 reads them.
         const api = yield* qemuReverseProxyClient;
-        const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
+        const error = yield* Effect.flip(api.Sessions.reserve({ payload: reserveBody }));
         expect(error.message).toBe("no server registered");
         const http = yield* HttpClient.HttpClient;
-        const raw = yield* http.post("/start", {
+        const raw = yield* http.post("/reserve", {
           headers: { authorization: AUTHORIZATION },
-          body: HttpBody.jsonUnsafe(startBody),
+          body: HttpBody.jsonUnsafe(reserveBody),
         });
         expect(raw.status).toBe(503);
         expect(yield* raw.json).toEqual({ error: "no server registered" });
@@ -611,7 +574,7 @@ describe("placement", () => {
       expect(fixed.log.lines).toEqual([
         {
           level: "error",
-          text: "POST /start failed: no server registered",
+          text: "POST /reserve failed: no server registered",
           location: "server",
           agentId: AGENT_ID,
           skipSentry: false,
@@ -619,7 +582,7 @@ describe("placement", () => {
         },
         {
           level: "error",
-          text: "POST /start failed: no server registered",
+          text: "POST /reserve failed: no server registered",
           location: "server",
           agentId: AGENT_ID,
           skipSentry: false,
@@ -635,10 +598,10 @@ describe("placement", () => {
       fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
       yield* Effect.gen(function* () {
         const api = yield* qemuReverseProxyClient;
-        const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
+        const error = yield* Effect.flip(api.Sessions.reserve({ payload: reserveBody }));
         expect(error.message).toBe("no server available");
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.store.routes.size).toBe(0);
+      expect(fixed.store.agents.size).toBe(0);
       expect(fixed.log.lines.map((line) => [line.level, line.text, line.agentId])).toEqual([
         [
           "warning",
@@ -650,8 +613,28 @@ describe("placement", () => {
           `server skipped; server ${SERVER_B} unreachable: connect ECONNREFUSED 10.0.0.6:42069`,
           AGENT_ID,
         ],
-        ["error", "POST /start failed: no server available", AGENT_ID],
+        ["error", "POST /reserve failed: no server available", AGENT_ID],
       ]);
+    }),
+  );
+
+  it.effect("POST /start without a reservation is 400 no reservation", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      fixed.store.servers.push(qemu(SERVER_A));
+      yield* Effect.gen(function* () {
+        const api = yield* qemuServerClient;
+        const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
+        expect(error).toMatchObject({ _tag: "BadRequest", message: "no reservation" });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/start", {
+          headers: { authorization: AUTHORIZATION },
+          body: HttpBody.jsonUnsafe(startBody),
+        });
+        expect(raw.status).toBe(400);
+        expect(yield* raw.json).toEqual({ error: "no reservation" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.upstream.requests).toEqual([]);
     }),
   );
 
@@ -665,7 +648,7 @@ describe("placement", () => {
         fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
         yield* Effect.gen(function* () {
           const api = yield* qemuServerClient;
-          const ok = yield* api.Sessions.reserve({ payload: startBody });
+          const ok = yield* api.Sessions.reserve({ payload: reserveBody });
           expect(ok).toEqual(Contract.Ok.make({}));
         }).pipe(Effect.provide(serve(fixed)));
         expect(fixed.upstream.requests[2]).toEqual({
@@ -675,7 +658,7 @@ describe("placement", () => {
             authorization: AUTHORIZATION,
             "content-type": "application/json",
           }),
-          body: '{"iso":"omarchy.iso","agent":"OLI-61"}',
+          body: '{"agent":"OLI-61"}',
         });
         expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_B);
         expect(fixed.log.lines).toEqual([
@@ -705,7 +688,7 @@ describe("placement", () => {
       fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
       yield* Effect.gen(function* () {
         const api = yield* qemuServerClient;
-        yield* api.Sessions.reserve({ payload: startBody });
+        yield* api.Sessions.reserve({ payload: reserveBody });
       }).pipe(Effect.provide(serve(fixed)));
       expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_A);
       expect(
@@ -728,7 +711,7 @@ describe("placement", () => {
         const http = yield* HttpClient.HttpClient;
         const raw = yield* http.post("/reserve", {
           headers: { authorization: AUTHORIZATION },
-          body: HttpBody.jsonUnsafe(startBody),
+          body: HttpBody.jsonUnsafe(reserveBody),
         });
         expect(raw.status).toBe(503);
         expect(yield* raw.json).toEqual({ error: "at capacity: max-jobs is 1" });
@@ -749,7 +732,7 @@ describe("placement", () => {
       fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
       yield* Effect.gen(function* () {
         const api = yield* qemuServerClient;
-        yield* api.Sessions.reserve({ payload: startBody });
+        yield* api.Sessions.reserve({ payload: reserveBody });
         yield* api.Sessions.start({ payload: startBody });
       }).pipe(Effect.provide(serve(fixed)));
       expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_B);
@@ -770,6 +753,7 @@ describe("placement", () => {
           : fleet(request, url),
       );
       fixed.store.servers.push(qemu(SERVER_A));
+      fixed.store.agents.set(AGENT_ID, SERVER_A);
       yield* Effect.gen(function* () {
         const api = yield* qemuServerClient;
         const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
@@ -795,6 +779,7 @@ describe("placement", () => {
     Effect.gen(function* () {
       const fixed = fixture(placing(null));
       fixed.store.servers.push(qemu(SERVER_A));
+      fixed.store.agents.set(AGENT_ID, SERVER_A);
       yield* Effect.gen(function* () {
         const http = yield* HttpClient.HttpClient;
         const raw = yield* http.post("/start", {
@@ -824,6 +809,7 @@ describe("placement", () => {
         url.pathname === "/start" ? refused(request, url) : fleet(request, url),
       );
       fixed.store.servers.push(qemu(SERVER_A));
+      fixed.store.agents.set(AGENT_ID, SERVER_A);
       yield* Effect.gen(function* () {
         // ./client reads a 502 on /start as StartFailed: same status, same message, which is all
         // ./client ever shows.
@@ -858,13 +844,14 @@ describe("placement", () => {
           store: Stores.fakeServerStore({ routeSession: () => Effect.fail(failure) }),
         });
         fixed.store.servers.push(qemu(SERVER_A));
+        fixed.store.agents.set(AGENT_ID, SERVER_A);
         yield* Effect.gen(function* () {
           const api = yield* qemuServerClient;
           const error = yield* Effect.flip(api.Sessions.start({ payload: startBody }));
           expect(error).toMatchObject({ _tag: "Internal", message: "internal error" });
         }).pipe(Effect.provide(serve(fixed)));
         // No compensating stop: the machine times out on its server, as the doc says.
-        expect(upstreamCalls(fixed)).toEqual([`GET ${SERVER_A}/stats`, `POST ${SERVER_A}/start`]);
+        expect(upstreamCalls(fixed)).toEqual([`POST ${SERVER_A}/start`]);
         expect(fixed.log.lines).toEqual([
           {
             level: "error",
@@ -899,6 +886,7 @@ describe("placement", () => {
         },
       );
       fixed.store.servers.push(qemu(SERVER_A));
+      fixed.store.agents.set(AGENT_ID, SERVER_A);
       yield* Effect.gen(function* () {
         const api = yield* qemuServerClient;
         const request = yield* Effect.forkChild(api.Sessions.start({ payload: startBody }));

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -737,7 +737,7 @@ describe("placement", () => {
         yield* api.Sessions.reserve({ payload: reserveBody });
         yield* api.Sessions.start({ payload: startBody });
       }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_B);
+      expect(fixed.store.agents.has(AGENT_ID)).toBe(false);
       expect(fixed.store.routes.get(STARTED_ID)).toBe(SERVER_B);
       expect(
         fixed.upstream.requests

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -676,6 +676,35 @@ describe("placement", () => {
       }),
   );
 
+  it.effect("overlapping reserves for the same agent are one 200 and one already reserved", () =>
+    Effect.gen(function* () {
+      const fixed = fixture((request, url) =>
+        url.pathname === "/reserve" ? FakeHttp.json({ ok: "true" }) : fleet(request, url),
+      );
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+      yield* Effect.gen(function* () {
+        const api = yield* qemuServerClient;
+        const results = yield* Effect.all(
+          [
+            Effect.exit(api.Sessions.reserve({ payload: reserveBody })),
+            Effect.exit(api.Sessions.reserve({ payload: reserveBody })),
+          ],
+          { concurrency: "unbounded" },
+        );
+        expect(results.filter(Exit.isSuccess)).toHaveLength(1);
+        const failed = results.find(Exit.isFailure);
+        expect(failed !== undefined && Cause.squash(failed.cause)).toMatchObject({
+          _tag: "BadRequest",
+          message: "already reserved",
+        });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_B);
+      expect(
+        fixed.upstream.requests.filter((request) => request.url.endsWith("/reserve")),
+      ).toHaveLength(1);
+    }),
+  );
+
   it.effect("a second reserve for the same agent is 400 already reserved and reaches Sentry", () =>
     Effect.gen(function* () {
       const fixed = fixture((request, url) =>

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -655,6 +655,113 @@ describe("placement", () => {
     }),
   );
 
+  it.effect(
+    "POST /reserve probes every qemu server, tries the fewest qemus, records the agent and logs it",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture((request, url) =>
+          url.pathname === "/reserve" ? FakeHttp.json({ ok: "true" }) : fleet(request, url),
+        );
+        fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+        yield* Effect.gen(function* () {
+          const api = yield* qemuServerClient;
+          const ok = yield* api.Sessions.reserve({ payload: startBody });
+          expect(ok).toEqual(Contract.Ok.make({}));
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.upstream.requests[2]).toEqual({
+          method: "POST",
+          url: `${SERVER_B}/reserve`,
+          headers: expect.objectContaining({
+            authorization: AUTHORIZATION,
+            "content-type": "application/json",
+          }),
+          body: '{"iso":"omarchy.iso","agent":"OLI-61"}',
+        });
+        expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_B);
+        expect(fixed.log.lines).toEqual([
+          {
+            level: "info",
+            text: `reserved; ${SERVER_B}`,
+            location: "server",
+            agentId: AGENT_ID,
+            skipSentry: false,
+            cause: undefined,
+          },
+        ]);
+      }),
+  );
+
+  it.effect("a reserve the first server refuses with 503 is placed on the next", () =>
+    Effect.gen(function* () {
+      const fixed = fixture((request, url) => {
+        if (url.pathname === "/reserve") {
+          return url.origin === SERVER_B
+            ? FakeHttp.json({ error: "at capacity: max-jobs is 1" }, 503)
+            : FakeHttp.json({ ok: "true" });
+        }
+        return fleet(request, url);
+      });
+      // B has fewer qemus, so place tries B first; it is full, A takes the slot.
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+      yield* Effect.gen(function* () {
+        const api = yield* qemuServerClient;
+        yield* api.Sessions.reserve({ payload: startBody });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_A);
+      expect(
+        fixed.upstream.requests
+          .filter((request) => request.url.endsWith("/reserve"))
+          .map((request) => request.url),
+      ).toEqual([`${SERVER_B}/reserve`, `${SERVER_A}/reserve`]);
+    }),
+  );
+
+  it.effect("every server at capacity is 503 at capacity, without an agent route", () =>
+    Effect.gen(function* () {
+      const fixed = fixture((request, url) =>
+        url.pathname === "/reserve"
+          ? FakeHttp.json({ error: "at capacity: max-jobs is 1" }, 503)
+          : fleet(request, url),
+      );
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/reserve", {
+          headers: { authorization: AUTHORIZATION },
+          body: HttpBody.jsonUnsafe(startBody),
+        });
+        expect(raw.status).toBe(503);
+        expect(yield* raw.json).toEqual({ error: "at capacity: max-jobs is 1" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.store.agents.size).toBe(0);
+    }),
+  );
+
+  it.effect("POST /start after reserve forwards to the reserved server", () =>
+    Effect.gen(function* () {
+      const fixed = fixture((request, url) =>
+        url.pathname === "/start"
+          ? FakeHttp.json({ id: STARTED_ID })
+          : url.pathname === "/reserve"
+            ? FakeHttp.json({ ok: "true" })
+            : fleet(request, url),
+      );
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+      yield* Effect.gen(function* () {
+        const api = yield* qemuServerClient;
+        yield* api.Sessions.reserve({ payload: startBody });
+        yield* api.Sessions.start({ payload: startBody });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.store.agents.get(AGENT_ID)).toBe(SERVER_B);
+      expect(fixed.store.routes.get(STARTED_ID)).toBe(SERVER_B);
+      expect(
+        fixed.upstream.requests
+          .filter((request) => request.url.endsWith("/start"))
+          .map((request) => request.url),
+      ).toEqual([`${SERVER_B}/start`]);
+    }),
+  );
+
   it.effect("a start the server refuses passes through as it came, without a route or a line", () =>
     Effect.gen(function* () {
       const fixed = fixture((request, url) =>
@@ -1301,6 +1408,7 @@ describe("forwarding refusals", () => {
   );
 
   const everyRoute: ReadonlyArray<readonly [string, string, boolean]> = [
+    ["POST", "/reserve", true],
     ["POST", "/start", true],
     ["GET", `/image?id=${SESSION_ID}&agent=${AGENT_ID}`, false],
     ["GET", `/serial?id=${SESSION_ID}&agent=${AGENT_ID}`, false],

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -722,37 +722,39 @@ describe("placement", () => {
     }),
   );
 
-  it.effect("POST /relinquish after reserve forwards to the reserved server and forgets the agent", () =>
-    Effect.gen(function* () {
-      const fixed = fixture((request, url) =>
-        url.pathname === "/relinquish" || url.pathname === "/reserve"
-          ? FakeHttp.json({ ok: "true" })
-          : fleet(request, url),
-      );
-      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
-      yield* Effect.gen(function* () {
-        const api = yield* qemuServerClient;
-        yield* api.Sessions.reserve({ payload: reserveBody });
-        const ok = yield* api.Sessions.relinquish({ payload: reserveBody });
-        expect(ok).toEqual(Contract.Ok.make({}));
-      }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.store.agents.has(AGENT_ID)).toBe(false);
-      expect(
-        fixed.upstream.requests
-          .filter((request) => request.url.endsWith("/relinquish"))
-          .map((request) => request.url),
-      ).toEqual([`${SERVER_B}/relinquish`]);
-      expect(fixed.log.lines.filter((line) => line.text.startsWith("relinquished"))).toEqual([
-        {
-          level: "info",
-          text: `relinquished; ${SERVER_B}`,
-          location: "server",
-          agentId: AGENT_ID,
-          skipSentry: false,
-          cause: undefined,
-        },
-      ]);
-    }),
+  it.effect(
+    "POST /relinquish after reserve forwards to the reserved server and forgets the agent",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture((request, url) =>
+          url.pathname === "/relinquish" || url.pathname === "/reserve"
+            ? FakeHttp.json({ ok: "true" })
+            : fleet(request, url),
+        );
+        fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+        yield* Effect.gen(function* () {
+          const api = yield* qemuServerClient;
+          yield* api.Sessions.reserve({ payload: reserveBody });
+          const ok = yield* api.Sessions.relinquish({ payload: reserveBody });
+          expect(ok).toEqual(Contract.Ok.make({}));
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.store.agents.has(AGENT_ID)).toBe(false);
+        expect(
+          fixed.upstream.requests
+            .filter((request) => request.url.endsWith("/relinquish"))
+            .map((request) => request.url),
+        ).toEqual([`${SERVER_B}/relinquish`]);
+        expect(fixed.log.lines.filter((line) => line.text.startsWith("relinquished"))).toEqual([
+          {
+            level: "info",
+            text: `relinquished; ${SERVER_B}`,
+            location: "server",
+            agentId: AGENT_ID,
+            skipSentry: false,
+            cause: undefined,
+          },
+        ]);
+      }),
   );
 
   it.effect("POST /relinquish without a reservation is 400 no reservation", () =>

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -522,7 +522,9 @@ describe("placement", () => {
         if (url.origin === SERVER_A && url.pathname === "/stats") {
           return refused(request, url);
         }
-        return url.pathname === "/reserve" ? FakeHttp.json({ ok: "true" }) : placing()(request, url);
+        return url.pathname === "/reserve"
+          ? FakeHttp.json({ ok: "true" })
+          : placing()(request, url);
       });
       fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
       yield* Effect.gen(function* () {

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -757,6 +757,42 @@ describe("placement", () => {
       }),
   );
 
+  it.effect("a 200 whose body dies still forgets the agent", () =>
+    Effect.gen(function* () {
+      const encoder = new TextEncoder();
+      const fixed = fixture((request, url) => {
+        if (url.pathname === "/reserve") {
+          return FakeHttp.json({ ok: "true" });
+        }
+        if (url.pathname === "/relinquish") {
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(encoder.encode('{"ok":"true"}'));
+                controller.error(new Error("read ECONNRESET"));
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return fleet(request, url);
+      });
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+      yield* Effect.gen(function* () {
+        const api = yield* qemuServerClient;
+        yield* api.Sessions.reserve({ payload: reserveBody });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/relinquish", {
+          headers: { authorization: AUTHORIZATION },
+          body: HttpBody.jsonUnsafe(reserveBody),
+        });
+        expect(raw.status).toBe(200);
+        yield* Effect.exit(raw.text);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.store.agents.has(AGENT_ID)).toBe(false);
+    }),
+  );
+
   it.effect("POST /relinquish without a reservation is 400 no reservation", () =>
     Effect.gen(function* () {
       const fixed = fixture();

--- a/test/qemu-server/http.unit.test.ts
+++ b/test/qemu-server/http.unit.test.ts
@@ -931,55 +931,57 @@ describe("Sessions failures", () => {
     }),
   );
 
-  it.effect("a relinquish without a reservation is 400 no reservation, attributed to the agent", () =>
-    Effect.gen(function* () {
-      const fixed = fixture({
-        sessions: FakeSessions.fakeSessions({
-          relinquish: (agent) =>
-            Effect.fail(
-              Errors.BadRequest.make({
-                message: "no reservation",
-                agentId: agent,
-              }),
-            ),
-        }),
-      });
-      yield* Effect.gen(function* () {
-        const api = yield* client;
-        const error = yield* Effect.flip(
-          api.Sessions.relinquish({
-            payload: Contract.ReserveAgentBody.make({ agent: AGENT_ID }),
+  it.effect(
+    "a relinquish without a reservation is 400 no reservation, attributed to the agent",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture({
+          sessions: FakeSessions.fakeSessions({
+            relinquish: (agent) =>
+              Effect.fail(
+                Errors.BadRequest.make({
+                  message: "no reservation",
+                  agentId: agent,
+                }),
+              ),
           }),
-        );
-        expect(error).toMatchObject({ _tag: "BadRequest", message: "no reservation" });
-        const http = yield* HttpClient.HttpClient;
-        const raw = yield* http.post("/relinquish", {
-          headers: { authorization: `Bearer ${TOKEN}` },
-          body: HttpBody.jsonUnsafe({ agent: AGENT_ID }),
         });
-        expect(raw.status).toBe(400);
-        expect(yield* raw.json).toEqual({ error: "no reservation" });
-      }).pipe(Effect.provide(serve(fixed)));
-      expect(fixed.log.lines).toEqual([
-        {
-          level: "error",
-          text: "POST /relinquish failed: no reservation",
-          location: "server",
-          agentId: AGENT_ID,
-          skipSentry: true,
-          cause: undefined,
-        },
-        {
-          level: "error",
-          text: "POST /relinquish failed: no reservation",
-          location: "server",
-          agentId: AGENT_ID,
-          skipSentry: true,
-          cause: undefined,
-        },
-      ]);
-      expect(fixed.reporter.reported).toEqual([]);
-    }),
+        yield* Effect.gen(function* () {
+          const api = yield* client;
+          const error = yield* Effect.flip(
+            api.Sessions.relinquish({
+              payload: Contract.ReserveAgentBody.make({ agent: AGENT_ID }),
+            }),
+          );
+          expect(error).toMatchObject({ _tag: "BadRequest", message: "no reservation" });
+          const http = yield* HttpClient.HttpClient;
+          const raw = yield* http.post("/relinquish", {
+            headers: { authorization: `Bearer ${TOKEN}` },
+            body: HttpBody.jsonUnsafe({ agent: AGENT_ID }),
+          });
+          expect(raw.status).toBe(400);
+          expect(yield* raw.json).toEqual({ error: "no reservation" });
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.log.lines).toEqual([
+          {
+            level: "error",
+            text: "POST /relinquish failed: no reservation",
+            location: "server",
+            agentId: AGENT_ID,
+            skipSentry: true,
+            cause: undefined,
+          },
+          {
+            level: "error",
+            text: "POST /relinquish failed: no reservation",
+            location: "server",
+            agentId: AGENT_ID,
+            skipSentry: true,
+            cause: undefined,
+          },
+        ]);
+        expect(fixed.reporter.reported).toEqual([]);
+      }),
   );
 
   it.effect("a start without a reservation is 400 no reservation, attributed to the agent", () =>

--- a/test/qemu-server/http.unit.test.ts
+++ b/test/qemu-server/http.unit.test.ts
@@ -880,6 +880,56 @@ describe("Sessions failures", () => {
     }),
   );
 
+  it.effect("a second reserve for the same agent is 400 already reserved and reaches Sentry", () =>
+    Effect.gen(function* () {
+      const fixed = fixture({
+        sessions: FakeSessions.fakeSessions({
+          reserve: (agent) =>
+            Effect.fail(
+              Errors.BadRequest.make({
+                message: "already reserved",
+                agentId: agent,
+              }),
+            ),
+        }),
+      });
+      yield* Effect.gen(function* () {
+        const api = yield* client;
+        const error = yield* Effect.flip(
+          api.Sessions.reserve({
+            payload: Contract.ReserveAgentBody.make({ agent: AGENT_ID }),
+          }),
+        );
+        expect(error).toMatchObject({ _tag: "BadRequest", message: "already reserved" });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/reserve", {
+          headers: { authorization: `Bearer ${TOKEN}` },
+          body: HttpBody.jsonUnsafe({ agent: AGENT_ID }),
+        });
+        expect(raw.status).toBe(400);
+        expect(yield* raw.json).toEqual({ error: "already reserved" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /reserve failed: already reserved",
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: false,
+          cause: undefined,
+        },
+        {
+          level: "error",
+          text: "POST /reserve failed: already reserved",
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+    }),
+  );
+
   it.effect("an AtCapacity from reserve is 503 with its message, attributed to the agent", () =>
     Effect.gen(function* () {
       const fixed = fixture({

--- a/test/qemu-server/http.unit.test.ts
+++ b/test/qemu-server/http.unit.test.ts
@@ -102,6 +102,26 @@ describe("Sessions endpoints happy path", () => {
     }),
   );
 
+  it.effect("POST /reserve answers ok and hands the start body to Sessions", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const api = yield* client;
+        const ok = yield* api.Sessions.reserve({
+          payload: Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID }),
+        });
+        expect(ok).toEqual(Contract.Ok.make({}));
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.sessions.calls).toEqual([
+        {
+          method: "reserve",
+          args: [Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID })],
+        },
+      ]);
+      expect(fixed.log.lines).toEqual([]);
+    }),
+  );
+
   it.effect("GET /image returns image/png bytes with x-image-url after a lookup", () =>
     Effect.gen(function* () {
       const fixed = fixture();
@@ -311,6 +331,7 @@ describe("Sessions endpoints happy path", () => {
 
 describe("authentication", () => {
   const sessionsRoutes: ReadonlyArray<readonly [string, string, boolean]> = [
+    ["POST", "/reserve", true],
     ["POST", "/start", true],
     ["GET", "/image?id=x&agent=y", false],
     ["GET", "/serial?id=x&agent=y", false],
@@ -829,6 +850,57 @@ describe("Sessions failures", () => {
           level: "error",
           text: "POST /start failed: qemu: disk not found: /tmp/nope.qcow2",
           location: STARTED_ID,
+          agentId: AGENT_ID,
+          skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
+  it.effect("an AtCapacity from reserve is 503 with its message, attributed to the agent", () =>
+    Effect.gen(function* () {
+      const fixed = fixture({
+        sessions: FakeSessions.fakeSessions({
+          reserve: (body) =>
+            Effect.fail(
+              Errors.AtCapacity.make({
+                message: "at capacity: max-jobs is 2",
+                agentId: body.agent,
+              }),
+            ),
+        }),
+      });
+      yield* Effect.gen(function* () {
+        const api = yield* client;
+        const error = yield* Effect.flip(
+          api.Sessions.reserve({
+            payload: Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID }),
+          }),
+        );
+        expect(error).toMatchObject({ _tag: "AtCapacity", message: "at capacity: max-jobs is 2" });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/reserve", {
+          headers: { authorization: `Bearer ${TOKEN}` },
+          body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: AGENT_ID }),
+        });
+        expect(raw.status).toBe(503);
+        expect(yield* raw.json).toEqual({ error: "at capacity: max-jobs is 2" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /reserve failed: at capacity: max-jobs is 2",
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: false,
+          cause: undefined,
+        },
+        {
+          level: "error",
+          text: "POST /reserve failed: at capacity: max-jobs is 2",
+          location: "server",
           agentId: AGENT_ID,
           skipSentry: false,
           cause: undefined,

--- a/test/qemu-server/http.unit.test.ts
+++ b/test/qemu-server/http.unit.test.ts
@@ -1220,53 +1220,69 @@ describe("defects", () => {
     }),
   );
 
-  it.effect("the real Log reports a 5xx cause and a defect to the reporter, never a 4xx", () =>
-    Effect.gen(function* () {
-      const defect = new Error("kaboom");
-      const failure = new Error("connect ECONNREFUSED 127.0.0.1:5432");
-      const fixed = fixture({
-        sessions: FakeSessions.fakeSessions({
-          stats: Effect.die(defect),
-          serial: (live) =>
-            Effect.fail(
-              Errors.Internal.make({
-                message: "internal error",
-                cause: failure,
-                sessionId: live.id,
-                agentId: live.agent,
-              }),
-            ),
-        }),
-      });
-      const stdout = Log.Log.layerStdout.pipe(Layer.provide(fixed.reporter.layer));
-      yield* Effect.gen(function* () {
-        const api = yield* client;
-        yield* Effect.flip(api.Sessions.stats());
-        yield* Effect.flip(api.Sessions.serial({ query: { id: SESSION_ID, agent: AGENT_ID } }));
-        yield* Effect.flip(api.Sessions.serial({ query: { id: "nope", agent: AGENT_ID } }));
-        const wrong = yield* client.pipe(Effect.provide(bearer("wrong")));
-        yield* Effect.flip(wrong.Sessions.serial({ query: { id: SESSION_ID, agent: AGENT_ID } }));
-      }).pipe(Effect.provide(serve(fixed, stdout)));
-      // The log line is what reports; the cause it carries is what Sentry is handed.
-      expect(fixed.reporter.reported).toHaveLength(2);
-      const causes = fixed.reporter.reported.map((report) =>
-        Render.errorDetail(report.error.cause),
-      );
-      expect(causes).toContain("kaboom");
-      expect(causes).toContain("connect ECONNREFUSED 127.0.0.1:5432");
-      const withSession = fixed.reporter.reported.find(
-        (report) =>
-          Render.errorDetail(report.error.cause) === "connect ECONNREFUSED 127.0.0.1:5432",
-      );
-      expect(withSession?.error.message).toBe(
-        `GET /serial?id=${SESSION_ID}&agent=${AGENT_ID} failed: connect ECONNREFUSED 127.0.0.1:5432`,
-      );
-      expect(withSession?.severity).toBe("Error");
-      expect(withSession?.annotations).toMatchObject({
-        location: SESSION_ID,
-        agent_id: AGENT_ID,
-      });
-    }),
+  it.effect(
+    "the real Log reports a 5xx cause, a defect and already reserved, never another 4xx",
+    () =>
+      Effect.gen(function* () {
+        const defect = new Error("kaboom");
+        const failure = new Error("connect ECONNREFUSED 127.0.0.1:5432");
+        const fixed = fixture({
+          sessions: FakeSessions.fakeSessions({
+            stats: Effect.die(defect),
+            reserve: (agent) =>
+              Effect.fail(
+                Errors.BadRequest.make({
+                  message: "already reserved",
+                  agentId: agent,
+                }),
+              ),
+            serial: (live) =>
+              Effect.fail(
+                Errors.Internal.make({
+                  message: "internal error",
+                  cause: failure,
+                  sessionId: live.id,
+                  agentId: live.agent,
+                }),
+              ),
+          }),
+        });
+        const stdout = Log.Log.layerStdout.pipe(Layer.provide(fixed.reporter.layer));
+        yield* Effect.gen(function* () {
+          const api = yield* client;
+          yield* Effect.flip(api.Sessions.stats());
+          yield* Effect.flip(api.Sessions.serial({ query: { id: SESSION_ID, agent: AGENT_ID } }));
+          yield* Effect.flip(api.Sessions.serial({ query: { id: "nope", agent: AGENT_ID } }));
+          yield* Effect.flip(
+            api.Sessions.reserve({
+              payload: Contract.ReserveAgentBody.make({ agent: AGENT_ID }),
+            }),
+          );
+          const wrong = yield* client.pipe(Effect.provide(bearer("wrong")));
+          yield* Effect.flip(wrong.Sessions.serial({ query: { id: SESSION_ID, agent: AGENT_ID } }));
+        }).pipe(Effect.provide(serve(fixed, stdout)));
+        // The log line is what reports; the cause it carries is what Sentry is handed.
+        expect(fixed.reporter.reported).toHaveLength(3);
+        const messages = fixed.reporter.reported.map((report) => report.error.message);
+        expect(messages).toContain("POST /reserve failed: already reserved");
+        const causes = fixed.reporter.reported.map((report) =>
+          Render.errorDetail(report.error.cause),
+        );
+        expect(causes).toContain("kaboom");
+        expect(causes).toContain("connect ECONNREFUSED 127.0.0.1:5432");
+        const withSession = fixed.reporter.reported.find(
+          (report) =>
+            Render.errorDetail(report.error.cause) === "connect ECONNREFUSED 127.0.0.1:5432",
+        );
+        expect(withSession?.error.message).toBe(
+          `GET /serial?id=${SESSION_ID}&agent=${AGENT_ID} failed: connect ECONNREFUSED 127.0.0.1:5432`,
+        );
+        expect(withSession?.severity).toBe("Error");
+        expect(withSession?.annotations).toMatchObject({
+          location: SESSION_ID,
+          agent_id: AGENT_ID,
+        });
+      }),
   );
 });
 

--- a/test/qemu-server/http.unit.test.ts
+++ b/test/qemu-server/http.unit.test.ts
@@ -102,20 +102,20 @@ describe("Sessions endpoints happy path", () => {
     }),
   );
 
-  it.effect("POST /reserve answers ok and hands the start body to Sessions", () =>
+  it.effect("POST /reserve answers ok and hands the agent to Sessions", () =>
     Effect.gen(function* () {
       const fixed = fixture();
       yield* Effect.gen(function* () {
         const api = yield* client;
         const ok = yield* api.Sessions.reserve({
-          payload: Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID }),
+          payload: Contract.ReserveAgentBody.make({ agent: AGENT_ID }),
         });
         expect(ok).toEqual(Contract.Ok.make({}));
       }).pipe(Effect.provide(serve(fixed)));
       expect(fixed.sessions.calls).toEqual([
         {
           method: "reserve",
-          args: [Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID })],
+          args: [AGENT_ID],
         },
       ]);
       expect(fixed.log.lines).toEqual([]);
@@ -863,11 +863,11 @@ describe("Sessions failures", () => {
     Effect.gen(function* () {
       const fixed = fixture({
         sessions: FakeSessions.fakeSessions({
-          reserve: (body) =>
+          reserve: (agent) =>
             Effect.fail(
               Errors.AtCapacity.make({
                 message: "at capacity: max-jobs is 2",
-                agentId: body.agent,
+                agentId: agent,
               }),
             ),
         }),
@@ -876,14 +876,14 @@ describe("Sessions failures", () => {
         const api = yield* client;
         const error = yield* Effect.flip(
           api.Sessions.reserve({
-            payload: Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID }),
+            payload: Contract.ReserveAgentBody.make({ agent: AGENT_ID }),
           }),
         );
         expect(error).toMatchObject({ _tag: "AtCapacity", message: "at capacity: max-jobs is 2" });
         const http = yield* HttpClient.HttpClient;
         const raw = yield* http.post("/reserve", {
           headers: { authorization: `Bearer ${TOKEN}` },
-          body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: AGENT_ID }),
+          body: HttpBody.jsonUnsafe({ agent: AGENT_ID }),
         });
         expect(raw.status).toBe(503);
         expect(yield* raw.json).toEqual({ error: "at capacity: max-jobs is 2" });
@@ -910,14 +910,14 @@ describe("Sessions failures", () => {
     }),
   );
 
-  it.effect("an AtCapacity from start is 503 with its message, attributed to the agent", () =>
+  it.effect("a start without a reservation is 400 no reservation, attributed to the agent", () =>
     Effect.gen(function* () {
       const fixed = fixture({
         sessions: FakeSessions.fakeSessions({
           start: (body) =>
             Effect.fail(
-              Errors.AtCapacity.make({
-                message: "at capacity: max-jobs is 2",
+              Errors.BadRequest.make({
+                message: "no reservation",
                 agentId: body.agent,
               }),
             ),
@@ -930,32 +930,30 @@ describe("Sessions failures", () => {
             payload: Contract.StartBody.make({ iso: "omarchy.iso", agent: AGENT_ID }),
           }),
         );
-        expect(error).toMatchObject({ _tag: "AtCapacity", message: "at capacity: max-jobs is 2" });
+        expect(error).toMatchObject({ _tag: "BadRequest", message: "no reservation" });
         const http = yield* HttpClient.HttpClient;
         const raw = yield* http.post("/start", {
           headers: { authorization: `Bearer ${TOKEN}` },
           body: HttpBody.jsonUnsafe({ iso: "omarchy.iso", agent: AGENT_ID }),
         });
-        expect(raw.status).toBe(503);
-        expect(yield* raw.json).toEqual({ error: "at capacity: max-jobs is 2" });
+        expect(raw.status).toBe(400);
+        expect(yield* raw.json).toEqual({ error: "no reservation" });
       }).pipe(Effect.provide(serve(fixed)));
-      // No session was minted, so the line sits in the server bucket under the refused agent;
-      // a 503 is the fleet's problem to place elsewhere, so unlike a 4xx it reaches Sentry.
       expect(fixed.log.lines).toEqual([
         {
           level: "error",
-          text: "POST /start failed: at capacity: max-jobs is 2",
+          text: "POST /start failed: no reservation",
           location: "server",
           agentId: AGENT_ID,
-          skipSentry: false,
+          skipSentry: true,
           cause: undefined,
         },
         {
           level: "error",
-          text: "POST /start failed: at capacity: max-jobs is 2",
+          text: "POST /start failed: no reservation",
           location: "server",
           agentId: AGENT_ID,
-          skipSentry: false,
+          skipSentry: true,
           cause: undefined,
         },
       ]);

--- a/test/qemu-server/http.unit.test.ts
+++ b/test/qemu-server/http.unit.test.ts
@@ -122,6 +122,26 @@ describe("Sessions endpoints happy path", () => {
     }),
   );
 
+  it.effect("POST /relinquish answers ok and hands the agent to Sessions", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const api = yield* client;
+        const ok = yield* api.Sessions.relinquish({
+          payload: Contract.ReserveAgentBody.make({ agent: AGENT_ID }),
+        });
+        expect(ok).toEqual(Contract.Ok.make({}));
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.sessions.calls).toEqual([
+        {
+          method: "relinquish",
+          args: [AGENT_ID],
+        },
+      ]);
+      expect(fixed.log.lines).toEqual([]);
+    }),
+  );
+
   it.effect("GET /image returns image/png bytes with x-image-url after a lookup", () =>
     Effect.gen(function* () {
       const fixed = fixture();
@@ -332,6 +352,7 @@ describe("Sessions endpoints happy path", () => {
 describe("authentication", () => {
   const sessionsRoutes: ReadonlyArray<readonly [string, string, boolean]> = [
     ["POST", "/reserve", true],
+    ["POST", "/relinquish", true],
     ["POST", "/start", true],
     ["GET", "/image?id=x&agent=y", false],
     ["GET", "/serial?id=x&agent=y", false],
@@ -903,6 +924,57 @@ describe("Sessions failures", () => {
           location: "server",
           agentId: AGENT_ID,
           skipSentry: false,
+          cause: undefined,
+        },
+      ]);
+      expect(fixed.reporter.reported).toEqual([]);
+    }),
+  );
+
+  it.effect("a relinquish without a reservation is 400 no reservation, attributed to the agent", () =>
+    Effect.gen(function* () {
+      const fixed = fixture({
+        sessions: FakeSessions.fakeSessions({
+          relinquish: (agent) =>
+            Effect.fail(
+              Errors.BadRequest.make({
+                message: "no reservation",
+                agentId: agent,
+              }),
+            ),
+        }),
+      });
+      yield* Effect.gen(function* () {
+        const api = yield* client;
+        const error = yield* Effect.flip(
+          api.Sessions.relinquish({
+            payload: Contract.ReserveAgentBody.make({ agent: AGENT_ID }),
+          }),
+        );
+        expect(error).toMatchObject({ _tag: "BadRequest", message: "no reservation" });
+        const http = yield* HttpClient.HttpClient;
+        const raw = yield* http.post("/relinquish", {
+          headers: { authorization: `Bearer ${TOKEN}` },
+          body: HttpBody.jsonUnsafe({ agent: AGENT_ID }),
+        });
+        expect(raw.status).toBe(400);
+        expect(yield* raw.json).toEqual({ error: "no reservation" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.log.lines).toEqual([
+        {
+          level: "error",
+          text: "POST /relinquish failed: no reservation",
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: true,
+          cause: undefined,
+        },
+        {
+          level: "error",
+          text: "POST /relinquish failed: no reservation",
+          location: "server",
+          agentId: AGENT_ID,
+          skipSentry: true,
           cause: undefined,
         },
       ]);

--- a/test/qemu-server/sessions.unit.test.ts
+++ b/test/qemu-server/sessions.unit.test.ts
@@ -2019,6 +2019,65 @@ describe("stats", () => {
 // ---------------------------------------------------------------------------
 
 describe("capacity", () => {
+  it.effect("a reserve past --max-jobs is AtCapacity before anything is minted or written", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          yield* sessions.reserve(startBody());
+          const error = yield* Effect.flip(sessions.reserve(startBody(ISO, OTHER_AGENT)));
+          expect(error).toMatchObject({
+            _tag: "AtCapacity",
+            message: "at capacity: max-jobs is 1",
+            agentId: OTHER_AGENT,
+          });
+          expect(h.sessions.sessions).toEqual([]);
+          expect(h.sessions.agentRuns).toEqual([]);
+          expect(h.iso.calls).toHaveLength(0);
+          expect(h.qemu.calls).toEqual([]);
+          expect(spanNamed(h, OTHER_AGENT)).toBeUndefined();
+          expect(h.log.acquired).toEqual([]);
+          expect(texts(h)).toEqual([]);
+          expect(yield* qemus(sessions)).toBe(0);
+        }),
+      );
+    }),
+  );
+
+  it.effect("a second reserve for the same agent is the same slot", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          yield* sessions.reserve(startBody());
+          yield* sessions.reserve(startBody());
+          const error = yield* Effect.flip(sessions.reserve(startBody(ISO, OTHER_AGENT)));
+          expect(error._tag).toBe("AtCapacity");
+        }),
+      );
+    }),
+  );
+
+  it.effect("start after reserve does not take a second slot and still boots", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          yield* sessions.reserve(startBody());
+          const { id } = yield* start();
+          expect(
+            (yield* Effect.flip(sessions.start(startBody(ISO, OTHER_AGENT), "none", false)))._tag,
+          ).toBe("AtCapacity");
+          expect(h.sessions.sessions.map((row) => row.id)).toEqual([id]);
+          expect(yield* qemus(sessions)).toBe(1);
+        }),
+      );
+    }),
+  );
+
   it.effect("a start past --max-jobs is AtCapacity before anything is minted or written", () =>
     Effect.gen(function* () {
       const h = harness({ maxJobs: 1 });

--- a/test/qemu-server/sessions.unit.test.ts
+++ b/test/qemu-server/sessions.unit.test.ts
@@ -2202,4 +2202,62 @@ describe("capacity", () => {
       );
     }),
   );
+
+  it.effect("relinquish gives back an unused reservation so another agent can take it", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          yield* sessions.reserve(AGENT);
+          expect((yield* Effect.flip(sessions.reserve(OTHER_AGENT)))._tag).toBe("AtCapacity");
+          yield* sessions.relinquish(AGENT);
+          yield* sessions.reserve(OTHER_AGENT);
+          expect((yield* Effect.flip(sessions.reserve(AGENT)))._tag).toBe("AtCapacity");
+          expect(h.sessions.sessions).toEqual([]);
+          expect(yield* qemus(sessions)).toBe(0);
+        }),
+      );
+    }),
+  );
+
+  it.effect("relinquish without a reservation is BadRequest", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          const error = yield* Effect.flip(sessions.relinquish(AGENT));
+          expect(error).toMatchObject({
+            _tag: "BadRequest",
+            message: "no reservation",
+            agentId: AGENT,
+          });
+          yield* sessions.reserve(AGENT);
+          expect((yield* Effect.flip(sessions.relinquish(OTHER_AGENT)))._tag).toBe("BadRequest");
+          expect((yield* Effect.flip(sessions.reserve(OTHER_AGENT)))._tag).toBe("AtCapacity");
+        }),
+      );
+    }),
+  );
+
+  it.effect("relinquish after start is BadRequest and the running session keeps its slot", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const { sessions, id } = yield* start();
+          const error = yield* Effect.flip(sessions.relinquish(AGENT));
+          expect(error).toMatchObject({
+            _tag: "BadRequest",
+            message: "no reservation",
+            agentId: AGENT,
+          });
+          expect((yield* Effect.flip(sessions.reserve(OTHER_AGENT)))._tag).toBe("AtCapacity");
+          expect(h.sessions.sessions.map((row) => row.id)).toEqual([id]);
+          expect(yield* qemus(sessions)).toBe(1);
+        }),
+      );
+    }),
+  );
 });

--- a/test/qemu-server/sessions.unit.test.ts
+++ b/test/qemu-server/sessions.unit.test.ts
@@ -315,7 +315,6 @@ describe("start", () => {
       const h = harness();
       yield* h.run(
         Effect.gen(function* () {
-          const sessions = yield* Sessions.Sessions;
           const error = yield* Effect.flip(reservedStart(startBody(URL_ISO, AGENT, DISK)));
           expect(error).toMatchObject({
             _tag: "StartFailed",
@@ -436,7 +435,6 @@ describe("start", () => {
         });
         yield* h.run(
           Effect.gen(function* () {
-            const sessions = yield* Sessions.Sessions;
             const error = yield* Effect.flip(reservedStart(startBody()));
             expect(error).toMatchObject({ _tag: "StartFailed", message: "qemu: exited 1" });
             const logged = line(h, "db: recording a failed start failed too:");
@@ -460,7 +458,6 @@ describe("start", () => {
       });
       yield* h.run(
         Effect.gen(function* () {
-          const sessions = yield* Sessions.Sessions;
           const error = yield* Effect.flip(reservedStart(startBody()));
           expect(error).toMatchObject({
             _tag: "Internal",
@@ -2084,29 +2081,31 @@ describe("capacity", () => {
     }),
   );
 
-  it.effect("a start without a reservation is BadRequest before anything is minted or written", () =>
-    Effect.gen(function* () {
-      const h = harness({ maxJobs: 1 });
-      yield* h.run(
-        Effect.gen(function* () {
-          const sessions = yield* Sessions.Sessions;
-          const error = yield* Effect.flip(sessions.start(startBody(), "none", false));
-          expect(error).toMatchObject({
-            _tag: "BadRequest",
-            message: "no reservation",
-            agentId: AGENT,
-          });
-          expect(h.sessions.sessions).toEqual([]);
-          expect(h.sessions.agentRuns).toEqual([]);
-          expect(h.iso.calls).toHaveLength(0);
-          expect(h.qemu.calls).toEqual([]);
-          expect(spanNamed(h, AGENT)).toBeUndefined();
-          expect(h.log.acquired).toEqual([]);
-          expect(texts(h)).toEqual([]);
-          expect(yield* qemus(sessions)).toBe(0);
-        }),
-      );
-    }),
+  it.effect(
+    "a start without a reservation is BadRequest before anything is minted or written",
+    () =>
+      Effect.gen(function* () {
+        const h = harness({ maxJobs: 1 });
+        yield* h.run(
+          Effect.gen(function* () {
+            const sessions = yield* Sessions.Sessions;
+            const error = yield* Effect.flip(sessions.start(startBody(), "none", false));
+            expect(error).toMatchObject({
+              _tag: "BadRequest",
+              message: "no reservation",
+              agentId: AGENT,
+            });
+            expect(h.sessions.sessions).toEqual([]);
+            expect(h.sessions.agentRuns).toEqual([]);
+            expect(h.iso.calls).toHaveLength(0);
+            expect(h.qemu.calls).toEqual([]);
+            expect(spanNamed(h, AGENT)).toBeUndefined();
+            expect(h.log.acquired).toEqual([]);
+            expect(texts(h)).toEqual([]);
+            expect(yield* qemus(sessions)).toBe(0);
+          }),
+        );
+      }),
   );
 
   it.effect("a booting session holds its slot until it is running", () =>

--- a/test/qemu-server/sessions.unit.test.ts
+++ b/test/qemu-server/sessions.unit.test.ts
@@ -2051,16 +2051,20 @@ describe("capacity", () => {
     }),
   );
 
-  it.effect("a second reserve for the same agent is the same slot", () =>
+  it.effect("a second reserve for the same agent is already reserved", () =>
     Effect.gen(function* () {
       const h = harness({ maxJobs: 1 });
       yield* h.run(
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
           yield* sessions.reserve(AGENT);
-          yield* sessions.reserve(AGENT);
-          const error = yield* Effect.flip(sessions.reserve(OTHER_AGENT));
-          expect(error._tag).toBe("AtCapacity");
+          const error = yield* Effect.flip(sessions.reserve(AGENT));
+          expect(error).toMatchObject({
+            _tag: "BadRequest",
+            message: "already reserved",
+            agentId: AGENT,
+          });
+          expect((yield* Effect.flip(sessions.reserve(OTHER_AGENT)))._tag).toBe("AtCapacity");
         }),
       );
     }),

--- a/test/qemu-server/sessions.unit.test.ts
+++ b/test/qemu-server/sessions.unit.test.ts
@@ -146,10 +146,21 @@ const startBody = (iso = ISO, agent = AGENT, disk?: string) =>
     ? Contract.StartBody.make({ iso, agent })
     : Contract.StartBody.make({ iso, agent, disk });
 
+const reservedStart = (
+  body: Contract.StartBody,
+  display: Domain.QemuDisplay = "none",
+  automation = false,
+) =>
+  Effect.gen(function* () {
+    const sessions = yield* Sessions.Sessions;
+    yield* sessions.reserve(body.agent);
+    return yield* sessions.start(body, display, automation);
+  });
+
 const start = (agent = AGENT, iso = ISO) =>
   Effect.gen(function* () {
     const sessions = yield* Sessions.Sessions;
-    const id = yield* sessions.start(startBody(iso, agent), "none", false);
+    const id = yield* reservedStart(startBody(iso, agent));
     const live = yield* sessions.lookup(id, agent);
     return { sessions, id, live };
   });
@@ -225,7 +236,7 @@ describe("start", () => {
         yield* h.run(
           Effect.gen(function* () {
             const sessions = yield* Sessions.Sessions;
-            const id = yield* sessions.start(startBody(URL_ISO, AGENT, DISK), "gtk", true);
+            const id = yield* reservedStart(startBody(URL_ISO, AGENT, DISK), "gtk", true);
             expect(Domain.isSessionId(id)).toBe(true);
             expect(h.fsCalls).toEqual([`stat ${DISK}`]);
             expect(order).toEqual([
@@ -305,9 +316,7 @@ describe("start", () => {
       yield* h.run(
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
-          const error = yield* Effect.flip(
-            sessions.start(startBody(URL_ISO, AGENT, DISK), "none", false),
-          );
+          const error = yield* Effect.flip(reservedStart(startBody(URL_ISO, AGENT, DISK)));
           expect(error).toMatchObject({
             _tag: "StartFailed",
             message: `qemu: disk not found: ${DISK}`,
@@ -340,7 +349,7 @@ describe("start", () => {
       yield* h.run(
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
-          const error = yield* Effect.flip(sessions.start(startBody(URL_ISO), "none", false));
+          const error = yield* Effect.flip(reservedStart(startBody(URL_ISO)));
           expect(error).toMatchObject({
             _tag: "StartFailed",
             message: "qemu-img create exited 1",
@@ -354,7 +363,7 @@ describe("start", () => {
           ]);
           expect(h.log.released).toEqual([AGENT]);
           // The registration was never spent: the same agent boots on its next try.
-          const id = yield* sessions.start(startBody(), "none", false);
+          const id = yield* reservedStart(startBody());
           expect(h.sessions.agentRuns).toMatchObject([{ agentId: AGENT, sessionId: id }]);
           expect(yield* qemus(sessions)).toBe(1);
         }),
@@ -377,7 +386,7 @@ describe("start", () => {
         yield* h.run(
           Effect.gen(function* () {
             const sessions = yield* Sessions.Sessions;
-            const error = yield* Effect.flip(sessions.start(startBody(), "none", false));
+            const error = yield* Effect.flip(reservedStart(startBody()));
             expect(error._tag).toBe("StartFailed");
             if (error._tag !== "StartFailed") {
               return;
@@ -428,7 +437,7 @@ describe("start", () => {
         yield* h.run(
           Effect.gen(function* () {
             const sessions = yield* Sessions.Sessions;
-            const error = yield* Effect.flip(sessions.start(startBody(), "none", false));
+            const error = yield* Effect.flip(reservedStart(startBody()));
             expect(error).toMatchObject({ _tag: "StartFailed", message: "qemu: exited 1" });
             const logged = line(h, "db: recording a failed start failed too:");
             expect(logged).toMatchObject({
@@ -452,7 +461,7 @@ describe("start", () => {
       yield* h.run(
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
-          const error = yield* Effect.flip(sessions.start(startBody(), "none", false));
+          const error = yield* Effect.flip(reservedStart(startBody()));
           expect(error).toMatchObject({
             _tag: "Internal",
             message: "internal error",
@@ -1467,7 +1476,7 @@ describe("follow", () => {
         yield* h.run(
           Effect.gen(function* () {
             const sessions = yield* Sessions.Sessions;
-            const booting = yield* Effect.forkChild(sessions.start(startBody(), "none", false), {
+            const booting = yield* Effect.forkChild(reservedStart(startBody()), {
               startImmediately: true,
             });
             const id = h.sessions.sessions[0]?.id ?? "";
@@ -2025,8 +2034,8 @@ describe("capacity", () => {
       yield* h.run(
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
-          yield* sessions.reserve(startBody());
-          const error = yield* Effect.flip(sessions.reserve(startBody(ISO, OTHER_AGENT)));
+          yield* sessions.reserve(AGENT);
+          const error = yield* Effect.flip(sessions.reserve(OTHER_AGENT));
           expect(error).toMatchObject({
             _tag: "AtCapacity",
             message: "at capacity: max-jobs is 1",
@@ -2051,9 +2060,9 @@ describe("capacity", () => {
       yield* h.run(
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
-          yield* sessions.reserve(startBody());
-          yield* sessions.reserve(startBody());
-          const error = yield* Effect.flip(sessions.reserve(startBody(ISO, OTHER_AGENT)));
+          yield* sessions.reserve(AGENT);
+          yield* sessions.reserve(AGENT);
+          const error = yield* Effect.flip(sessions.reserve(OTHER_AGENT));
           expect(error._tag).toBe("AtCapacity");
         }),
       );
@@ -2066,11 +2075,8 @@ describe("capacity", () => {
       yield* h.run(
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
-          yield* sessions.reserve(startBody());
           const { id } = yield* start();
-          expect(
-            (yield* Effect.flip(sessions.start(startBody(ISO, OTHER_AGENT), "none", false)))._tag,
-          ).toBe("AtCapacity");
+          expect((yield* Effect.flip(sessions.reserve(OTHER_AGENT)))._tag).toBe("AtCapacity");
           expect(h.sessions.sessions.map((row) => row.id)).toEqual([id]);
           expect(yield* qemus(sessions)).toBe(1);
         }),
@@ -2078,31 +2084,26 @@ describe("capacity", () => {
     }),
   );
 
-  it.effect("a start past --max-jobs is AtCapacity before anything is minted or written", () =>
+  it.effect("a start without a reservation is BadRequest before anything is minted or written", () =>
     Effect.gen(function* () {
       const h = harness({ maxJobs: 1 });
       yield* h.run(
         Effect.gen(function* () {
-          const { sessions, id } = yield* start();
-          const error = yield* Effect.flip(
-            sessions.start(startBody(ISO, OTHER_AGENT), "none", false),
-          );
+          const sessions = yield* Sessions.Sessions;
+          const error = yield* Effect.flip(sessions.start(startBody(), "none", false));
           expect(error).toMatchObject({
-            _tag: "AtCapacity",
-            message: "at capacity: max-jobs is 1",
-            agentId: OTHER_AGENT,
+            _tag: "BadRequest",
+            message: "no reservation",
+            agentId: AGENT,
           });
-          // Nothing of the refused start exists: no row, no iso lookup, no machine, no span, no
-          // colour, no log line; the running session is untouched.
-          expect(h.sessions.sessions.map((row) => row.id)).toEqual([id]);
-          expect(h.sessions.agentRuns.map((row) => row.agentId)).toEqual([AGENT]);
-          expect(h.iso.calls).toHaveLength(1);
-          expect(h.qemu.calls.map((call) => call._tag)).toEqual(["prepare", "start"]);
-          expect(spanNamed(h, OTHER_AGENT)).toBeUndefined();
-          expect(h.log.acquired).toEqual([AGENT]);
-          expect(texts(h)).toEqual([`starting; iso ${ISO}`, "running; started in 0ms"]);
-          expect(yield* qemus(sessions)).toBe(1);
-          expect(yield* sessions.lookup(id, AGENT)).toBeDefined();
+          expect(h.sessions.sessions).toEqual([]);
+          expect(h.sessions.agentRuns).toEqual([]);
+          expect(h.iso.calls).toHaveLength(0);
+          expect(h.qemu.calls).toEqual([]);
+          expect(spanNamed(h, AGENT)).toBeUndefined();
+          expect(h.log.acquired).toEqual([]);
+          expect(texts(h)).toEqual([]);
+          expect(yield* qemus(sessions)).toBe(0);
         }),
       );
     }),
@@ -2115,14 +2116,10 @@ describe("capacity", () => {
       yield* h.run(
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
-          const booting = yield* Effect.forkChild(sessions.start(startBody(), "none", false), {
+          const booting = yield* Effect.forkChild(reservedStart(startBody()), {
             startImmediately: true,
           });
-          expect(yield* qemus(sessions)).toBe(0);
-          const error = yield* Effect.flip(
-            sessions.start(startBody(ISO, OTHER_AGENT), "none", false),
-          );
-          expect(error).toMatchObject({ _tag: "AtCapacity", agentId: OTHER_AGENT });
+          expect((yield* Effect.flip(sessions.reserve(OTHER_AGENT)))._tag).toBe("AtCapacity");
           yield* Deferred.succeed(gate, undefined);
           const id = yield* Fiber.join(booting);
           expect(h.sessions.sessions.map((row) => row.id)).toEqual([id]);
@@ -2138,11 +2135,9 @@ describe("capacity", () => {
       yield* h.run(
         Effect.gen(function* () {
           const { sessions, live } = yield* start();
-          expect(
-            (yield* Effect.flip(sessions.start(startBody(ISO, OTHER_AGENT), "none", false)))._tag,
-          ).toBe("AtCapacity");
+          expect((yield* Effect.flip(sessions.reserve(OTHER_AGENT)))._tag).toBe("AtCapacity");
           yield* sessions.stop(live, "succeeded", "done");
-          const next = yield* sessions.start(startBody(ISO, OTHER_AGENT), "none", false);
+          const next = yield* reservedStart(startBody(ISO, OTHER_AGENT));
           expect(h.sessions.sessions.map((row) => [row.id, row.status])).toEqual([
             [live.id, "succeeded"],
             [next, "running"],
@@ -2180,18 +2175,14 @@ describe("capacity", () => {
       yield* h.run(
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
-          const booted = yield* Effect.flip(sessions.start(startBody(ISO, AGENT), "none", false));
+          const booted = yield* Effect.flip(reservedStart(startBody(ISO, AGENT)));
           expect(booted._tag).toBe("StartFailed");
-          const inserted = yield* Effect.flip(
-            sessions.start(startBody(ISO, OTHER_AGENT), "none", false),
-          );
+          const inserted = yield* Effect.flip(reservedStart(startBody(ISO, OTHER_AGENT)));
           expect(inserted._tag).toBe("Internal");
-          const id = yield* sessions.start(startBody(ISO, "OLI-63"), "none", false);
+          const id = yield* reservedStart(startBody(ISO, "OLI-63"));
           expect(Domain.isSessionId(id)).toBe(true);
           expect(yield* qemus(sessions)).toBe(1);
-          expect(
-            (yield* Effect.flip(sessions.start(startBody(ISO, "OLI-64"), "none", false)))._tag,
-          ).toBe("AtCapacity");
+          expect((yield* Effect.flip(sessions.reserve("OLI-64")))._tag).toBe("AtCapacity");
         }),
       );
     }),
@@ -2205,7 +2196,7 @@ describe("capacity", () => {
           const { sessions, id } = yield* start();
           yield* TestClock.adjust("10 minutes");
           expect(h.sessions.sessions[0]).toMatchObject({ id, status: "timed_out" });
-          const next = yield* sessions.start(startBody(ISO, OTHER_AGENT), "none", false);
+          const next = yield* reservedStart(startBody(ISO, OTHER_AGENT));
           expect(next).not.toBe(id);
           expect(yield* qemus(sessions)).toBe(1);
         }),

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -118,9 +118,9 @@ describe("QemuServerApi", () => {
 
   it("declares the error statuses of §2.4 plus the middleware's 400, 401 and 500", () => {
     const sessions = [400, 401, 500];
-    // 502: the machine failed to boot; 503: the server is at --max-jobs.
+    // 502: the machine failed to boot; 503: only /reserve, when the server is at --max-jobs.
     expect(byIdentifier(Api.QemuServerApi, "reserve").errors).toEqual([...sessions, 503]);
-    expect(byIdentifier(Api.QemuServerApi, "start").errors).toEqual([...sessions, 502, 503]);
+    expect(byIdentifier(Api.QemuServerApi, "start").errors).toEqual([...sessions, 502]);
     expect(byIdentifier(Api.QemuServerApi, "image").errors).toEqual(
       [...sessions, 403, 404, 502].sort((a, b) => a - b),
     );
@@ -290,8 +290,8 @@ describe("AutomationClientApi", () => {
     expect(run.group).toBe("Runs");
     expect(run.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);
     expect(spec.paths["/run"]?.post?.security).toEqual([{ bearer: [] }]);
-    // 500: opencode failed; 503: the client is at --max-jobs.
-    expect(run.errors).toEqual([400, 401, 500, 503]);
+    // 500: opencode failed. Capacity is /reserve's 503.
+    expect(run.errors).toEqual([400, 401, 500]);
     const abort = byIdentifier(client, "abort");
     expect(abort.group).toBe("Runs");
     expect(abort.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -51,6 +51,7 @@ describe("QemuServerApi", () => {
     expect(table.sort()).toEqual(
       [
         "POST /reserve",
+        "POST /relinquish",
         "POST /start",
         "GET /image",
         "GET /serial",
@@ -68,6 +69,7 @@ describe("QemuServerApi", () => {
   it("builds every url through the client url builder", () => {
     const urls = HttpApiClient.urlBuilder(Api.QemuServerApi);
     expect(urls.Sessions.reserve()).toBe("/reserve");
+    expect(urls.Sessions.relinquish()).toBe("/relinquish");
     expect(urls.Sessions.start()).toBe("/start");
     expect(urls.Sessions.image({ query: { id: "abc", agent: "OLI-61" } })).toBe(
       "/image?id=abc&agent=OLI-61",
@@ -120,6 +122,7 @@ describe("QemuServerApi", () => {
     const sessions = [400, 401, 500];
     // 502: the machine failed to boot; 503: only /reserve, when the server is at --max-jobs.
     expect(byIdentifier(Api.QemuServerApi, "reserve").errors).toEqual([...sessions, 503]);
+    expect(byIdentifier(Api.QemuServerApi, "relinquish").errors).toEqual(sessions);
     expect(byIdentifier(Api.QemuServerApi, "start").errors).toEqual([...sessions, 502]);
     expect(byIdentifier(Api.QemuServerApi, "image").errors).toEqual(
       [...sessions, 403, 404, 502].sort((a, b) => a - b),
@@ -161,6 +164,7 @@ describe("QemuReverseProxyApi", () => {
     expect(table.sort()).toEqual(
       [
         "POST /reserve",
+        "POST /relinquish",
         "POST /start",
         "GET /image",
         "GET /serial",
@@ -214,6 +218,7 @@ describe("QemuReverseProxyApi", () => {
   it("declares the boundary's 400, 401, 500, 502 and 503 on every endpoint plus each endpoint's own", () => {
     const boundary = [400, 401, 500, 502, 503];
     expect(byIdentifier(reverse, "reserve").errors).toEqual(boundary);
+    expect(byIdentifier(reverse, "relinquish").errors).toEqual(boundary);
     expect(byIdentifier(reverse, "start").errors).toEqual(boundary);
     expect(byIdentifier(reverse, "image").errors).toEqual(ascending([...boundary, 403, 404]));
     expect(byIdentifier(reverse, "serial").errors).toEqual(ascending([...boundary, 403, 404]));

--- a/test/shared/api.unit.test.ts
+++ b/test/shared/api.unit.test.ts
@@ -50,6 +50,7 @@ describe("QemuServerApi", () => {
     const table = routes(Api.QemuServerApi).map(({ method, path }) => `${method} ${path}`);
     expect(table.sort()).toEqual(
       [
+        "POST /reserve",
         "POST /start",
         "GET /image",
         "GET /serial",
@@ -66,6 +67,7 @@ describe("QemuServerApi", () => {
 
   it("builds every url through the client url builder", () => {
     const urls = HttpApiClient.urlBuilder(Api.QemuServerApi);
+    expect(urls.Sessions.reserve()).toBe("/reserve");
     expect(urls.Sessions.start()).toBe("/start");
     expect(urls.Sessions.image({ query: { id: "abc", agent: "OLI-61" } })).toBe(
       "/image?id=abc&agent=OLI-61",
@@ -117,6 +119,7 @@ describe("QemuServerApi", () => {
   it("declares the error statuses of §2.4 plus the middleware's 400, 401 and 500", () => {
     const sessions = [400, 401, 500];
     // 502: the machine failed to boot; 503: the server is at --max-jobs.
+    expect(byIdentifier(Api.QemuServerApi, "reserve").errors).toEqual([...sessions, 503]);
     expect(byIdentifier(Api.QemuServerApi, "start").errors).toEqual([...sessions, 502, 503]);
     expect(byIdentifier(Api.QemuServerApi, "image").errors).toEqual(
       [...sessions, 403, 404, 502].sort((a, b) => a - b),
@@ -157,6 +160,7 @@ describe("QemuReverseProxyApi", () => {
     const table = routes(reverse).map(({ method, path }) => `${method} ${path}`);
     expect(table.sort()).toEqual(
       [
+        "POST /reserve",
         "POST /start",
         "GET /image",
         "GET /serial",
@@ -209,6 +213,7 @@ describe("QemuReverseProxyApi", () => {
 
   it("declares the boundary's 400, 401, 500, 502 and 503 on every endpoint plus each endpoint's own", () => {
     const boundary = [400, 401, 500, 502, 503];
+    expect(byIdentifier(reverse, "reserve").errors).toEqual(boundary);
     expect(byIdentifier(reverse, "start").errors).toEqual(boundary);
     expect(byIdentifier(reverse, "image").errors).toEqual(ascending([...boundary, 403, 404]));
     expect(byIdentifier(reverse, "serial").errors).toEqual(ascending([...boundary, 403, 404]));
@@ -266,15 +271,21 @@ describe("AutomationServerApi", () => {
 describe("AutomationClientApi", () => {
   const client = Api.AutomationClientApi;
 
-  it("declares POST /run and POST /abort", () => {
+  it("declares POST /reserve, POST /run and POST /abort", () => {
     const table = routes(client).map(({ method, path }) => `${method} ${path}`);
-    expect(table.sort()).toEqual(["POST /abort", "POST /run"]);
+    expect(table.sort()).toEqual(["POST /abort", "POST /reserve", "POST /run"]);
+    expect(HttpApiClient.urlBuilder(client).Runs.reserve()).toBe("/reserve");
     expect(HttpApiClient.urlBuilder(client).Runs.run()).toBe("/run");
     expect(HttpApiClient.urlBuilder(client).Runs.abort()).toBe("/abort");
   });
 
   it("requires the bearer and applies BearerAuth then ApiBoundary", () => {
     const spec = OpenApi.fromApi(client);
+    const reserve = byIdentifier(client, "reserve");
+    expect(reserve.group).toBe("Runs");
+    expect(reserve.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);
+    expect(spec.paths["/reserve"]?.post?.security).toEqual([{ bearer: [] }]);
+    expect(reserve.errors).toEqual([400, 401, 500, 503]);
     const run = byIdentifier(client, "run");
     expect(run.group).toBe("Runs");
     expect(run.middleware).toEqual([Api.BearerAuth.key, Api.ApiBoundary.key]);

--- a/test/support/fake-sessions.ts
+++ b/test/support/fake-sessions.ts
@@ -146,6 +146,7 @@ export const fakeSessions = (
         });
       return Sessions.Sessions.of({
         reserve: (agent) => record("reserve", agent),
+        relinquish: (agent) => record("relinquish", agent),
         start: (body, display, automation) =>
           record("start", body, display, automation).pipe(Effect.as(STARTED_ID)),
         lookup,

--- a/test/support/fake-sessions.ts
+++ b/test/support/fake-sessions.ts
@@ -145,6 +145,7 @@ export const fakeSessions = (
           return found === undefined ? yield* Errors.unknownSession(id) : found;
         });
       return Sessions.Sessions.of({
+        reserve: (body) => record("reserve", body),
         start: (body, display, automation) =>
           record("start", body, display, automation).pipe(Effect.as(STARTED_ID)),
         lookup,

--- a/test/support/fake-sessions.ts
+++ b/test/support/fake-sessions.ts
@@ -145,7 +145,7 @@ export const fakeSessions = (
           return found === undefined ? yield* Errors.unknownSession(id) : found;
         });
       return Sessions.Sessions.of({
-        reserve: (body) => record("reserve", body),
+        reserve: (agent) => record("reserve", agent),
         start: (body, display, automation) =>
           record("start", body, display, automation).pipe(Effect.as(STARTED_ID)),
         lookup,

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -756,6 +756,10 @@ export const fakeServerStore = (
         }
       }),
     serverForAgent: (agentId) => Effect.sync(() => Option.fromUndefinedOr(agents.get(agentId))),
+    clearAgent: (agentId) =>
+      Effect.sync(() => {
+        agents.delete(agentId);
+      }),
     ...overrides,
   });
   return {

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -576,6 +576,24 @@ export const fakeAutomationStore = (
           jobs.find((job) => sameId(job.resultId, resultId) && job.status === "running"),
         ),
       ),
+    unclaim: (id) =>
+      Effect.sync(() => {
+        const job = jobs.find((row) => row.id === id && row.status === "running");
+        if (job === undefined) {
+          return false;
+        }
+        job.status = "pending";
+        job.startedAt = null;
+        job.serverId = null;
+        return true;
+      }),
+    assign: (id, serverId) =>
+      Effect.sync(() => {
+        const job = jobs.find((row) => row.id === id && row.status === "running");
+        if (job !== undefined) {
+          job.serverId = serverId;
+        }
+      }),
     finish: (id, status, reason) =>
       Effect.sync(() => {
         const job = jobs.find((row) => row.id === id && row.status === "running");
@@ -656,6 +674,8 @@ export type FakeServerStore = {
   readonly servers: Array<RegisteredServer>;
   // Session id to the url of the server that started it.
   readonly routes: Map<string, string>;
+  // Agent id to the url that reserved a slot for it.
+  readonly agents: Map<string, string>;
   // Every heartbeat written, in order.
   readonly heartbeats: Array<Heartbeat>;
   readonly layer: Layer.Layer<Servers.ServerStore>;
@@ -669,6 +689,7 @@ export const fakeServerStore = (
 ): FakeServerStore => {
   const servers: Array<RegisteredServer> = [];
   const routes = new Map<string, string>();
+  const agents = new Map<string, string>();
   const heartbeats: Array<Heartbeat> = [];
   const indexOf = (url: string) => servers.findIndex((server) => server.url === url);
   const service = Servers.ServerStore.of({
@@ -728,9 +749,22 @@ export const fakeServerStore = (
           }),
     serverForSession: (sessionId) =>
       Effect.sync(() => Option.fromUndefinedOr(routes.get(sessionId))),
+    routeAgent: (agentId, url) =>
+      Effect.sync(() => {
+        if (!agents.has(agentId)) {
+          agents.set(agentId, url);
+        }
+      }),
+    serverForAgent: (agentId) => Effect.sync(() => Option.fromUndefinedOr(agents.get(agentId))),
     ...overrides,
   });
-  return { servers, routes, heartbeats, layer: Layer.succeed(Servers.ServerStore)(service) };
+  return {
+    servers,
+    routes,
+    agents,
+    heartbeats,
+    layer: Layer.succeed(Servers.ServerStore)(service),
+  };
 };
 
 // Every store at once, sharing nothing: the common fixture for handler and command tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Capacity is taken on `POST /reserve` only. `/start` and `/run` consume that reservation and answer 400 without one.

Dispatch order:

1. Automation server claims a job, then `POST`s each live automation-client `/reserve` `{ ticket }`.
2. A client that is full answers **503**; the server tries the next live client.
3. Every client 503 unclaims the job (`pending`, same `created_at`) so queue order is unchanged.
4. Client `/reserve` calls QEMU `/reserve` `{ agent: ticket }` first. An automation client cannot take a `--max-jobs` slot until QEMU is reserved.
5. QEMU **503** becomes client 503, so the server can try the next host. Other QEMU failures are 500 and fail the job.
6. If QEMU reserved and the client itself is then full, the client `POST`s QEMU `/relinquish` `{ agent }` and still answers **503**. Relinquish only frees an unused reservation; after `/start` it is 400 `"no reservation"` and the running session keeps its slot.
7. A second `/reserve` for an id that already holds an unused reservation is **400** `"already reserved"` and is reported to Sentry. That is a broken contract, not an idempotent 200. Overlapping same-id reserves on the reverse proxy are serialized so only one can succeed.
8. Then `POST /run`, which consumes the client reservation and launches OpenCode, which `/start`s QEMU (start consumes the QEMU reservation).

Interactive `./client start` reserves, then starts.

`npm run check:fast`: 56 files, 1052 unit tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a093d3-36fb-717d-b846-c040b9a840c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a093d3-36fb-717d-b846-c040b9a840c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

