### PR TITLE
Dispatch every pending job a client will reserve

### DIFF
--- a/.cursor/skills/oligarchy-super-run/SKILL.md
+++ b/.cursor/skills/oligarchy-super-run/SKILL.md
@@ -131,7 +131,7 @@ psql "$DBURL" -X -c "select name, type, url, heartbeat_at from servers where hea
 
 Expect `qemu-server-4` / `qemu-server-3` (`qemu`) and `automation-client-5` / `automation-client-3` (`automation-client`).
 
-`N` is monotonic (`/tmp/superrun/next`). Never take N from `active`. Target: `counted + active == 100` after replacing every INFRA. Dispatch is 1-wide: keep at most **2** drive jobs in `running`+`pending` (backlog, not a capacity test). `new.sh` exit 2 = no drive webhook — pause refill.
+`N` is monotonic (`/tmp/superrun/next`). Never take N from `active`. Target: `counted + active == 100` after replacing every INFRA. Dispatch fills every slot a live client will reserve; keep enough pending drives that `--max-jobs` is exercised. `new.sh` exit 2 = no drive webhook — pause refill.
 
 ```bash
 /tmp/superrun/new.sh muse

--- a/.cursor/skills/oligarchy-super-run/SKILL.md
+++ b/.cursor/skills/oligarchy-super-run/SKILL.md
@@ -14,8 +14,8 @@ description: >-
 Process **100 COUNTED** lock-screen runs through drive + diagnose. INFRA
 attempts are recorded and replaced; they do not count. After the batch:
 report stability, whether the paid model landed on every result/diagnosis,
-and whether `--max-jobs` was actually exercised (current automation-server
-claims **one** job at a time, so 4/3 qemu and 5/3 client caps will not be).
+and whether `--max-jobs` was actually exercised (dispatch claims every
+pending job a live client will reserve; qemu 4/3 and client 5/3 are the caps).
 </Goal>
 <WriteableFiles>
 | File | What goes here |
@@ -77,7 +77,7 @@ sh .cursor/skills/oligarchy-super-run/scripts/install.sh
 . /tmp/superrun/env
 ```
 
-Start **six** processes. `./qemu-server` and `./automation-client` require `--name` and `--max-jobs`. Announce with `--url` on `http://127.0.0.1:…` (these binaries bind `127.0.0.1`; `localhost` can be `::1`). `--name` is unique on `servers`. Clients reserve guests through the proxy: `SERVER_URL=http://127.0.0.1:55555`. Omit it and they call `:42069`. `./automation-server` has no `--jobs` (one claim at a time) and defaults to **free** Muse — always pass the paid model.
+Start **six** processes. `./qemu-server` and `./automation-client` require `--name` and `--max-jobs`. Announce with `--url` on `http://127.0.0.1:…` (these binaries bind `127.0.0.1`; `localhost` can be `::1`). `--name` is unique on `servers`. Clients reserve guests through the proxy: `SERVER_URL=http://127.0.0.1:55555`. Omit it and they call `:42069`. `./automation-server` has no `--jobs` (it fills from client reserve) and defaults to **free** Muse — always pass the paid model.
 
 ```bash
 P=automation-super-run-logs/processes

--- a/.cursor/skills/oligarchy-super-run/reference.md
+++ b/.cursor/skills/oligarchy-super-run/reference.md
@@ -96,8 +96,7 @@ Cloudflare tunnel in front of `:55555` is not started by this skill.
 `--name` is unique on `servers`. `--url` is the upsert key and how they
 announce. Proxy and `./automation-server` have neither flag.
 
-`./automation-server --help` has `--port` and `--model` only. Dispatch is
-**one job at a time**. `--max-jobs` on qemu/client is the reserve cap, not
-how many the server claims. This skill cannot verify 4/3 or 5/3 under
-load. Default `--model` is the free Muse; this skill passes paid
-`openrouter/meta/muse-spark-1.3-contributor`.
+`./automation-server --help` has `--port` and `--model` only. Dispatch
+claims every pending job a live client will reserve. `--max-jobs` on
+qemu/client is the reserve cap. Default `--model` is the free Muse; this
+skill passes paid `openrouter/meta/muse-spark-1.3-contributor`.

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Option, Result, Schedule, Schema } from "effect";
+import { Cause, Effect, Option, Result, Schedule, Schema, Scope } from "effect";
 import * as Automation from "../db/automation.ts";
 import * as Servers from "../db/servers.ts";
 import * as Tests from "../db/tests.ts";
@@ -153,6 +153,7 @@ export const dispatch = Effect.fn("dispatch")(function* (model: string) {
   const servers = yield* Servers.ServerStore;
   const store = yield* Automation.AutomationStore;
   const log = yield* Log.Log;
+  const work = yield* Scope.Scope;
 
   const tick = Effect.fn("tick")(function* () {
     const live = yield* servers.listLiveServers("automation-client");
@@ -202,15 +203,32 @@ export const dispatch = Effect.fn("dispatch")(function* (model: string) {
             }
             continue;
           }
-          yield* restore(
-            perform(job, placed.placement, model).pipe(
-              Effect.matchCause({
-                onSuccess: (): Outcome => ({ status: "succeeded", reason: null }),
-                onFailure: outcomeFrom,
-              }),
-              Effect.flatMap((outcome) => Effect.uninterruptible(closeJob(job, outcome))),
+          // /run lives on the dispatch scope so a shutdown interrupts every in-flight
+          // job, and this tick can reserve the next pending row without waiting.
+          // Do not startImmediately: forkIn adds the interrupt finalizer only after
+          // that evaluate returns, and /run parks on the HTTP wait.
+          yield* Effect.forkIn(
+            Effect.uninterruptibleMask((release) =>
+              release(perform(job, placed.placement, model)).pipe(
+                Effect.matchCause({
+                  onSuccess: (): Outcome => ({ status: "succeeded", reason: null }),
+                  onFailure: outcomeFrom,
+                }),
+                Effect.flatMap((outcome) => closeJob(job, outcome)),
+                Effect.catchCause((cause) => {
+                  if (Cause.hasInterruptsOnly(cause)) {
+                    return Effect.void;
+                  }
+                  const error = Cause.squash(cause);
+                  return log.error(`dispatch job failed: ${detail(error)}`, {
+                    location: Log.Locations.automation,
+                    cause: error,
+                  });
+                }),
+              ),
             ),
-          ).pipe(Effect.forkScoped({ startImmediately: true }));
+            work,
+          );
         }
       }),
     );

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -34,7 +34,15 @@ const outcomeFrom = (cause: Cause.Cause<unknown>): Outcome =>
     ? aborted
     : { status: "failed", reason: Render.errorDetail(Cause.squash(cause)) };
 
-const execute = Effect.fn("execute")(function* (
+type Placement = {
+  readonly url: string;
+  readonly prompt: string;
+  readonly ticket: string;
+};
+
+// Build the prompt and take a client slot. /run is not waited here: a reserved job
+// starts in its own fiber so the next pending row can reserve on this tick.
+const place = Effect.fn("place")(function* (
   job: Automation.AutomationJobRow,
   clients: ReadonlyArray<Servers.LiveServer>,
   model: string,
@@ -62,25 +70,8 @@ const execute = Effect.fn("execute")(function* (
         location: Log.Locations.automation,
         agentId: ticket,
       });
-      yield* AutomationClient.run(client.url, prompt, ticket, model);
-      // A diagnose is judged by nothing here: the result was closed before it was queued.
-      if (job.action === "diagnose") {
-        return yield* Effect.void;
-      }
-      // A driver's last act is ./ctrl test-results; opencode exiting 0 with the result still open
-      // is an agent that quit early, and the job says so rather than reading as a run.
-      const after = yield* tests.findResult(job.resultId);
-      if (Option.isNone(after)) {
-        return yield* Effect.die(
-          new Error(`execute: result ${job.resultId} vanished during the drive`),
-        );
-      }
-      if (after.value.status === "pending" || after.value.status === "running") {
-        return yield* Errors.AutomationClientError.make({
-          message: `driver exited; result ${job.resultId} is ${after.value.status}`,
-        });
-      }
-      return yield* Effect.void;
+      const placement: Placement = { url: client.url, prompt, ticket };
+      return placement;
     }
     if (reserved.failure.status === 503) {
       lastCapacity = reserved.failure.message;
@@ -92,6 +83,33 @@ const execute = Effect.fn("execute")(function* (
     message: lastCapacity ?? "at capacity",
     agentId: ticket,
   });
+});
+
+const perform = Effect.fn("perform")(function* (
+  job: Automation.AutomationJobRow,
+  placement: Placement,
+  model: string,
+) {
+  const tests = yield* Tests.TestStore;
+  yield* AutomationClient.run(placement.url, placement.prompt, placement.ticket, model);
+  // A diagnose is judged by nothing here: the result was closed before it was queued.
+  if (job.action === "diagnose") {
+    return yield* Effect.void;
+  }
+  // A driver's last act is ./ctrl test-results; opencode exiting 0 with the result still open
+  // is an agent that quit early, and the job says so rather than reading as a run.
+  const after = yield* tests.findResult(job.resultId);
+  if (Option.isNone(after)) {
+    return yield* Effect.die(
+      new Error(`perform: result ${job.resultId} vanished during the drive`),
+    );
+  }
+  if (after.value.status === "pending" || after.value.status === "running") {
+    return yield* Errors.AutomationClientError.make({
+      message: `driver exited; result ${job.resultId} is ${after.value.status}`,
+    });
+  }
+  return yield* Effect.void;
 });
 
 const logOutcome = Effect.fn("logOutcome")(function* (
@@ -111,11 +129,26 @@ const logOutcome = Effect.fn("logOutcome")(function* (
   yield* log.error(`${job.action} failed; ${outcome.reason}`, attr);
 });
 
-// One job at a time, every one run as `model`. A tick with no live client does not claim.
-// Reserve runs against every live client; a 503 from all of them puts the row back to pending so
-// the queue is unchanged. Claim is uninterruptible so a shutdown cannot leave a pending row
-// half-taken; the HTTP wait is restored so SIGTERM aborts an in-flight job; finish and unclaim
-// are uninterruptible so the write lands. A tick that fails is one error line; the next tick runs.
+const closeJob = Effect.fn("closeJob")(function* (
+  job: Automation.AutomationJobRow,
+  outcome: Outcome,
+) {
+  const store = yield* Automation.AutomationStore;
+  const closed = yield* store.finish(job.id, outcome.status, outcome.reason);
+  // abort may have closed the row first
+  if (closed) {
+    yield* logOutcome(job, outcome);
+  }
+});
+
+// Pending jobs are claimed and reserved on this tick until a client accepts none of
+// them. A successful reserve starts /run in its own fiber so the next pending job can
+// reserve without waiting. Every job runs as `model`. A tick with no live client does
+// not claim. A 503 from every client puts that row back to pending so the queue is
+// unchanged. Claim is uninterruptible so a shutdown cannot leave a pending row
+// half-taken; the HTTP wait is restored so SIGTERM aborts an in-flight job; finish and
+// unclaim are uninterruptible so the write lands. A tick that fails is one error line;
+// the next tick runs.
 export const dispatch = Effect.fn("dispatch")(function* (model: string) {
   const servers = yield* Servers.ServerStore;
   const store = yield* Automation.AutomationStore;
@@ -128,54 +161,58 @@ export const dispatch = Effect.fn("dispatch")(function* (model: string) {
       return;
     }
     yield* Effect.uninterruptibleMask((restore) =>
-      store.claim(chosen.id).pipe(
-        Effect.flatMap((maybe) => {
+      Effect.gen(function* () {
+        for (;;) {
+          const maybe = yield* store.claim(chosen.id);
           if (Option.isNone(maybe)) {
-            return Effect.void;
+            return;
           }
           const job = maybe.value;
-          return restore(execute(job, live, model)).pipe(
+          const placed = yield* restore(place(job, live, model)).pipe(
             Effect.matchCause({
-              onSuccess: (): Outcome | { readonly deferred: true; readonly agentId?: string } => ({
-                status: "succeeded",
-                reason: null,
-              }),
-              onFailure: (
-                cause,
-              ): Outcome | { readonly deferred: true; readonly agentId?: string } => {
+              onSuccess: (placement) => ({ _tag: "placed" as const, placement }),
+              onFailure: (cause) => {
                 const error = Cause.squash(cause);
                 return isAtCapacity(error)
                   ? Object.assign(
-                      { deferred: true as const },
+                      { _tag: "deferred" as const },
                       error.agentId === undefined ? undefined : { agentId: error.agentId },
                     )
-                  : outcomeFrom(cause);
+                  : { _tag: "closed" as const, outcome: outcomeFrom(cause) };
               },
             }),
-            Effect.flatMap((outcome) =>
-              Effect.gen(function* () {
-                if ("deferred" in outcome) {
-                  const restored = yield* store.unclaim(job.id);
-                  if (restored) {
-                    yield* log.info(
-                      "deferred; at capacity",
-                      outcome.agentId === undefined
-                        ? { location: Log.Locations.automation }
-                        : { location: Log.Locations.automation, agentId: outcome.agentId },
-                    );
-                  }
-                  return;
-                }
-                const closed = yield* store.finish(job.id, outcome.status, outcome.reason);
-                // abort may have closed the row first
-                if (closed) {
-                  yield* logOutcome(job, outcome);
-                }
-              }),
-            ),
           );
-        }),
-      ),
+          if (placed._tag === "deferred") {
+            const restored = yield* store.unclaim(job.id);
+            if (restored) {
+              yield* log.info(
+                "deferred; at capacity",
+                placed.agentId === undefined
+                  ? { location: Log.Locations.automation }
+                  : { location: Log.Locations.automation, agentId: placed.agentId },
+              );
+            }
+            return;
+          }
+          if (placed._tag === "closed") {
+            yield* closeJob(job, placed.outcome);
+            // An interrupt is a shutdown: do not claim the next pending row.
+            if (placed.outcome.status === "aborted") {
+              return;
+            }
+            continue;
+          }
+          yield* restore(
+            perform(job, placed.placement, model).pipe(
+              Effect.matchCause({
+                onSuccess: (): Outcome => ({ status: "succeeded", reason: null }),
+                onFailure: outcomeFrom,
+              }),
+              Effect.flatMap((outcome) => Effect.uninterruptible(closeJob(job, outcome))),
+            ),
+          ).pipe(Effect.forkScoped({ startImmediately: true }));
+        }
+      }),
     );
   });
 

--- a/src/db/automation.ts
+++ b/src/db/automation.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, notInArray, sql } from "drizzle-orm";
 import { Array as Arr, Context, Effect, Layer, Option } from "effect";
 import * as Client from "./client.ts";
 import * as DbSchema from "./schema.ts";
@@ -47,17 +47,33 @@ export class AutomationStore extends Context.Service<AutomationStore>()(
         return row;
       });
 
-      // Oldest pending, locked for the transaction so a second claimer waits. Queue order is
-      // created_at; id breaks a tie. serverId is the client that took it: /abort looks that
-      // server up for its url.
+      // Oldest pending whose result is not already running, locked for the
+      // transaction so a second claimer waits. Queue order is created_at; id
+      // breaks a tie. One running job per result: drive and diagnose share a
+      // ticket, and the client will not reserve it twice. serverId is the
+      // client that took it: /abort looks that server up for its url.
       const claim = Effect.fn("db.claimAutomationJob")(function* (serverId: string) {
         return yield* database.transaction("claimAutomationJob", (tx) =>
           Effect.gen(function* () {
+            const running = yield* Client.attempt("claimAutomationJob", () =>
+              tx
+                .select({ resultId: DbSchema.automationJobs.resultId })
+                .from(DbSchema.automationJobs)
+                .where(eq(DbSchema.automationJobs.status, "running")),
+            );
+            const busy = running.map((row) => row.resultId);
             const pending = yield* Client.attempt("claimAutomationJob", () =>
               tx
                 .select()
                 .from(DbSchema.automationJobs)
-                .where(eq(DbSchema.automationJobs.status, "pending"))
+                .where(
+                  busy.length === 0
+                    ? eq(DbSchema.automationJobs.status, "pending")
+                    : and(
+                        eq(DbSchema.automationJobs.status, "pending"),
+                        notInArray(DbSchema.automationJobs.resultId, busy),
+                      ),
+                )
                 .orderBy(DbSchema.automationJobs.createdAt, DbSchema.automationJobs.id)
                 .limit(1)
                 .for("update"),

--- a/test/automation-server/command.unit.test.ts
+++ b/test/automation-server/command.unit.test.ts
@@ -105,6 +105,7 @@ describe("automation server command flags", () => {
       expect(stdout.join("\n")).toContain("--port");
       expect(stdout.join("\n")).toContain("--model");
       expect(stdout.join("\n")).not.toContain("--jobs");
+      expect(stdout.join("\n")).not.toContain("--max-jobs");
       expect(stdout.join("\n")).not.toContain("--diagnostics-port");
       expect(stdout.join("\n")).not.toContain("--display");
     }),

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -13,7 +13,9 @@ import * as Stores from "../support/stores.ts";
 const URL = "http://127.0.0.1:55333";
 const TOKEN = "test-token";
 const TICKET = "OLI-42";
+const TICKET_B = "OLI-43";
 const RESULT_ID = "22222222-2222-4222-8222-222222222222";
+const RESULT_B = "33333333-3333-4333-8333-333333333333";
 const RUN_ID = "11111111-1111-4111-8111-111111111111";
 const MODEL = "opencode/muse-spark-1.3-contributor-free";
 const STATS = {
@@ -49,9 +51,10 @@ const seedResult = (
   tests: Stores.FakeTestStore,
   linearId: string | null = TICKET,
   status: ResultStatus = "pending",
+  resultId = RESULT_ID,
 ) => {
   tests.results.push({
-    id: RESULT_ID,
+    id: resultId,
     runId: RUN_ID,
     definitionId: 1,
     sessionId: null,
@@ -158,6 +161,24 @@ const settle = (jobs: Array<{ status: string }>, status: string) =>
     return yield* Effect.die(`job did not become ${status}: ${JSON.stringify(jobs)}`);
   });
 
+const settleAll = (jobs: Array<{ status: string }>, status: string) =>
+  Effect.gen(function* () {
+    for (let i = 0; i < 1_000; i++) {
+      if (jobs.length > 0 && jobs.every((job) => job.status === status)) {
+        return yield* Effect.void;
+      }
+      yield* Effect.yieldNow;
+    }
+    return yield* Effect.die(`jobs did not all become ${status}: ${JSON.stringify(jobs)}`);
+  });
+
+const seedPair = (fixed: Harness) => {
+  seedResult(fixed.tests);
+  seedResult(fixed.tests, TICKET_B, "pending", RESULT_B);
+  seedJob(fixed.automation, "drive", RESULT_ID);
+  seedJob(fixed.automation, "drive", RESULT_B);
+};
+
 describe("dispatch happy path", () => {
   it.effect("claims the job before POST /run", () =>
     Effect.gen(function* () {
@@ -252,21 +273,60 @@ describe("dispatch happy path", () => {
     }),
   );
 
-  it.effect("the next pending job runs after five seconds", () =>
+  it.effect("pending jobs whose reserve succeeds start together on the same tick", () =>
     Effect.gen(function* () {
       const fixed = harness();
-      seedResult(fixed.tests);
-      seedJob(fixed.automation, "drive");
-      seedJob(fixed.automation, "diagnose");
+      seedPair(fixed);
       seedLiveClient(fixed.servers);
       const http = FakeHttp.recordRequests(reserving(() => closing(fixed.tests)));
       yield* start(fixed, http.layer);
-      yield* settle(fixed.automation.jobs, "succeeded");
-      expect(fixed.automation.jobs.map((job) => job.status)).toEqual(["succeeded", "pending"]);
-      yield* TestClock.adjust("5 seconds");
-      yield* settle(fixed.automation.jobs, "succeeded");
+      yield* settleAll(fixed.automation.jobs, "succeeded");
       expect(fixed.automation.jobs.every((job) => job.status === "succeeded")).toBe(true);
+      expect(http.requests.filter((request) => request.url.endsWith("/reserve"))).toHaveLength(2);
       expect(http.requests.filter((request) => request.url.endsWith("/run"))).toHaveLength(2);
+      expect(FakeLog.texts(fixed.log).filter((text) => text.startsWith("dispatching drive"))).toEqual(
+        [`dispatching drive; ${URL}; ${MODEL}`, `dispatching drive; ${URL}; ${MODEL}`],
+      );
+    }),
+  );
+
+  it.effect("a /run still in flight does not hold the next pending job", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedPair(fixed);
+      seedLiveClient(fixed.servers);
+      const firstStarted = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<void>();
+      const firstRelease = yield* Deferred.make<void>();
+      const secondRelease = yield* Deferred.make<void>();
+      let runs = 0;
+      const http = FakeHttp.recordRequests(
+        reserving(() =>
+          Effect.gen(function* () {
+            const index = runs;
+            runs += 1;
+            if (index === 0) {
+              yield* Deferred.succeed(firstStarted, undefined);
+              yield* Deferred.await(firstRelease);
+            } else if (index === 1) {
+              yield* Deferred.succeed(secondStarted, undefined);
+              yield* Deferred.await(secondRelease);
+            } else {
+              return yield* Effect.die(`unexpected /run ${String(index)}`);
+            }
+            return yield* closing(fixed.tests);
+          }),
+        ),
+      );
+      yield* start(fixed, http.layer);
+      yield* Deferred.await(firstStarted);
+      yield* Deferred.await(secondStarted);
+      expect(fixed.automation.jobs.map((job) => job.status)).toEqual(["running", "running"]);
+      expect(http.requests.filter((request) => request.url.endsWith("/run"))).toHaveLength(2);
+      yield* Deferred.succeed(firstRelease, undefined);
+      yield* Deferred.succeed(secondRelease, undefined);
+      yield* settleAll(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs.every((job) => job.status === "succeeded")).toBe(true);
     }),
   );
 
@@ -583,6 +643,56 @@ describe("dispatch unhappy path", () => {
       expect(fixed.log.lines[0]?.agentId).toBe(TICKET);
       expect(first).toBeDefined();
       expect(second).toBeDefined();
+    }),
+  );
+
+  it.effect("a 503 after a successful reserve leaves the next job pending", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedPair(fixed);
+      seedLiveClient(fixed.servers);
+      const started = yield* Deferred.make<void>();
+      const release = yield* Deferred.make<void>();
+      let reserves = 0;
+      const http = FakeHttp.recordRequests((request, url) => {
+        if (url.pathname === "/reserve") {
+          reserves += 1;
+          return reserves === 1
+            ? FakeHttp.json({ ok: "true" })
+            : FakeHttp.json({ error: "at capacity: max-jobs is 1" }, 503);
+        }
+        return Effect.gen(function* () {
+          yield* Deferred.succeed(started, undefined);
+          yield* Deferred.await(release);
+          return yield* closing(fixed.tests);
+        });
+      });
+      yield* start(fixed, http.layer);
+      yield* Deferred.await(started);
+      for (let i = 0; i < 200; i++) {
+        if (FakeLog.texts(fixed.log).includes("deferred; at capacity")) {
+          break;
+        }
+        yield* Effect.yieldNow;
+      }
+      expect(fixed.automation.jobs.map((job) => job.status)).toEqual(["running", "pending"]);
+      expect(fixed.automation.jobs[1]).toMatchObject({
+        status: "pending",
+        serverId: null,
+        startedAt: null,
+        finishedAt: null,
+        reason: null,
+      });
+      expect(http.requests.filter((request) => request.url.endsWith("/reserve"))).toHaveLength(2);
+      expect(http.requests.filter((request) => request.url.endsWith("/run"))).toHaveLength(1);
+      expect(FakeLog.texts(fixed.log)).toContain("deferred; at capacity");
+      expect(fixed.log.lines.some((line) => line.text === "deferred; at capacity")).toBe(true);
+      expect(fixed.log.lines.find((line) => line.text === "deferred; at capacity")?.agentId).toBe(
+        TICKET_B,
+      );
+      yield* Deferred.succeed(release, undefined);
+      yield* settle(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs.map((job) => job.status)).toEqual(["succeeded", "pending"]);
     }),
   );
 

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -284,9 +284,9 @@ describe("dispatch happy path", () => {
       expect(fixed.automation.jobs.every((job) => job.status === "succeeded")).toBe(true);
       expect(http.requests.filter((request) => request.url.endsWith("/reserve"))).toHaveLength(2);
       expect(http.requests.filter((request) => request.url.endsWith("/run"))).toHaveLength(2);
-      expect(FakeLog.texts(fixed.log).filter((text) => text.startsWith("dispatching drive"))).toEqual(
-        [`dispatching drive; ${URL}; ${MODEL}`, `dispatching drive; ${URL}; ${MODEL}`],
-      );
+      expect(
+        FakeLog.texts(fixed.log).filter((text) => text.startsWith("dispatching drive")),
+      ).toEqual([`dispatching drive; ${URL}; ${MODEL}`, `dispatching drive; ${URL}; ${MODEL}`]);
     }),
   );
 
@@ -327,6 +327,59 @@ describe("dispatch happy path", () => {
       yield* Deferred.succeed(secondRelease, undefined);
       yield* settleAll(fixed.automation.jobs, "succeeded");
       expect(fixed.automation.jobs.every((job) => job.status === "succeeded")).toBe(true);
+    }),
+  );
+
+  it.effect("a diagnose behind a running drive is skipped so another result can start", () =>
+    Effect.gen(function* () {
+      const fixed = harness();
+      seedResult(fixed.tests);
+      seedJob(fixed.automation, "drive", RESULT_ID);
+      seedJob(fixed.automation, "diagnose", RESULT_ID);
+      seedResult(fixed.tests, TICKET_B, "pending", RESULT_B);
+      seedJob(fixed.automation, "drive", RESULT_B);
+      seedLiveClient(fixed.servers);
+      const firstStarted = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<void>();
+      const firstRelease = yield* Deferred.make<void>();
+      const secondRelease = yield* Deferred.make<void>();
+      let runs = 0;
+      const http = FakeHttp.recordRequests(
+        reserving(() =>
+          Effect.gen(function* () {
+            const index = runs;
+            runs += 1;
+            if (index === 0) {
+              yield* Deferred.succeed(firstStarted, undefined);
+              yield* Deferred.await(firstRelease);
+            } else if (index === 1) {
+              yield* Deferred.succeed(secondStarted, undefined);
+              yield* Deferred.await(secondRelease);
+            } else {
+              return yield* Effect.die(`unexpected /run ${String(index)}`);
+            }
+            return yield* closing(fixed.tests);
+          }),
+        ),
+      );
+      yield* start(fixed, http.layer);
+      yield* Deferred.await(firstStarted);
+      yield* Deferred.await(secondStarted);
+      expect(fixed.automation.jobs.map((job) => [job.action, job.status])).toEqual([
+        ["drive", "running"],
+        ["diagnose", "pending"],
+        ["drive", "running"],
+      ]);
+      expect(http.requests.filter((request) => request.url.endsWith("/reserve"))).toHaveLength(2);
+      expect(http.requests.filter((request) => request.url.endsWith("/run"))).toHaveLength(2);
+      yield* Deferred.succeed(firstRelease, undefined);
+      yield* Deferred.succeed(secondRelease, undefined);
+      yield* settle(fixed.automation.jobs, "succeeded");
+      expect(fixed.automation.jobs.map((job) => [job.action, job.status])).toEqual([
+        ["drive", "succeeded"],
+        ["diagnose", "pending"],
+        ["drive", "succeeded"],
+      ]);
     }),
   );
 

--- a/test/integration/automation-server.integration.test.ts
+++ b/test/integration/automation-server.integration.test.ts
@@ -229,6 +229,7 @@ describe("automation server startup refusals", () => {
       expect(process.stdout()).toContain("--port");
       expect(process.stdout()).toContain("--model");
       expect(process.stdout()).not.toContain("--jobs");
+      expect(process.stdout()).not.toContain("--max-jobs");
       expect(process.stdout()).not.toContain("--diagnostics-port");
       expect(process.stdout()).not.toContain("--display");
     }),

--- a/test/integration/qemu-reverse-proxy.integration.test.ts
+++ b/test/integration/qemu-reverse-proxy.integration.test.ts
@@ -151,6 +151,8 @@ describe("qemu reverse proxy startup refusals", () => {
       expect(code).toBe(0);
       expect(process.stdout()).toContain("qemu-reverse-proxy");
       expect(process.stdout()).toContain("--port");
+      expect(process.stdout()).not.toContain("--jobs");
+      expect(process.stdout()).not.toContain("--max-jobs");
       expect(process.stdout()).not.toContain("--diagnostics-port");
       expect(process.stdout()).not.toContain("--display");
       expect(process.stdout()).not.toContain("--automation");

--- a/test/qemu-reverse-proxy/command.unit.test.ts
+++ b/test/qemu-reverse-proxy/command.unit.test.ts
@@ -121,6 +121,8 @@ describe("qemu reverse proxy command flags", () => {
       const stdout = yield* TestConsole.logLines;
       expect(stdout.join("\n")).toContain("qemu-reverse-proxy");
       expect(stdout.join("\n")).toContain("--port");
+      expect(stdout.join("\n")).not.toContain("--jobs");
+      expect(stdout.join("\n")).not.toContain("--max-jobs");
       expect(stdout.join("\n")).not.toContain("--diagnostics-port");
       expect(stdout.join("\n")).not.toContain("--display");
     }),

--- a/test/support/stores.ts
+++ b/test/support/stores.ts
@@ -555,8 +555,11 @@ export const fakeAutomationStore = (
       }),
     claim: (serverId) =>
       Effect.sync(() => {
+        const busy = new Set(
+          jobs.filter((job) => job.status === "running").map((job) => job.resultId),
+        );
         const pending = jobs
-          .filter((job) => job.status === "pending")
+          .filter((job) => job.status === "pending" && !busy.has(job.resultId))
           .sort(
             (left, right) =>
               left.createdAt.getTime() - right.createdAt.getTime() ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The automation server treated itself as a one-job worker: each tick claimed a single row and waited for `POST /run` to finish before looking at the rest of the queue. That cap does not belong here. How many jobs run is decided by the clients (`--max-jobs`), the same way qemu capacity is decided by `./qemu-server` and not by the reverse proxy.

## What changed

- A dispatch tick walks pending jobs: claim, attempt reserve, and if a client accepts, start `/run` in its own fiber so the next pending row can reserve on the same tick.
- A 503 from every live client puts that row back to pending and stops the tick. The next tick (5s) tries again.
- Claim skips a result that already has a running job, so a diagnose does not take the same ticket as its drive.
- Shutdown still finishes in-flight `/run`s as aborted (`uninterruptibleMask` on each job fiber; no `startImmediately` so the scope finalizer is installed first).
- The qemu reverse proxy already had no job count. Help tests now pin that it (and the automation server) advertise neither `--jobs` nor `--max-jobs`.

## Tests

- Happy: two pending jobs whose reserve succeeds both start without waiting 5 seconds; a hung `/run` does not hold the next job; a diagnose behind a running drive stays pending so another result can start.
- Unhappy: after one successful reserve, a 503 on the next job leaves that row pending and does not start a second `/run`; closing the dispatch scope aborts an in-flight `/run`.

`npm run check:fast`: lint, format, types, and 1107 unit tests passed.

[check:fast unit results](https://cursor.com/agents/bc-01a096da-87a3-7eaa-9714-f9addf606480/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcheck-fast.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a096da-87a3-7eaa-9714-f9addf606480?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a096da-87a3-7eaa-9714-f9addf606480&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

