### PR TITLE
Dark /servers page with combined job, CPU, and memory graphs

### DIFF
--- a/src/dashboard/query.ts
+++ b/src/dashboard/query.ts
@@ -72,7 +72,7 @@ export type ProcessStat = {
   readonly queriedAt: Date;
 };
 
-// One heartbeat in a name's series. The page draws a bar per sample, oldest on the left.
+// One heartbeat in a name's series. The page draws one sample on the combined graph, oldest on the left.
 export type ProcessSample = {
   readonly jobs: number;
   readonly memoryBytes: number;

--- a/src/dashboard/servers.tsx
+++ b/src/dashboard/servers.tsx
@@ -81,27 +81,89 @@ const Row: FC<{ server: Server }> = ({ server }) => {
 
 const megabytes = (bytes: number): string => (bytes / 1_000_000).toFixed(1);
 
-// One named metric: the current reading in the heading, one bar per sample, oldest on the left.
-const BarGraph: FC<{
-  label: string;
-  current: string;
+const yOf = (value: number, max: number): number => (max === 0 ? 100 : 100 - (value / max) * 100);
+
+// One series as SVG line segments, oldest on the left. A single sample spans the plot so it
+// stays visible; a zero max sits on the baseline rather than inventing a height.
+const SeriesLine: FC<{
+  kind: "jobs" | "cpu";
   values: ReadonlyArray<number>;
   max: number;
-}> = ({ label, current, values, max }) => (
-  <div class="process-graph">
-    <h4>
-      {label} {current}
-    </h4>
-    <div class="process-graph__bars" role="img" aria-label={`${label} ${current}`}>
-      {values.map((value) => (
-        <span
-          class="process-graph__bar"
-          style={{ height: max === 0 ? "0%" : `${String((value / max) * 100)}%` }}
-        ></span>
+}> = ({ kind, values, max }) => {
+  if (values.length === 0) {
+    return null;
+  }
+  if (values.length === 1) {
+    const y = yOf(values[0] ?? 0, max);
+    return (
+      <line
+        class={`process-graph__${kind}`}
+        x1="0"
+        y1={y}
+        x2="100"
+        y2={y}
+        vector-effect="non-scaling-stroke"
+      ></line>
+    );
+  }
+  const last = values.length - 1;
+  return (
+    <>
+      {values.slice(1).map((value, index) => (
+        <line
+          class={`process-graph__${kind}`}
+          x1={(index / last) * 100}
+          y1={yOf(values[index] ?? 0, max)}
+          x2={((index + 1) / last) * 100}
+          y2={yOf(value, max)}
+          vector-effect="non-scaling-stroke"
+        ></line>
       ))}
+    </>
+  );
+};
+
+// Memory as bars, jobs and cpu as lines on the same plot. Each metric scales on its own
+// (cpu against 100 percent, or higher when a sample is), oldest on the left.
+const CombinedGraph: FC<{ series: ProcessSeries }> = ({ series }) => {
+  const jobs = series.samples.map((sample) => sample.jobs);
+  const cpu = series.samples.map((sample) => sample.cpuPercent);
+  const memory = series.samples.map((sample) => sample.memoryBytes);
+  const jobsMax = jobs.reduce((max, value) => (value > max ? value : max), 0);
+  const cpuMax = cpu.reduce((max, value) => (value > max ? value : max), 100);
+  const memoryMax = memory.reduce((max, value) => (value > max ? value : max), 0);
+  const current = `jobs ${String(series.jobs)} · cpu ${percent(series.cpuPercent)} · memory ${megabytes(series.memoryBytes)} MB`;
+  return (
+    <div class="process-graph" role="img" aria-label={current}>
+      <p class="process-graph__legend">
+        <span class="process-graph__jobs">jobs {series.jobs}</span>
+        {" · "}
+        <span class="process-graph__cpu">cpu {percent(series.cpuPercent)}</span>
+        {" · "}
+        <span class="process-graph__memory">memory {megabytes(series.memoryBytes)} MB</span>
+      </p>
+      <div class="process-graph__plot">
+        <div class="process-graph__bars">
+          {memory.map((value) => (
+            <span
+              class="process-graph__bar"
+              style={{ height: memoryMax === 0 ? "0%" : `${String((value / memoryMax) * 100)}%` }}
+            ></span>
+          ))}
+        </div>
+        <svg
+          class="process-graph__lines"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <SeriesLine kind="jobs" values={jobs} max={jobsMax} />
+          <SeriesLine kind="cpu" values={cpu} max={cpuMax} />
+        </svg>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 const ProcessCard: FC<{ series: ProcessSeries }> = ({ series }) => {
   const sinceReport = series.queriedAt.getTime() - series.reportedAt.getTime();
@@ -116,39 +178,14 @@ const ProcessCard: FC<{ series: ProcessSeries }> = ({ series }) => {
           <strong>silent</strong>
         </p>
       ) : (
-        <div class="process-graphs">
-          <BarGraph
-            label="jobs"
-            current={String(series.jobs)}
-            values={series.samples.map((sample) => sample.jobs)}
-            max={series.samples.reduce((max, sample) => (sample.jobs > max ? sample.jobs : max), 0)}
-          />
-          <BarGraph
-            label="cpu"
-            current={percent(series.cpuPercent)}
-            values={series.samples.map((sample) => sample.cpuPercent)}
-            max={series.samples.reduce(
-              (max, sample) => (sample.cpuPercent > max ? sample.cpuPercent : max),
-              100,
-            )}
-          />
-          <BarGraph
-            label="memory"
-            current={`${megabytes(series.memoryBytes)} MB`}
-            values={series.samples.map((sample) => sample.memoryBytes)}
-            max={series.samples.reduce(
-              (max, sample) => (sample.memoryBytes > max ? sample.memoryBytes : max),
-              0,
-            )}
-          />
-        </div>
+        <CombinedGraph series={series} />
       )}
     </article>
   );
 };
 
-// Current process readings as one card per name: jobs, cpu and memory as bar graphs of the
-// series, or the sentence that there are none. What the page polls for.
+// Current process readings as one card per name: one graph of jobs, cpu and memory, or the
+// sentence that there are none. What the page polls for.
 export const Process: FC<{ series: ReadonlyArray<ProcessSeries> }> = ({ series }) =>
   series.length === 0 ? (
     <p>no process stats</p>
@@ -264,11 +301,11 @@ export type Halves = {
   readonly process: ReadonlyArray<ProcessSeries>;
 };
 
-// Text an operator reads at a glance, in two halves side by side: the automation queue, then the
-// qemu fleet with its add box, each swapped in fresh every thirty seconds, and below them the
-// process graphs, one card per named server. The style is the split and the bars. `halves` is
-// absent only when the database could not be read, so a 500 page claims neither an empty queue
-// nor an empty fleet; `error` is the reason a request was refused, on top.
+// Text an operator reads at a glance: the process graphs first, one card per named server, then
+// two halves side by side — the automation queue and the qemu fleet with its add box — each
+// swapped in fresh every thirty seconds. The style is the split and the combined graph. `halves`
+// is absent only when the database could not be read, so a 500 page claims neither an empty
+// queue nor an empty fleet; `error` is the reason a request was refused, on top.
 export const ServersPage: FC<{
   halves: Halves | undefined;
   error: string | undefined;
@@ -279,7 +316,7 @@ export const ServersPage: FC<{
       <title>oligarchy servers</title>
       <style>
         {
-          ".halves { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: start; } .abort { background: none; border: none; padding: 0; cursor: pointer; line-height: 0; vertical-align: middle; } .process-card { display: grid; gap: 0.5rem; margin: 0 0 1.5rem; } .process-card > h3, .process-card > p, .process-graph > h4 { margin: 0; } .process-graphs { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1rem; } .process-graph { display: grid; gap: 0.35rem; } .process-graph__bars { display: flex; align-items: flex-end; gap: 1px; height: 4rem; border-bottom: 1px solid #888; } .process-graph__bar { flex: 1 1 0; min-width: 0; min-height: 0; background: #444; }"
+          ".halves { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: start; } .abort { background: none; border: none; padding: 0; cursor: pointer; line-height: 0; vertical-align: middle; } .process-card { display: grid; gap: 0.5rem; margin: 0 0 1.5rem; } .process-card > h3, .process-card > p { margin: 0; } .process-graph { display: grid; gap: 0.35rem; } .process-graph__legend { margin: 0; } .process-graph__jobs { color: #222; } .process-graph__cpu { color: #06c; } .process-graph__memory { color: #666; } .process-graph__plot { position: relative; height: 8rem; border-bottom: 1px solid #888; } .process-graph__bars { position: absolute; inset: 0; display: flex; align-items: flex-end; gap: 1px; } .process-graph__bar { flex: 1 1 0; min-width: 0; min-height: 0; background: #ccc; } .process-graph__lines { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; } .process-graph__lines .process-graph__jobs, .process-graph__lines .process-graph__cpu { fill: none; stroke-width: 2; } .process-graph__lines .process-graph__jobs { stroke: #222; } .process-graph__lines .process-graph__cpu { stroke: #06c; }"
         }
       </style>
       <script src={HTMX_URL} integrity={HTMX_INTEGRITY} crossorigin="anonymous"></script>
@@ -287,6 +324,14 @@ export const ServersPage: FC<{
     <body>
       <h1>oligarchy servers</h1>
       {error === undefined ? null : <p>error: {error}</p>}
+      <section>
+        <h2>process</h2>
+        {halves === undefined ? null : (
+          <div id="process" hx-get="/servers/process" hx-trigger="every 30s">
+            <Process series={halves.process} />
+          </div>
+        )}
+      </section>
       <div class="halves">
         <section>
           <h2>automation</h2>
@@ -310,14 +355,6 @@ export const ServersPage: FC<{
           </form>
         </section>
       </div>
-      <section>
-        <h2>process</h2>
-        {halves === undefined ? null : (
-          <div id="process" hx-get="/servers/process" hx-trigger="every 30s">
-            <Process series={halves.process} />
-          </div>
-        )}
-      </section>
     </body>
   </html>
 );

--- a/src/dashboard/servers.tsx
+++ b/src/dashboard/servers.tsx
@@ -135,13 +135,6 @@ const CombinedGraph: FC<{ series: ProcessSeries }> = ({ series }) => {
   const current = `jobs ${String(series.jobs)} · cpu ${percent(series.cpuPercent)} · memory ${megabytes(series.memoryBytes)} MB`;
   return (
     <div class="process-graph" role="img" aria-label={current}>
-      <p class="process-graph__legend">
-        <span class="process-graph__jobs">jobs {series.jobs}</span>
-        {" · "}
-        <span class="process-graph__cpu">cpu {percent(series.cpuPercent)}</span>
-        {" · "}
-        <span class="process-graph__memory">memory {megabytes(series.memoryBytes)} MB</span>
-      </p>
       <div class="process-graph__plot">
         <div class="process-graph__bars">
           {memory.map((value) => (
@@ -161,6 +154,11 @@ const CombinedGraph: FC<{ series: ProcessSeries }> = ({ series }) => {
           <SeriesLine kind="cpu" values={cpu} max={cpuMax} />
         </svg>
       </div>
+      <ul class="process-graph__legend">
+        <li class="process-graph__memory">memory {megabytes(series.memoryBytes)} MB</li>
+        <li class="process-graph__jobs">jobs {series.jobs}</li>
+        <li class="process-graph__cpu">cpu {percent(series.cpuPercent)}</li>
+      </ul>
     </div>
   );
 };
@@ -169,10 +167,12 @@ const ProcessCard: FC<{ series: ProcessSeries }> = ({ series }) => {
   const sinceReport = series.queriedAt.getTime() - series.reportedAt.getTime();
   return (
     <article class="process-card">
-      <h3>{series.name}</h3>
-      <p>
-        {series.type} · {age(sinceReport)} ago
-      </p>
+      <header>
+        <h3>{series.name}</h3>
+        <p>
+          {series.type} · {age(sinceReport)} ago
+        </p>
+      </header>
       {sinceReport > SILENT_AFTER_MS ? (
         <p>
           <strong>silent</strong>
@@ -190,11 +190,11 @@ export const Process: FC<{ series: ReadonlyArray<ProcessSeries> }> = ({ series }
   series.length === 0 ? (
     <p>no process stats</p>
   ) : (
-    <>
+    <div class="process-cards">
       {series.map((row) => (
         <ProcessCard series={row} />
       ))}
-    </>
+    </div>
   );
 
 // The fleet as a table, or the sentence that there is none: what the page polls for.
@@ -301,11 +301,12 @@ export type Halves = {
   readonly process: ReadonlyArray<ProcessSeries>;
 };
 
-// Text an operator reads at a glance: the process graphs first, one card per named server, then
-// two halves side by side — the automation queue and the qemu fleet with its add box — each
-// swapped in fresh every thirty seconds. The style is the split and the combined graph. `halves`
-// is absent only when the database could not be read, so a 500 page claims neither an empty
-// queue nor an empty fleet; `error` is the reason a request was refused, on top.
+// Text an operator reads at a glance on a dark page: the process graphs first, one card per
+// named server, then two halves side by side — the automation queue and the qemu fleet with its
+// add box — each swapped in fresh every thirty seconds. The style is the dark split and the
+// combined graph. `halves` is absent only when the database could not be read, so a 500 page
+// claims neither an empty queue nor an empty fleet; `error` is the reason a request was refused,
+// on top.
 export const ServersPage: FC<{
   halves: Halves | undefined;
   error: string | undefined;
@@ -316,7 +317,7 @@ export const ServersPage: FC<{
       <title>oligarchy servers</title>
       <style>
         {
-          ".halves { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: start; } .abort { background: none; border: none; padding: 0; cursor: pointer; line-height: 0; vertical-align: middle; } .process-card { display: grid; gap: 0.5rem; margin: 0 0 1.5rem; } .process-card > h3, .process-card > p { margin: 0; } .process-graph { display: grid; gap: 0.35rem; } .process-graph__legend { margin: 0; } .process-graph__jobs { color: #222; } .process-graph__cpu { color: #06c; } .process-graph__memory { color: #666; } .process-graph__plot { position: relative; height: 8rem; border-bottom: 1px solid #888; } .process-graph__bars { position: absolute; inset: 0; display: flex; align-items: flex-end; gap: 1px; } .process-graph__bar { flex: 1 1 0; min-width: 0; min-height: 0; background: #ccc; } .process-graph__lines { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; } .process-graph__lines .process-graph__jobs, .process-graph__lines .process-graph__cpu { fill: none; stroke-width: 2; } .process-graph__lines .process-graph__jobs { stroke: #222; } .process-graph__lines .process-graph__cpu { stroke: #06c; }"
+          ':root { color-scheme: dark; } body { margin: 24px 32px 40px; font: 16px/1.4 system-ui, sans-serif; color: #e8e6e3; background: #161616; } h1, h2, h3 { color: #fff; } h1 { margin: 0 0 20px; } h2 { margin: 1.25rem 0 12px; } table { border-collapse: collapse; width: 100%; } th, td { text-align: left; padding: 4px 10px 4px 0; vertical-align: top; } th { color: #9a9691; font-weight: 600; } input, button { color: #e8e6e3; background: #1f1f1f; border: 1px solid #2c2c2c; border-radius: 6px; padding: 4px 8px; } button { cursor: pointer; } .halves { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; align-items: start; } .abort { background: none; border: none; padding: 0; cursor: pointer; line-height: 0; vertical-align: middle; } .process-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; } .process-card { display: grid; gap: 10px; background: #1f1f1f; border: 1px solid #2c2c2c; border-radius: 12px; padding: 14px 16px 12px; } .process-card > header { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; } .process-card > header h3, .process-card > header p, .process-card > p { margin: 0; } .process-card > header p { color: #9a9691; font-size: 13px; } .process-graph { display: grid; gap: 10px; } .process-graph__plot { position: relative; height: 10rem; background: #111; border-radius: 8px; overflow: hidden; } .process-graph__plot::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(to top, #2a2a2a 1px, transparent 1px); background-size: 100% 25%; opacity: 0.7; } .process-graph__bars { position: absolute; inset: 10px 10px 8px; display: flex; align-items: flex-end; gap: 2px; } .process-graph__bar { flex: 1 1 0; min-width: 0; min-height: 0; background: #3f3f46; border-radius: 3px 3px 0 0; } .process-graph__lines { position: absolute; inset: 10px 10px 8px; width: calc(100% - 20px); height: calc(100% - 18px); overflow: visible; } .process-graph__lines .process-graph__jobs, .process-graph__lines .process-graph__cpu { fill: none; stroke-width: 2.25; } .process-graph__lines .process-graph__jobs { stroke: #fbbf24; } .process-graph__lines .process-graph__cpu { stroke: #38bdf8; } .process-graph__legend { display: flex; gap: 16px; list-style: none; margin: 0; padding: 0; font-size: 13px; color: #c4c0ba; } .process-graph__legend li::before { content: ""; display: inline-block; width: 12px; height: 8px; margin-right: 6px; vertical-align: middle; border-radius: 1px; } .process-graph__legend .process-graph__memory::before { background: #3f3f46; } .process-graph__legend .process-graph__jobs::before { background: #fbbf24; height: 3px; } .process-graph__legend .process-graph__cpu::before { background: #38bdf8; height: 3px; }'
         }
       </style>
       <script src={HTMX_URL} integrity={HTMX_INTEGRITY} crossorigin="anonymous"></script>

--- a/test/dashboard/servers.unit.test.ts
+++ b/test/dashboard/servers.unit.test.ts
@@ -112,7 +112,9 @@ const processSilent: ProcessSeries = {
 };
 
 const garageGraph =
-  '<div class="process-graph" role="img" aria-label="jobs 2 · cpu 37.5% · memory 512.0 MB"><p class="process-graph__legend"><span class="process-graph__jobs">jobs 2</span> · <span class="process-graph__cpu">cpu 37.5%</span> · <span class="process-graph__memory">memory 512.0 MB</span></p><div class="process-graph__plot"><div class="process-graph__bars"><span class="process-graph__bar" style="height:50%"></span><span class="process-graph__bar" style="height:100%"></span></div><svg class="process-graph__lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><line class="process-graph__jobs" x1="0" y1="50" x2="100" y2="0" vector-effect="non-scaling-stroke"></line><line class="process-graph__cpu" x1="0" y1="90" x2="100" y2="62.5" vector-effect="non-scaling-stroke"></line></svg></div></div>';
+  '<div class="process-graph" role="img" aria-label="jobs 2 · cpu 37.5% · memory 512.0 MB"><div class="process-graph__plot"><div class="process-graph__bars"><span class="process-graph__bar" style="height:50%"></span><span class="process-graph__bar" style="height:100%"></span></div><svg class="process-graph__lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><line class="process-graph__jobs" x1="0" y1="50" x2="100" y2="0" vector-effect="non-scaling-stroke"></line><line class="process-graph__cpu" x1="0" y1="90" x2="100" y2="62.5" vector-effect="non-scaling-stroke"></line></svg></div><ul class="process-graph__legend"><li class="process-graph__memory">memory 512.0 MB</li><li class="process-graph__jobs">jobs 2</li><li class="process-graph__cpu">cpu 37.5%</li></ul></div>';
+
+const garageCard = `<div class="process-cards"><article class="process-card"><header><h3>garage</h3><p>qemu · 12 s ago</p></header>${garageGraph}</article></div>`;
 
 const JOB_COLUMNS =
   "<tr><th>ticket</th><th>test</th><th>action</th><th>status</th><th>queued</th><th>started</th><th>finished</th><th>reason</th><th></th></tr>";
@@ -306,11 +308,9 @@ describe("Queue unhappy path", () => {
 });
 
 describe("Process happy path", () => {
-  it("names a server and draws one graph: memory as bars, jobs and cpu as lines, newest reading on the legend", async () => {
+  it("names a server and draws one dark-well graph: memory as bars, jobs and cpu as lines, newest reading on the legend", async () => {
     const page = await render(Process({ series: [processAlive] }));
-    expect(page).toContain("<h3>garage</h3>");
-    expect(page).toContain("<p>qemu · 12 s ago</p>");
-    expect(page).toContain(garageGraph);
+    expect(page).toBe(garageCard);
     expect(page.match(/class="process-graph"/g)?.length).toBe(1);
     expect(page).not.toContain("<h4>");
     expect(page).not.toContain("<table>");
@@ -357,8 +357,7 @@ describe("Process happy path", () => {
 describe("Process unhappy path", () => {
   it("collapses a silent process's graphs into one word", async () => {
     const page = await render(Process({ series: [processSilent] }));
-    expect(page).toContain("<h3>attic</h3>");
-    expect(page).toContain("<p>automation-client · 5 min ago</p>");
+    expect(page).toContain("<header><h3>attic</h3><p>automation-client · 5 min ago</p></header>");
     expect(page).toContain("<p><strong>silent</strong></p>");
     expect(page).not.toContain("process-graph__bar");
     expect(page).not.toContain("256.0 MB");
@@ -384,9 +383,9 @@ describe("Process unhappy path", () => {
     };
     const page = await render(Process({ series: [idle] }));
     expect(page).toContain('aria-label="jobs 0 · cpu 0.0% · memory 0.0 MB"');
-    expect(page).toContain('<span class="process-graph__jobs">jobs 0</span>');
-    expect(page).toContain('<span class="process-graph__cpu">cpu 0.0%</span>');
-    expect(page).toContain('<span class="process-graph__memory">memory 0.0 MB</span>');
+    expect(page).toContain('<li class="process-graph__memory">memory 0.0 MB</li>');
+    expect(page).toContain('<li class="process-graph__jobs">jobs 0</li>');
+    expect(page).toContain('<li class="process-graph__cpu">cpu 0.0%</li>');
     expect(page.match(/style="height:0%"/g)?.length).toBe(2);
     expect(page).toContain(
       '<line class="process-graph__jobs" x1="0" y1="100" x2="100" y2="100" vector-effect="non-scaling-stroke">',
@@ -408,11 +407,13 @@ describe("ServersPage happy path", () => {
     );
     expect(page).toContain("<title>oligarchy servers</title>");
     expect(page).toContain('<script src="https://cdn.jsdelivr.net/npm/htmx.org@4.0.0"');
+    expect(page).toMatch(/<style>[^<]*body\s*\{[^}]*background:\s*#161616/);
+    expect(page).toMatch(/<style>[^<]*\.process-cards\s*\{[^}]*grid-template-columns:\s*1fr 1fr/);
     expect(page).toMatch(/<style>[^<]*\.halves\s*\{[^}]*grid-template-columns:\s*1fr 1fr/);
     expect(page).toMatch(/<style>[^<]*\.abort\s*\{[^}]*background:\s*none/);
     expect(page).toContain("<h1>oligarchy servers</h1>");
     expect(page).toContain(
-      '<section><h2>process</h2><div id="process" hx-get="/servers/process" hx-trigger="every 30s"><article class="process-card"><h3>garage</h3>',
+      `<section><h2>process</h2><div id="process" hx-get="/servers/process" hx-trigger="every 30s">${garageCard}`,
     );
     expect(page).toContain(garageGraph);
     expect(page).toContain(

--- a/test/dashboard/servers.unit.test.ts
+++ b/test/dashboard/servers.unit.test.ts
@@ -111,14 +111,8 @@ const processSilent: ProcessSeries = {
   samples: [{ jobs: 1, memoryBytes: 256_000_000, cpuPercent: 8, reportedAt: ago(5 * 60 + 12) }],
 };
 
-const jobsBars =
-  '<div class="process-graph__bars" role="img" aria-label="jobs 2"><span class="process-graph__bar" style="height:50%"></span><span class="process-graph__bar" style="height:100%"></span></div>';
-
-const cpuBars =
-  '<div class="process-graph__bars" role="img" aria-label="cpu 37.5%"><span class="process-graph__bar" style="height:10%"></span><span class="process-graph__bar" style="height:37.5%"></span></div>';
-
-const memoryBars =
-  '<div class="process-graph__bars" role="img" aria-label="memory 512.0 MB"><span class="process-graph__bar" style="height:50%"></span><span class="process-graph__bar" style="height:100%"></span></div>';
+const garageGraph =
+  '<div class="process-graph" role="img" aria-label="jobs 2 · cpu 37.5% · memory 512.0 MB"><p class="process-graph__legend"><span class="process-graph__jobs">jobs 2</span> · <span class="process-graph__cpu">cpu 37.5%</span> · <span class="process-graph__memory">memory 512.0 MB</span></p><div class="process-graph__plot"><div class="process-graph__bars"><span class="process-graph__bar" style="height:50%"></span><span class="process-graph__bar" style="height:100%"></span></div><svg class="process-graph__lines" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><line class="process-graph__jobs" x1="0" y1="50" x2="100" y2="0" vector-effect="non-scaling-stroke"></line><line class="process-graph__cpu" x1="0" y1="90" x2="100" y2="62.5" vector-effect="non-scaling-stroke"></line></svg></div></div>';
 
 const JOB_COLUMNS =
   "<tr><th>ticket</th><th>test</th><th>action</th><th>status</th><th>queued</th><th>started</th><th>finished</th><th>reason</th><th></th></tr>";
@@ -312,13 +306,13 @@ describe("Queue unhappy path", () => {
 });
 
 describe("Process happy path", () => {
-  it("names a server and draws jobs, cpu and memory bar graphs of its series, newest reading on the labels", async () => {
+  it("names a server and draws one graph: memory as bars, jobs and cpu as lines, newest reading on the legend", async () => {
     const page = await render(Process({ series: [processAlive] }));
     expect(page).toContain("<h3>garage</h3>");
     expect(page).toContain("<p>qemu · 12 s ago</p>");
-    expect(page).toContain(`<h4>jobs 2</h4>${jobsBars}`);
-    expect(page).toContain(`<h4>cpu 37.5%</h4>${cpuBars}`);
-    expect(page).toContain(`<h4>memory 512.0 MB</h4>${memoryBars}`);
+    expect(page).toContain(garageGraph);
+    expect(page.match(/class="process-graph"/g)?.length).toBe(1);
+    expect(page).not.toContain("<h4>");
     expect(page).not.toContain("<table>");
   });
 
@@ -327,7 +321,7 @@ describe("Process happy path", () => {
     expect(page).toBe("<p>no process stats</p>");
   });
 
-  it("scales cpu against 100 percent so a quiet host is a short bar, and above 100 when a sample is", async () => {
+  it("scales cpu against 100 percent so a quiet host is a low line, and above 100 when a sample is", async () => {
     const over: ProcessSeries = {
       ...processAlive,
       cpuPercent: 150,
@@ -337,9 +331,26 @@ describe("Process happy path", () => {
       ],
     };
     const page = await render(Process({ series: [over] }));
-    expect(page).toContain('aria-label="cpu 150.0%"');
-    expect(page).toContain('style="height:50%"');
-    expect(page).toContain('style="height:100%"');
+    expect(page).toContain('aria-label="jobs 2 · cpu 150.0% · memory 512.0 MB"');
+    expect(page).toContain(
+      '<line class="process-graph__cpu" x1="0" y1="50" x2="100" y2="0" vector-effect="non-scaling-stroke">',
+    );
+  });
+
+  it("draws a single sample as a horizontal line across the plot so the reading is still visible", async () => {
+    const one: ProcessSeries = {
+      ...processAlive,
+      samples: [{ jobs: 2, memoryBytes: 512_000_000, cpuPercent: 37.5, reportedAt: ago(12) }],
+    };
+    const page = await render(Process({ series: [one] }));
+    expect(page).toContain(
+      '<line class="process-graph__jobs" x1="0" y1="0" x2="100" y2="0" vector-effect="non-scaling-stroke">',
+    );
+    expect(page).toContain(
+      '<line class="process-graph__cpu" x1="0" y1="62.5" x2="100" y2="62.5" vector-effect="non-scaling-stroke">',
+    );
+    expect(page).toContain('<span class="process-graph__bar" style="height:100%"></span>');
+    expect(page.match(/class="process-graph__bar"/g)?.length).toBe(1);
   });
 });
 
@@ -372,17 +383,23 @@ describe("Process unhappy path", () => {
       ],
     };
     const page = await render(Process({ series: [idle] }));
-    expect(page).toContain("<h4>jobs 0</h4>");
-    expect(page).toContain("<h4>cpu 0.0%</h4>");
-    expect(page).toContain("<h4>memory 0.0 MB</h4>");
-    expect(page).toContain('aria-label="jobs 0"');
-    expect(page.match(/style="height:0%"/g)?.length).toBe(6);
+    expect(page).toContain('aria-label="jobs 0 · cpu 0.0% · memory 0.0 MB"');
+    expect(page).toContain('<span class="process-graph__jobs">jobs 0</span>');
+    expect(page).toContain('<span class="process-graph__cpu">cpu 0.0%</span>');
+    expect(page).toContain('<span class="process-graph__memory">memory 0.0 MB</span>');
+    expect(page.match(/style="height:0%"/g)?.length).toBe(2);
+    expect(page).toContain(
+      '<line class="process-graph__jobs" x1="0" y1="100" x2="100" y2="100" vector-effect="non-scaling-stroke">',
+    );
+    expect(page).toContain(
+      '<line class="process-graph__cpu" x1="0" y1="100" x2="100" y2="100" vector-effect="non-scaling-stroke">',
+    );
     expect(page).not.toContain('style="height:100%"');
   });
 });
 
 describe("ServersPage happy path", () => {
-  it("is split in two halves side by side: the automation queue first, the qemu fleet with its add box second, each polled every thirty seconds", async () => {
+  it("puts the process graphs first, then two halves side by side: the automation queue, the qemu fleet with its add box, each polled every thirty seconds", async () => {
     const page = await render(
       ServersPage({
         halves: { queue: QUEUE, servers: [alive, neverHeardFrom], process: [processAlive] },
@@ -394,6 +411,10 @@ describe("ServersPage happy path", () => {
     expect(page).toMatch(/<style>[^<]*\.halves\s*\{[^}]*grid-template-columns:\s*1fr 1fr/);
     expect(page).toMatch(/<style>[^<]*\.abort\s*\{[^}]*background:\s*none/);
     expect(page).toContain("<h1>oligarchy servers</h1>");
+    expect(page).toContain(
+      '<section><h2>process</h2><div id="process" hx-get="/servers/process" hx-trigger="every 30s"><article class="process-card"><h3>garage</h3>',
+    );
+    expect(page).toContain(garageGraph);
     expect(page).toContain(
       '<div class="halves"><section><h2>automation</h2><div id="queue" hx-get="/servers/queue" hx-trigger="every 30s"><h3>running</h3>',
     );
@@ -407,17 +428,14 @@ describe("ServersPage happy path", () => {
     expect(page).toContain(
       '<form method="post" action="/servers"><input name="url" size="60" placeholder="https://qemu.example.com"/><button>add</button></form>',
     );
+    expect(page.indexOf("<h2>process</h2>")).toBeLessThan(page.indexOf("<h2>automation</h2>"));
     expect(page.indexOf("<h2>automation</h2>")).toBeLessThan(page.indexOf("<h2>qemu servers</h2>"));
     expect(page.indexOf("<h2>qemu servers</h2>")).toBeLessThan(
       page.indexOf("<h2>add a server</h2>"),
     );
-    expect(page).toContain(
-      '<section><h2>process</h2><div id="process" hx-get="/servers/process" hx-trigger="every 30s"><article class="process-card"><h3>garage</h3>',
-    );
-    expect(page).toContain("<h4>cpu 37.5%</h4>");
     expect(page).toMatch(/<style>[^<]*\.process-card/);
+    expect(page).toMatch(/<style>[^<]*\.process-graph__plot/);
     expect(page).toMatch(/<style>[^<]*\.process-graph__bar/);
-    expect(page.indexOf("<h2>add a server</h2>")).toBeLessThan(page.indexOf("<h2>process</h2>"));
     expect(page).not.toContain("<h2>servers</h2>");
     expect(page).not.toContain("error:");
   });

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -1017,16 +1017,18 @@ describe.skipIf(dbUrl === "")("dashboard/servers page happy path", () => {
     );
     expect(html).toContain('<div id="process" hx-get="/servers/process" hx-trigger="every 30s">');
     expect(html).toContain("<h3>garage</h3>");
-    expect(html).toContain("<h4>jobs 2</h4>");
-    expect(html).toContain("<h4>cpu 37.5%</h4>");
-    expect(html).toContain("<h4>memory 512.0 MB</h4>");
-    expect(html).toContain('aria-label="jobs 2"');
+    expect(html).toContain('aria-label="jobs 2 · cpu 37.5% · memory 512.0 MB"');
+    expect(html).toContain('<span class="process-graph__jobs">jobs 2</span>');
+    expect(html).toContain('<span class="process-graph__cpu">cpu 37.5%</span>');
+    expect(html).toContain('<span class="process-graph__memory">memory 512.0 MB</span>');
+    expect(html).toContain('class="process-graph__jobs"');
+    expect(html).toContain('class="process-graph__cpu"');
+    expect(html).toContain("process-graph__bar");
+    expect(html.indexOf("<h2>process</h2>")).toBeLessThan(html.indexOf("<h2>automation</h2>"));
     expect(html).toContain("<h3>attic</h3>");
     expect(html).toContain("<p><strong>silent</strong></p>");
     expect(html).toContain("<h3>workshop</h3>");
-    expect(html).toContain("<h4>jobs 1</h4>");
-    expect(html).toContain("<h4>cpu 8.0%</h4>");
-    expect(html).toContain("<h4>memory 128.0 MB</h4>");
+    expect(html).toContain('aria-label="jobs 1 · cpu 8.0% · memory 128.0 MB"');
     expect(html).not.toContain("dashboard.css");
   });
 
@@ -1051,8 +1053,10 @@ describe.skipIf(dbUrl === "")("dashboard/servers page happy path", () => {
     expect(status).toBe(200);
     expect(html).toContain('<article class="process-card">');
     expect(html).toContain("<h3>garage</h3>");
-    expect(html).toContain("<h4>cpu 37.5%</h4>");
+    expect(html).toContain('aria-label="jobs 2 · cpu 37.5% · memory 512.0 MB"');
     expect(html).toContain("process-graph__bar");
+    expect(html).toContain('class="process-graph__jobs"');
+    expect(html).toContain('class="process-graph__cpu"');
     expect(html).not.toContain("<table>");
     expect(html).not.toContain("<html");
     expect(html).not.toContain("add a server");

--- a/test/integration/dashboard.integration.test.ts
+++ b/test/integration/dashboard.integration.test.ts
@@ -1018,9 +1018,11 @@ describe.skipIf(dbUrl === "")("dashboard/servers page happy path", () => {
     expect(html).toContain('<div id="process" hx-get="/servers/process" hx-trigger="every 30s">');
     expect(html).toContain("<h3>garage</h3>");
     expect(html).toContain('aria-label="jobs 2 · cpu 37.5% · memory 512.0 MB"');
-    expect(html).toContain('<span class="process-graph__jobs">jobs 2</span>');
-    expect(html).toContain('<span class="process-graph__cpu">cpu 37.5%</span>');
-    expect(html).toContain('<span class="process-graph__memory">memory 512.0 MB</span>');
+    expect(html).toContain('<li class="process-graph__memory">memory 512.0 MB</li>');
+    expect(html).toContain('<li class="process-graph__jobs">jobs 2</li>');
+    expect(html).toContain('<li class="process-graph__cpu">cpu 37.5%</li>');
+    expect(html).toContain('class="process-cards"');
+    expect(html).toMatch(/body\s*\{[^}]*background:\s*#161616/);
     expect(html).toContain('class="process-graph__jobs"');
     expect(html).toContain('class="process-graph__cpu"');
     expect(html).toContain("process-graph__bar");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The whole `/servers` page is dark. Process cards sit at the top in a two-column grid, still polled every 30 seconds. Each named host is one graph:

- **memory** — process RSS as bars
- **jobs** — active jobs as a gold line
- **cpu** — process CPU as a cyan line (scaled to 100%, or higher if a sample exceeds it)

A silent host still collapses to one word. An empty list still says there are no process stats.

`process_stats` already kept older readings for this graph. The page reads that series (last 60 samples, and only rows from the last 30 minutes) instead of only the newest row.

[Dark servers page with combined graphs](https://cursor.com/agents/bc-01a09692-d4f4-7c9a-ad86-af118d79a2d2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdark_servers_page.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09692-d4f4-7c9a-ad86-af118d79a2d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09692-d4f4-7c9a-ad86-af118d79a2d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

