### PR TITLE
Automation client: end a run at opencode's exit; reserve by action; expire unused reservations

### DIFF
--- a/client.md
+++ b/client.md
@@ -73,7 +73,8 @@ CLIENT_IMAGE=screen.png ./client-with-image send-keys --agent-id OLI-42 --server
 
 Boots a QEMU session and prints its session id. Consumes a reservation already held
 for `--agent-id`. Without one the host answers 400 `no reservation` and the command
-fails. `./client start` does not reserve.
+fails. `./client start` does not reserve. A reservation nobody starts within ten
+minutes is given back, and a start after that is refused the same way.
 
 - `--iso <path|url>` — the ISO. A local path must exist; an http(s) URL is downloaded and cached by the server. Default `omarchy.iso` in the current directory.
 - `--disk <path>` — an existing qcow2 disk. Omit it and the server creates a fresh one.

--- a/src/automation-client/command.ts
+++ b/src/automation-client/command.ts
@@ -90,6 +90,6 @@ export const makeAutomationClientCommand = <RServe>(server: AutomationClient<RSe
       }),
   ).pipe(
     Command.withDescription(
-      "The automation client: POST /reserve reserves QEMU first, then takes a --max-jobs slot for a ticket; POST /run consumes that reservation and launches OpenCode with a prompt and waits until it finishes; POST /abort kills the matching run by ticket",
+      "The automation client: POST /reserve takes a --max-jobs slot for a ticket, for a drive after reserving QEMU first, for a diagnose alone; POST /run consumes that reservation and launches OpenCode with a prompt and waits until it finishes; POST /abort kills the matching run by ticket",
     ),
   );

--- a/src/automation-client/handlers.ts
+++ b/src/automation-client/handlers.ts
@@ -19,7 +19,7 @@ export const RunsLive = HttpApiBuilder.group(Api.AutomationClientApi, "Runs", (h
       ({ payload }) =>
         Effect.gen(function* () {
           const sessions = yield* Sessions.Sessions;
-          yield* sessions.reserve(payload.ticket);
+          yield* sessions.reserve(payload.ticket, payload.action);
           return ok;
         }),
       uninterruptible,

--- a/src/automation-client/main.ts
+++ b/src/automation-client/main.ts
@@ -23,12 +23,11 @@ import * as Render from "../observability/render.ts";
 import * as Sentry from "../observability/sentry.ts";
 import * as Stats from "../qemu/stats.ts";
 import * as Api from "../shared/api.ts";
-import * as Contract from "../shared/contract.ts";
-import * as Errors from "../shared/errors.ts";
 import * as ProcessUsage from "../shared/process-usage.ts";
 import * as AutomationClientCommand from "./command.ts";
 import * as Handlers from "./handlers.ts";
 import * as Heartbeat from "./heartbeat.ts";
+import * as Qemu from "./qemu.ts";
 import * as Sessions from "./sessions.ts";
 
 const HOST = "127.0.0.1";
@@ -78,36 +77,8 @@ const ServerLive = (maxJobs: number, name: string, port: number, url: Option.Opt
           const serverUrl = yield* EffectConfig.string("SERVER_URL").pipe(
             Effect.orElseSucceed(() => Config.DEFAULT_SERVER_URL),
           );
-          const proxy: ProxyClient.ProxyClientService = yield* ProxyClient.connect({
-            serverUrl,
-            token,
-          });
-          const asQemuError = (
-            agent: string,
-            error: ProxyClient.Failure,
-          ): Effect.Effect<never, Errors.AtCapacity | Errors.Internal> => {
-            if (error._tag === "ProxyRefusal" && error.status === 503) {
-              return Errors.AtCapacity.make({ message: error.message, agentId: agent });
-            }
-            return Errors.Internal.make({
-              cause: new Error(error.message),
-              agentId: agent,
-            });
-          };
-          const reserveQemu: Sessions.ReserveQemu = (agent) =>
-            proxy
-              .reserve(Contract.ReserveAgentBody.make({ agent }))
-              .pipe(Effect.catch((error) => asQemuError(agent, error)));
-          const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
-            proxy.relinquish(Contract.ReserveAgentBody.make({ agent })).pipe(
-              Effect.catch((error: ProxyClient.Failure) =>
-                Errors.Internal.make({
-                  cause: new Error(error.message),
-                  agentId: agent,
-                }),
-              ),
-            );
-          return Sessions.Sessions.layer(maxJobs, reserveQemu, relinquishQemu);
+          const proxy = yield* ProxyClient.connect({ serverUrl, token });
+          return Sessions.Sessions.layer(maxJobs, Qemu.reserve(proxy), Qemu.relinquish(proxy));
         }),
       ),
     ),

--- a/src/automation-client/qemu.ts
+++ b/src/automation-client/qemu.ts
@@ -1,0 +1,52 @@
+import { Effect } from "effect";
+import type * as ProxyClient from "../client/proxy-client.ts";
+import * as Contract from "../shared/contract.ts";
+import * as Errors from "../shared/errors.ts";
+import type * as Sessions from "./sessions.ts";
+
+// The guest host, reached through the reverse proxy, as Sessions sees it: a 503 is the fleet
+// being full, which the dispatcher places elsewhere; every other failure is this client's to
+// report.
+const internal = (agent: string, error: ProxyClient.Failure): Errors.Internal =>
+  Errors.Internal.make({ cause: new Error(error.message), agentId: agent });
+
+const refused = (
+  agent: string,
+  error: ProxyClient.Failure,
+): Effect.Effect<never, Errors.AtCapacity | Errors.Internal> =>
+  error._tag === "ProxyRefusal" && error.status === 503
+    ? Errors.AtCapacity.make({ message: error.message, agentId: agent })
+    : internal(agent, error);
+
+export const reserve =
+  (proxy: ProxyClient.ProxyClientService): Sessions.ReserveQemu =>
+  (agent) =>
+    proxy
+      .reserve(Contract.ReserveAgentBody.make({ agent }))
+      .pipe(Effect.catch((error) => refused(agent, error)));
+
+// The guest host already let this reservation go (its own ten minutes ran out first, or it
+// restarted) and the proxy has forgotten the route: there is nothing to give back, which is what
+// relinquish was for.
+const gone = (agent: string, error: ProxyClient.Failure): Effect.Effect<void, Errors.Internal> =>
+  error._tag === "ProxyRefusal" && error.status === 400 ? Effect.void : internal(agent, error);
+
+// The sweep that gives expired reservations back is one fiber with nobody waiting on it, and
+// node:http has no ceiling of its own: a proxy that never answers must not hold every later
+// expiry behind this one.
+const RELINQUISH_TIMEOUT = "10 seconds";
+
+export const relinquish =
+  (proxy: ProxyClient.ProxyClientService): Sessions.RelinquishQemu =>
+  (agent) =>
+    proxy.relinquish(Contract.ReserveAgentBody.make({ agent })).pipe(
+      Effect.catch((error) => gone(agent, error)),
+      Effect.timeoutOrElse({
+        duration: RELINQUISH_TIMEOUT,
+        orElse: () =>
+          Errors.Internal.make({
+            cause: new Error(`relinquish: no answer within ${RELINQUISH_TIMEOUT}`),
+            agentId: agent,
+          }),
+      }),
+    );

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer, Ref, Semaphore } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as Cli from "../cli.ts";
+import type * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 import * as OpenCode from "./opencode.ts";
 
@@ -51,7 +52,10 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: Relinqu
     // slot remains.
     const reserveGate = yield* Semaphore.make(1);
 
-    const reserve = Effect.fn("Sessions.reserve")(function* (ticket: string) {
+    const reserve = Effect.fn("Sessions.reserve")(function* (
+      ticket: string,
+      action: Domain.AutomationAction,
+    ) {
       return yield* reserveGate.withPermits(1)(
         Effect.gen(function* () {
           const held = yield* Ref.get(slots);
@@ -61,9 +65,14 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: Relinqu
               agentId: ticket,
             });
           }
-          // QEMU first: this client cannot hold a slot until the guest host has one.
-          // A full client still asks, then gives that slot back rather than leak it.
-          yield* reserveQemu(ticket);
+          // A drive boots a guest, so QEMU first: this client cannot hold a slot until the
+          // guest host has one, and a full client still asks, then gives that slot back rather
+          // than leak it. A diagnose reads the session back and boots nothing: a guest slot it
+          // took would never be consumed by a start, nor given back, and would be gone for as
+          // long as that qemu server lived.
+          if (action === "drive") {
+            yield* reserveQemu(ticket);
+          }
           const admitted = yield* Ref.modify(slots, (current) => {
             if (current.count >= maxJobs) {
               return [false, current] as const;
@@ -74,7 +83,9 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: Relinqu
             ] as const;
           });
           if (!admitted) {
-            yield* relinquishQemu(ticket);
+            if (action === "drive") {
+              yield* relinquishQemu(ticket);
+            }
             return yield* atCapacity(ticket);
           }
           return yield* Effect.void;

--- a/src/automation-client/sessions.ts
+++ b/src/automation-client/sessions.ts
@@ -1,9 +1,20 @@
-import { Context, Effect, Layer, Ref, Semaphore } from "effect";
+import { Cause, Clock, Context, Effect, Layer, Ref, Schedule, Semaphore } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as Cli from "../cli.ts";
+import * as Log from "../observability/log.ts";
+import * as Render from "../observability/render.ts";
 import type * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 import * as OpenCode from "./opencode.ts";
+
+// A reservation is a promise that a run follows at once; the dispatcher POSTs /run right after
+// /reserve answers. One nobody runs (the dispatcher died in between) would hold a slot, and a
+// drive's guest slot with it, until this process restarted. Ten minutes unused and it is given
+// back, as a guest with no command is. In memory only: nothing durable records a reservation,
+// so a restart starts clean and a restarted dispatcher can place the job anew.
+const RESERVATION_TIMEOUT = "10 minutes";
+const RESERVATION_TIMEOUT_MS = 10 * 60 * 1000;
+const RESERVATION_SWEEP = "10 seconds";
 
 const mapWith = <V>(map: ReadonlyMap<string, V>, key: string, value: V): ReadonlyMap<string, V> =>
   new Map([...map, [key, value]]);
@@ -14,19 +25,18 @@ const mapWithout = <V>(map: ReadonlyMap<string, V>, key: string): ReadonlyMap<st
   return next;
 };
 
-const withItem = <T>(set: ReadonlySet<T>, item: T): ReadonlySet<T> => new Set([...set, item]);
-
-const without = <T>(set: ReadonlySet<T>, item: T): ReadonlySet<T> => {
-  const next = new Set(set);
-  next.delete(item);
-  return next;
-};
-
 export type ReserveQemu = (
   agent: string,
 ) => Effect.Effect<void, Errors.AtCapacity | Errors.Internal>;
 
 export type RelinquishQemu = (agent: string) => Effect.Effect<void, Errors.Internal>;
+
+// What a ticket holds before its run: which kind, so an expired drive gives its guest slot back,
+// and since when.
+type Reservation = {
+  readonly action: Domain.AutomationAction;
+  readonly since: number;
+};
 
 const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: RelinquishQemu) =>
   Effect.gen(function* () {
@@ -38,9 +48,10 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: Relinqu
     // has spawned, and the slot must be taken before that, so a refused run spawns nothing.
     const slots = yield* Ref.make<{
       readonly count: number;
-      readonly reserved: ReadonlySet<string>;
-    }>({ count: 0, reserved: new Set() });
+      readonly reserved: ReadonlyMap<string, Reservation>;
+    }>({ count: 0, reserved: new Map() });
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const log = yield* Log.Log;
 
     const atCapacity = (ticket: string): Errors.AtCapacity =>
       Errors.AtCapacity.make({
@@ -73,13 +84,17 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: Relinqu
           if (action === "drive") {
             yield* reserveQemu(ticket);
           }
+          const since = yield* Clock.currentTimeMillis;
           const admitted = yield* Ref.modify(slots, (current) => {
             if (current.count >= maxJobs) {
               return [false, current] as const;
             }
             return [
               true,
-              { count: current.count + 1, reserved: withItem(current.reserved, ticket) },
+              {
+                count: current.count + 1,
+                reserved: mapWith(current.reserved, ticket, { action, since }),
+              },
             ] as const;
           });
           if (!admitted) {
@@ -97,7 +112,7 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: Relinqu
       Effect.flatMap(
         Ref.modify(slots, (held) =>
           held.reserved.has(ticket)
-            ? ([true, { count: held.count, reserved: without(held.reserved, ticket) }] as const)
+            ? ([true, { count: held.count, reserved: mapWithout(held.reserved, ticket) }] as const)
             : ([false, held] as const),
         ),
         (held) =>
@@ -105,6 +120,53 @@ const make = (maxJobs: number, reserveQemu: ReserveQemu, relinquishQemu: Relinqu
             ? Effect.void
             : Errors.BadRequest.make({ message: "no reservation", agentId: ticket }),
       );
+
+    // Every reservation past the deadline leaves the reserved set and gives its slot back in one
+    // step, so a run arriving late is refused rather than admitted twice; then a drive's guest
+    // slot is given back, each failure its own line so the others still go.
+    const expire = Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      const expired = yield* Ref.modify(slots, (held) => {
+        const gone: Array<[string, Reservation]> = [];
+        const kept = new Map<string, Reservation>();
+        for (const [ticket, reservation] of held.reserved) {
+          if (now - reservation.since >= RESERVATION_TIMEOUT_MS) {
+            gone.push([ticket, reservation]);
+          } else {
+            kept.set(ticket, reservation);
+          }
+        }
+        return [gone, { count: held.count - gone.length, reserved: kept }] as const;
+      });
+      for (const [ticket, reservation] of expired) {
+        yield* log.warning(`reservation expired; unused for ${RESERVATION_TIMEOUT}`, {
+          location: Log.Locations.automationClient,
+          agentId: ticket,
+        });
+        if (reservation.action === "drive") {
+          yield* relinquishQemu(ticket).pipe(
+            Effect.catch((error) =>
+              log.error(`relinquish failed: ${Render.headline(error)}`, {
+                location: Log.Locations.automationClient,
+                agentId: ticket,
+                cause: error,
+              }),
+            ),
+          );
+        }
+      }
+    });
+    yield* expire.pipe(
+      Effect.catchCause((cause) => {
+        const error = Cause.squash(cause);
+        return log.error(`reservation sweep failed: ${Render.errorDetail(error)}`, {
+          location: Log.Locations.automationClient,
+          cause: error,
+        });
+      }),
+      Effect.repeat(Schedule.spaced(RESERVATION_SWEEP)),
+      Effect.forkScoped,
+    );
 
     const run = Effect.fn("Sessions.run")(function* (
       ticket: string,
@@ -186,6 +248,6 @@ export class Sessions extends Context.Service<Sessions>()("@oligarchy/automation
     maxJobs: number,
     reserveQemu: ReserveQemu,
     relinquishQemu: RelinquishQemu,
-  ): Layer.Layer<Sessions, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  ): Layer.Layer<Sessions, never, ChildProcessSpawner.ChildProcessSpawner | Log.Log> =>
     Layer.effect(this)(this.make(maxJobs, reserveQemu, relinquishQemu));
 }

--- a/src/automation-server/client.ts
+++ b/src/automation-server/client.ts
@@ -4,6 +4,7 @@ import { HttpApiClient, HttpApiMiddleware } from "effect/unstable/httpapi";
 import * as Config from "../config.ts";
 import * as Api from "../shared/api.ts";
 import * as Contract from "../shared/contract.ts";
+import type * as Domain from "../shared/domain.ts";
 import * as Errors from "../shared/errors.ts";
 
 export class OligarchyToken extends Context.Service<OligarchyToken>()(
@@ -56,9 +57,15 @@ const makeClient = Effect.fn("makeClient")(function* (url: string) {
   }).pipe(Effect.provide(middleware));
 });
 
-export const reserve = Effect.fn("reserve")(function* (url: string, ticket: string) {
+export const reserve = Effect.fn("reserve")(function* (
+  url: string,
+  ticket: string,
+  action: Domain.AutomationAction,
+) {
   const client = yield* makeClient(url);
-  return yield* client.Runs.reserve({ payload: Contract.ReserveBody.make({ ticket }) }).pipe(
+  return yield* client.Runs.reserve({
+    payload: Contract.ReserveBody.make({ ticket, action }),
+  }).pipe(
     Effect.catch((error) => {
       if (error._tag === "HttpClientError") {
         const response = error.response;

--- a/src/automation-server/worker.ts
+++ b/src/automation-server/worker.ts
@@ -40,8 +40,9 @@ type Placement = {
   readonly ticket: string;
 };
 
-// Build the prompt and take a client slot. /run is not waited here: a reserved job
-// starts in its own fiber so the next pending row can reserve on this tick.
+// Build the prompt and take a client slot, the client reserving a guest too when the job is a
+// drive. /run is not waited here: a reserved job starts in its own fiber so the next pending
+// row can reserve on this tick.
 const place = Effect.fn("place")(function* (
   job: Automation.AutomationJobRow,
   clients: ReadonlyArray<Servers.LiveServer>,
@@ -61,7 +62,7 @@ const place = Effect.fn("place")(function* (
       : yield* Prompts.diagnose(ticket, job.resultId, model);
   let lastCapacity: string | undefined;
   for (const client of clients) {
-    const reserved = yield* Effect.result(AutomationClient.reserve(client.url, ticket));
+    const reserved = yield* Effect.result(AutomationClient.reserve(client.url, ticket, job.action));
     if (Result.isSuccess(reserved)) {
       if (client.id !== job.serverId) {
         yield* store.assign(job.id, client.id);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect";
+import { Effect, Fiber, Ref, Stream } from "effect";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as ExternalFailure from "./external-failure.ts";
 import * as Render from "./observability/render.ts";
@@ -10,6 +10,18 @@ export const FORCE_KILL_AFTER = "5 seconds";
 // in a job's reason and a logs row, and Postgres text refuses NUL, so a binary blob a tool dumped
 // on stderr must not cost the run its verdict.
 export const STDERR_TAIL = 4_096;
+
+// What the drain keeps, NUL bytes already dropped: twice the tail, so the trailing whitespace the
+// message loses comes out of the excess, and a tool that floods stderr for half an hour costs the
+// process no more than this.
+const STDERR_KEPT = 2 * STDERR_TAIL;
+
+// The command's stderr is a pipe it shares with every process it starts (a tool the agent ran, an
+// MCP server), and the pipe ends only when the last of them closes it; Node's `exit` fires long
+// before that `close`. The exit is the end of the run: after it the drain gets this long to
+// deliver what the command itself wrote, then the tail so far is the tail. Without the bound a
+// straggler held every run to its ceiling.
+const STDERR_GRACE = "2 seconds";
 
 const detail = (error: unknown): string =>
   ExternalFailure.describeThrowable(ExternalFailure.causeOf(error), Render.errorDetail(error));
@@ -44,20 +56,30 @@ export const spawn = Effect.fn("Cli.spawn")(function* (
     .pipe(Effect.mapError((error) => failed(command, detail(error), error)));
 });
 
+// Drained while the command runs, so a full pipe never blocks it; the exit is awaited on its own.
 export const awaitExit = Effect.fn("Cli.awaitExit")(function* (
   command: string,
   handle: ChildProcessSpawner.ChildProcessHandle,
 ) {
-  const [stderr, code] = yield* Effect.all(
-    [
-      Stream.mkString(Stream.decodeText(handle.stderr)).pipe(
-        Effect.mapError((error) => failed(command, detail(error), error)),
+  const stderr = yield* Ref.make("");
+  const drain = yield* Effect.forkScoped(
+    handle.stderr.pipe(
+      Stream.decodeText(),
+      Stream.runForEach((text) =>
+        Ref.update(stderr, (kept) => `${kept}${text.replaceAll("\u0000", "")}`.slice(-STDERR_KEPT)),
       ),
-      handle.exitCode.pipe(Effect.mapError((error) => failed(command, detail(error), error))),
-    ],
-    { concurrency: "unbounded" },
+    ),
+    { startImmediately: true },
   );
-  const trimmed = stderr.replaceAll("\u0000", "").trim().slice(-STDERR_TAIL);
+  const code = yield* handle.exitCode.pipe(
+    Effect.mapError((error) => failed(command, detail(error), error)),
+  );
+  // A drain that ended with the pipe joins at once; one a straggler holds is left to the scope.
+  yield* Fiber.join(drain).pipe(
+    Effect.mapError((error) => failed(command, detail(error), error)),
+    Effect.timeoutOrElse({ duration: STDERR_GRACE, orElse: () => Effect.void }),
+  );
+  const trimmed = (yield* Ref.get(stderr)).trim().slice(-STDERR_TAIL);
   if (code !== 0) {
     return yield* failed(command, trimmed === "" ? `${command} exited ${String(code)}` : trimmed);
   }

--- a/src/qemu-reverse-proxy/router.ts
+++ b/src/qemu-reverse-proxy/router.ts
@@ -52,8 +52,9 @@ export type RouterService = {
     HttpServerResponse.HttpServerResponse,
     Errors.BadRequest | Errors.NoServer | Errors.ServerFailed | Errors.Internal
   >;
-  // Forwards relinquish to the server that reserved this agent and forgets the agent
-  // when that server accepts it. There is no placement here: /reserve already chose.
+  // Forwards relinquish to the server that reserved this agent and forgets the agent when
+  // that server accepts it or already holds nothing for it. There is no placement here:
+  // /reserve already chose.
   readonly relinquish: (
     request: HttpServerRequest.HttpServerRequest,
     agent: string,
@@ -384,12 +385,17 @@ const make = Effect.gen(function* () {
       Effect.mapError((error) => unreachable(url, error, who)),
     );
     // Status is on the wire before the body: a 200 means the slot is already free, even if
-    // the stream then dies. Forget the agent before passing the answer through.
-    if (response.status === 200) {
+    // the stream then dies. A 400 means the server holds nothing for this agent: it let the
+    // reservation go on its own (ten minutes unused) or restarted, so the route is stale too.
+    // Either way forget the agent before passing the answer through, so a fresh reserve places.
+    if (response.status === 200 || response.status === 400) {
       yield* store
         .clearAgent(agent)
         .pipe(Effect.mapError((cause) => internal(cause, undefined, agent)));
-      yield* log.info(`relinquished; ${url}`, { location: Log.Locations.server, agentId: agent });
+      yield* log.info(
+        response.status === 200 ? `relinquished; ${url}` : `reservation gone; ${url}`,
+        { location: Log.Locations.server, agentId: agent },
+      );
     }
     return passthrough(url, response, who);
   });

--- a/src/qemu-server/sessions.ts
+++ b/src/qemu-server/sessions.ts
@@ -38,6 +38,12 @@ import * as Errors from "../shared/errors.ts";
 const SESSION_TIMEOUT_MS = 10 * 60 * 1000;
 const SESSION_TIMEOUT_CHECK = "10 seconds";
 const SESSION_TIMEOUT_REASON = "no command received for 10 minutes";
+// A reservation is a promise that a start follows soon. One nobody starts (the client that took
+// it died, or the dispatcher behind it did) would hold a --max-jobs slot until this process
+// restarted; ten minutes unused and it is given back, as a session with no command is. The
+// sweep that times sessions out notices. In memory only: no row records a reservation.
+const RESERVATION_TIMEOUT_MS = 10 * 60 * 1000;
+const RESERVATION_TIMEOUT_REASON = "unused for 10 minutes";
 const SHUTDOWN_REASON = "qemu server shutdown";
 // A click is two QMP exchanges and two action rows; cap the pulse count so one request cannot
 // enqueue an unbounded amount of work.
@@ -211,13 +217,13 @@ const make = (maxJobs: number) =>
     const sessions = yield* Ref.make<ReadonlyMap<string, LiveSession>>(new Map());
     const openSessions = yield* Ref.make<ReadonlyMap<string, OpenSession>>(new Map());
     // How many sessions are admitted against --max-jobs, and which agents already hold a slot
-    // that start will consume. Taken at reserve, before the span, scope or row exist, so a
-    // refusal allocates nothing; given back in finishLiveSession, the one place every admitted
-    // session ends.
+    // that start will consume, each with when it was taken. Taken at reserve, before the span,
+    // scope or row exist, so a refusal allocates nothing; given back in finishLiveSession, the
+    // one place every admitted session ends, or by the sweep when no start ever came.
     const slots = yield* Ref.make<{
       readonly count: number;
-      readonly reserved: ReadonlySet<string>;
-    }>({ count: 0, reserved: new Set() });
+      readonly reserved: ReadonlyMap<string, number>;
+    }>({ count: 0, reserved: new Map() });
 
     const elapsed = (started: number) =>
       Effect.map(Clock.currentTimeMillis, (now) => String(now - started));
@@ -460,6 +466,7 @@ const make = (maxJobs: number) =>
     };
 
     const reserve = Effect.fn("Sessions.reserve")(function* (agent: string) {
+      const now = yield* Clock.currentTimeMillis;
       return yield* Effect.flatMap(
         Ref.modify(slots, (held) => {
           if (held.reserved.has(agent)) {
@@ -470,7 +477,7 @@ const make = (maxJobs: number) =>
           }
           return [
             "ok",
-            { count: held.count + 1, reserved: withItem(held.reserved, agent) },
+            { count: held.count + 1, reserved: mapWith(held.reserved, agent, now) },
           ] as const;
         }),
         (outcome) => admit(outcome, agent),
@@ -481,7 +488,10 @@ const make = (maxJobs: number) =>
       return yield* Effect.flatMap(
         Ref.modify(slots, (held) =>
           held.reserved.has(agent)
-            ? ([true, { count: held.count - 1, reserved: without(held.reserved, agent) }] as const)
+            ? ([
+                true,
+                { count: held.count - 1, reserved: mapWithout(held.reserved, [agent]) },
+              ] as const)
             : ([false, held] as const),
         ),
         (released) =>
@@ -502,7 +512,7 @@ const make = (maxJobs: number) =>
       const agent = body.agent;
       const reserved = yield* Ref.modify(slots, (held) =>
         held.reserved.has(agent)
-          ? ([true, { count: held.count, reserved: without(held.reserved, agent) }] as const)
+          ? ([true, { count: held.count, reserved: mapWithout(held.reserved, [agent]) }] as const)
           : ([false, held] as const),
       );
       if (!reserved) {
@@ -929,7 +939,32 @@ const make = (maxJobs: number) =>
           );
       });
 
+    // Every reservation past the deadline leaves the reserved set and gives its slot back in one
+    // step, so a start arriving late is refused rather than admitted twice.
+    const expireReservations = Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis;
+      const expired = yield* Ref.modify(slots, (held) => {
+        const gone: Array<string> = [];
+        for (const [agent, since] of held.reserved) {
+          if (now - since >= RESERVATION_TIMEOUT_MS) {
+            gone.push(agent);
+          }
+        }
+        return [
+          gone,
+          { count: held.count - gone.length, reserved: mapWithout(held.reserved, gone) },
+        ] as const;
+      });
+      for (const agent of expired) {
+        yield* log.warning(`reservation expired; ${RESERVATION_TIMEOUT_REASON}`, {
+          location: Log.Locations.server,
+          agentId: agent,
+        });
+      }
+    });
+
     const sweep = Effect.gen(function* () {
+      yield* expireReservations;
       const now = yield* Clock.currentTimeMillis;
       const timedOut: Array<LiveSession> = [];
       for (const live of (yield* Ref.get(sessions)).values()) {

--- a/src/shared/contract.ts
+++ b/src/shared/contract.ts
@@ -112,10 +112,13 @@ export class RunBody extends Schema.Class<RunBody>("@oligarchy/shared/contract/R
   model: Domain.ModelId,
 }) {}
 
+// What an automation client is asked to hold for a ticket: a drive takes a guest slot and a
+// client slot, a diagnose a client slot alone.
 export class ReserveBody extends Schema.Class<ReserveBody>(
   "@oligarchy/shared/contract/ReserveBody",
 )({
   ticket: Schema.NonEmptyString,
+  action: Domain.AutomationAction,
 }) {}
 
 export class ReserveAgentBody extends Schema.Class<ReserveAgentBody>(

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -164,6 +164,14 @@ export const MaxJobs = Schema.Int.check(
 ).annotate({ identifier: "@oligarchy/shared/domain/MaxJobs" });
 export type MaxJobs = typeof MaxJobs.Type;
 
+// The two automation steps for a test result, the twin of the automation_action pgEnum in
+// src/db/schema.ts, maintained by hand together. A drive boots a guest and so reserves one; a
+// diagnose reads the session back and reserves a client only.
+export const AutomationAction = Schema.Literals(["drive", "diagnose"]).annotate({
+  identifier: "@oligarchy/shared/domain/AutomationAction",
+});
+export type AutomationAction = typeof AutomationAction.Type;
+
 // An OpenCode model as `opencode run --model` takes it: the provider, a slash, the model's own
 // id (which may hold slashes of its own: openrouter/deepseek/deepseek-v4.1-flash). Refused at
 // the flag so a run is never dispatched as a model no client can launch.

--- a/test/automation-client/http.unit.test.ts
+++ b/test/automation-client/http.unit.test.ts
@@ -26,6 +26,8 @@ type Fixture = {
   readonly log: FakeLog.FakeLog;
   readonly reporter: Reporter.Collector;
   readonly maxJobs: number;
+  // Every ticket the client asked QEMU a slot for, in order.
+  readonly qemu: Array<string>;
 };
 
 // Room for the two runs some tests hold at once; the capacity test passes 1.
@@ -39,13 +41,19 @@ const fixture = (
   log: FakeLog.fakeLog(),
   reporter: Reporter.collect(),
   maxJobs,
+  qemu: [],
 });
 
-const qemuOk = (): Sessions.ReserveQemu => () => Effect.void;
+const qemuRecording =
+  (fixed: Fixture): Sessions.ReserveQemu =>
+  (agent) =>
+    Effect.sync(() => {
+      fixed.qemu.push(agent);
+    });
 
 const serve = (fixed: Fixture) =>
   HttpRouter.serve(Handlers.routes, { disableLogger: true, disableListenLog: true }).pipe(
-    Layer.provide(Sessions.Sessions.layer(fixed.maxJobs, qemuOk(), () => Effect.void)),
+    Layer.provide(Sessions.Sessions.layer(fixed.maxJobs, qemuRecording(fixed), () => Effect.void)),
     Layer.provide(Layer.mergeAll(fixed.spawner.layer, fixed.log.layer, ProxyConfigLive)),
     Layer.provide(Layer.succeed(Log.ProcessAttribution)(Log.AutomationClientProcessAttribution)),
     Layer.provideMerge(NodeHttpServer.layerTest),
@@ -60,10 +68,11 @@ const reserve = (
   http: HttpClient.HttpClient,
   ticket = TICKET,
   extraHeaders: Record<string, string> = headers,
+  action: "drive" | "diagnose" = "drive",
 ) =>
   http.post("/reserve", {
     headers: extraHeaders,
-    body: HttpBody.text(JSON.stringify({ ticket }), "application/json"),
+    body: HttpBody.text(JSON.stringify({ ticket, action }), "application/json"),
   });
 
 const run = (
@@ -100,7 +109,7 @@ const reservedRun = (
   });
 
 describe("POST /reserve happy path", () => {
-  it.effect("answers ok and does not spawn opencode", () =>
+  it.effect("a drive answers ok, asks QEMU for the ticket, and does not spawn opencode", () =>
     Effect.gen(function* () {
       const fixed = fixture(() => ({ exitCode: 0 }));
       yield* Effect.gen(function* () {
@@ -109,8 +118,73 @@ describe("POST /reserve happy path", () => {
         expect(response.status).toBe(200);
         expect(yield* response.json).toEqual({ ok: "true" });
       }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.qemu).toEqual([TICKET]);
       expect(fixed.spawner.spawned).toEqual([]);
       expect(fixed.log.lines).toEqual([]);
+    }),
+  );
+
+  it.effect("a diagnose answers ok and never asks QEMU: it boots no guest", () =>
+    Effect.gen(function* () {
+      const fixed = fixture(() => ({ exitCode: 0 }));
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* reserve(http, TICKET, headers, "diagnose");
+        expect(response.status).toBe(200);
+        expect(yield* response.json).toEqual({ ok: "true" });
+        // The slot is this client's: the run it reserved proceeds.
+        expect((yield* run(http, "diagnose the session")).status).toBe(200);
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.qemu).toEqual([]);
+      expect(fixed.spawner.spawned.map((spawned) => spawned.args[5])).toEqual([
+        "diagnose the session",
+      ]);
+      expect(fixed.log.lines).toEqual([]);
+    }),
+  );
+});
+
+describe("POST /reserve decoding", () => {
+  it.effect("a body without action is 400 and asks QEMU nothing", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* http.post("/reserve", {
+          headers,
+          body: HttpBody.text(JSON.stringify({ ticket: TICKET }), "application/json"),
+        });
+        expect(response.status).toBe(400);
+        const body = decodeErrorBody(yield* response.json);
+        expect(body.error).toContain("action");
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.qemu).toEqual([]);
+      expect(fixed.spawner.spawned).toEqual([]);
+    }),
+  );
+
+  it.effect("an action that is neither drive nor diagnose is 400 and asks QEMU nothing", () =>
+    Effect.gen(function* () {
+      const fixed = fixture();
+      yield* Effect.gen(function* () {
+        const http = yield* HttpClient.HttpClient;
+        const response = yield* http.post("/reserve", {
+          headers,
+          body: HttpBody.text(
+            JSON.stringify({ ticket: TICKET, action: "review" }),
+            "application/json",
+          ),
+        });
+        expect(response.status).toBe(400);
+        const body = decodeErrorBody(yield* response.json);
+        expect(body.error).toContain("action");
+        // Nothing was reserved: a run for the ticket is refused.
+        const refused = yield* run(http);
+        expect(refused.status).toBe(400);
+        expect(yield* refused.json).toEqual({ error: "no reservation" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.qemu).toEqual([]);
+      expect(fixed.spawner.spawned).toEqual([]);
     }),
   );
 });

--- a/test/automation-client/qemu.unit.test.ts
+++ b/test/automation-client/qemu.unit.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect } from "vitest";
+import { it } from "@effect/vitest";
+import { Effect, Fiber, Redacted } from "effect";
+import { TestClock } from "effect/testing";
+import { HttpClientError } from "effect/unstable/http";
+import * as Qemu from "../../src/automation-client/qemu.ts";
+import * as ProxyClient from "../../src/client/proxy-client.ts";
+import * as Render from "../../src/observability/render.ts";
+import * as FakeHttp from "../support/fake-http.ts";
+
+const SERVER = "http://127.0.0.1:55555";
+const TOKEN = "test-token";
+const AGENT = "OLI-42";
+
+const connect = ProxyClient.connect({ serverUrl: SERVER, token: Redacted.make(TOKEN) });
+
+const unreachable = FakeHttp.respondWith((request) =>
+  Effect.fail(
+    new HttpClientError.HttpClientError({
+      reason: new HttpClientError.TransportError({
+        request,
+        cause: new Error("connect ECONNREFUSED 127.0.0.1:55555"),
+      }),
+    }),
+  ),
+);
+
+describe("Qemu.reserve happy path", () => {
+  it.effect("posts the agent to /reserve and succeeds on 200", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      const proxy = yield* connect.pipe(Effect.provide(recorder.layer));
+      yield* Qemu.reserve(proxy)(AGENT);
+      expect(recorder.requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+        `POST ${SERVER}/reserve`,
+      ]);
+      expect(JSON.parse(recorder.requests[0]?.body ?? "")).toEqual({ agent: AGENT });
+    }),
+  );
+});
+
+describe("Qemu.reserve unhappy path", () => {
+  it.effect("a 503 is AtCapacity with the guest host's own words", () =>
+    Effect.gen(function* () {
+      const http = FakeHttp.respondWith(() =>
+        FakeHttp.json({ error: "at capacity: max-jobs is 4" }, 503),
+      );
+      const proxy = yield* connect.pipe(Effect.provide(http));
+      const error = yield* Effect.flip(Qemu.reserve(proxy)(AGENT));
+      expect(error).toMatchObject({
+        _tag: "AtCapacity",
+        message: "at capacity: max-jobs is 4",
+        agentId: AGENT,
+      });
+    }),
+  );
+
+  it.effect("any other refusal is Internal carrying the refusal", () =>
+    Effect.gen(function* () {
+      const http = FakeHttp.respondWith(() => FakeHttp.json({ error: "already reserved" }, 400));
+      const proxy = yield* connect.pipe(Effect.provide(http));
+      const error = yield* Effect.flip(Qemu.reserve(proxy)(AGENT));
+      expect(error).toMatchObject({ _tag: "Internal", agentId: AGENT });
+      expect(Render.headline(error)).toBe("internal error: already reserved");
+    }),
+  );
+
+  it.effect("an unreachable proxy is Internal naming the request", () =>
+    Effect.gen(function* () {
+      const proxy = yield* connect.pipe(Effect.provide(unreachable));
+      const error = yield* Effect.flip(Qemu.reserve(proxy)(AGENT));
+      expect(error).toMatchObject({ _tag: "Internal", agentId: AGENT });
+      expect(Render.headline(error)).toBe(`internal error: POST ${SERVER}/reserve failed`);
+    }),
+  );
+});
+
+describe("Qemu.relinquish happy path", () => {
+  it.effect("posts the agent to /relinquish and succeeds on 200", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      const proxy = yield* connect.pipe(Effect.provide(recorder.layer));
+      yield* Qemu.relinquish(proxy)(AGENT);
+      expect(recorder.requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+        `POST ${SERVER}/relinquish`,
+      ]);
+      expect(JSON.parse(recorder.requests[0]?.body ?? "")).toEqual({ agent: AGENT });
+    }),
+  );
+
+  // The guest host let the reservation go on its own (its ten minutes ran out first, or it
+  // restarted): there is nothing to give back, which is what relinquish was for.
+  it.effect("a 400 no reservation is nothing to give back, and succeeds", () =>
+    Effect.gen(function* () {
+      const http = FakeHttp.respondWith(() => FakeHttp.json({ error: "no reservation" }, 400));
+      const proxy = yield* connect.pipe(Effect.provide(http));
+      yield* Qemu.relinquish(proxy)(AGENT);
+    }),
+  );
+});
+
+describe("Qemu.relinquish unhappy path", () => {
+  it.effect("a 500 is Internal carrying the refusal", () =>
+    Effect.gen(function* () {
+      const http = FakeHttp.respondWith(() => FakeHttp.json({ error: "internal error" }, 500));
+      const proxy = yield* connect.pipe(Effect.provide(http));
+      const error = yield* Effect.flip(Qemu.relinquish(proxy)(AGENT));
+      expect(error).toMatchObject({ _tag: "Internal", agentId: AGENT });
+      expect(Render.headline(error)).toBe("internal error: internal error");
+    }),
+  );
+
+  it.effect("an unreachable proxy is Internal naming the request", () =>
+    Effect.gen(function* () {
+      const proxy = yield* connect.pipe(Effect.provide(unreachable));
+      const error = yield* Effect.flip(Qemu.relinquish(proxy)(AGENT));
+      expect(error).toMatchObject({ _tag: "Internal", agentId: AGENT });
+      expect(Render.headline(error)).toBe(`internal error: POST ${SERVER}/relinquish failed`);
+    }),
+  );
+
+  // The sweep that gives expired reservations back is one fiber with nobody waiting on it; a
+  // proxy that never answers must not hold every later expiry behind this one.
+  it.effect("a proxy that never answers is Internal after ten seconds", () =>
+    Effect.gen(function* () {
+      const proxy = yield* connect.pipe(Effect.provide(FakeHttp.never));
+      const pending = yield* Effect.forkChild(Effect.flip(Qemu.relinquish(proxy)(AGENT)));
+      yield* Effect.yieldNow;
+      expect(pending.pollUnsafe()).toBeUndefined();
+      yield* TestClock.adjust("10 seconds");
+      const error = yield* Fiber.join(pending);
+      expect(error).toMatchObject({ _tag: "Internal", agentId: AGENT });
+      expect(Render.headline(error)).toBe(
+        "internal error: relinquish: no answer within 10 seconds",
+      );
+    }),
+  );
+});

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -29,7 +29,7 @@ const layer = (
 const reservedRun = (ticket: string, prompt: string, model = MODEL) =>
   Effect.gen(function* () {
     const sessions = yield* Sessions.Sessions;
-    yield* sessions.reserve(ticket);
+    yield* sessions.reserve(ticket, "drive");
     return yield* sessions.run(ticket, prompt, model);
   });
 
@@ -104,7 +104,7 @@ describe("Sessions.run ceiling", () => {
       const spawner = FakeSpawner.fakeSpawner(() => ({}));
       return Effect.gen(function* () {
         const sessions = yield* Sessions.Sessions;
-        yield* sessions.reserve(TICKET);
+        yield* sessions.reserve(TICKET, "drive");
         const running = yield* Effect.forkChild(
           Effect.flip(sessions.run(TICKET, "do the work", MODEL)),
         );
@@ -120,7 +120,7 @@ describe("Sessions.run ceiling", () => {
         expect(spawner.spawned[0]?.isReleased()).toBe(true);
         expect(spawner.spawned[0]?.kills).toEqual(["SIGTERM"]);
         expect((yield* Effect.flip(sessions.abort(TICKET)))._tag).toBe("UnknownSession");
-        yield* sessions.reserve(OTHER);
+        yield* sessions.reserve(OTHER, "drive");
       }).pipe(Effect.provide(layer(spawner, 1)));
     },
   );
@@ -129,7 +129,7 @@ describe("Sessions.run ceiling", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work", MODEL));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
@@ -149,7 +149,7 @@ describe("Sessions.run unhappy path", () => {
     }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const error = yield* Effect.flip(sessions.run(TICKET, "do the work", MODEL));
       expect(error._tag).toBe("RunFailed");
       expect(error.message).toBe("spawn opencode ENOENT");
@@ -163,7 +163,7 @@ describe("Sessions.run unhappy path", () => {
     }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const error = yield* Effect.flip(sessions.run(TICKET, "do the work", MODEL));
       expect(error._tag).toBe("RunFailed");
       expect(error.message).toBe("out of token credits");
@@ -176,7 +176,7 @@ describe("Sessions.abort happy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work", MODEL));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
@@ -197,8 +197,8 @@ describe("Sessions.abort happy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
-      yield* sessions.reserve(OTHER);
+      yield* sessions.reserve(TICKET, "drive");
+      yield* sessions.reserve(OTHER, "drive");
       const first = yield* Effect.forkChild(sessions.run(TICKET, "first", MODEL));
       const second = yield* Effect.forkChild(sessions.run(OTHER, "second", MODEL));
       for (let i = 0; i < 100 && spawner.spawned.length < 2; i++) {
@@ -219,7 +219,7 @@ describe("Sessions.abort happy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ ignoreTerm: true }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work", MODEL));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
@@ -245,7 +245,7 @@ describe("Sessions.abort happy path", () => {
     }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work", MODEL));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
@@ -290,7 +290,7 @@ describe("Sessions.abort unhappy path", () => {
     }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work", MODEL));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
@@ -312,12 +312,12 @@ describe("Sessions.abort unhappy path", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const first = yield* Effect.forkChild(sessions.run(TICKET, "first", MODEL));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
       }
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const second = yield* Effect.forkChild(sessions.run(TICKET, "second", MODEL));
       for (let i = 0; i < 100 && spawner.spawned.length < 2; i++) {
         yield* Effect.yieldNow;
@@ -336,8 +336,8 @@ describe("capacity", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
-      const error = yield* Effect.flip(sessions.reserve(OTHER));
+      yield* sessions.reserve(TICKET, "drive");
+      const error = yield* Effect.flip(sessions.reserve(OTHER, "drive"));
       expect(error).toMatchObject({
         _tag: "AtCapacity",
         message: "at capacity: max-jobs is 1",
@@ -351,14 +351,14 @@ describe("capacity", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
-      const error = yield* Effect.flip(sessions.reserve(TICKET));
+      yield* sessions.reserve(TICKET, "drive");
+      const error = yield* Effect.flip(sessions.reserve(TICKET, "drive"));
       expect(error).toMatchObject({
         _tag: "BadRequest",
         message: "already reserved",
         agentId: TICKET,
       });
-      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.reserve(OTHER, "drive")))._tag).toBe("AtCapacity");
     }).pipe(Effect.provide(layer(spawner, 1)));
   });
 
@@ -366,13 +366,13 @@ describe("capacity", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const running = yield* Effect.forkChild(sessions.run(TICKET, "first", MODEL));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
       }
       expect(spawner.spawned).toHaveLength(1);
-      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.reserve(OTHER, "drive")))._tag).toBe("AtCapacity");
       expect((yield* Effect.flip(sessions.run(OTHER, "second", MODEL)))._tag).toBe("BadRequest");
       yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
       yield* Fiber.join(running);
@@ -413,15 +413,15 @@ describe("capacity", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({}));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const running = yield* Effect.forkChild(sessions.run(TICKET, "first", MODEL));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
       }
-      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.reserve(OTHER, "drive")))._tag).toBe("AtCapacity");
       yield* sessions.abort(TICKET);
       expect((yield* Effect.flip(Fiber.join(running)))._tag).toBe("RunFailed");
-      yield* sessions.reserve(OTHER);
+      yield* sessions.reserve(OTHER, "drive");
       const next = yield* Effect.forkChild(sessions.run(OTHER, "second", MODEL));
       for (let i = 0; i < 100 && spawner.spawned.length < 2; i++) {
         yield* Effect.yieldNow;
@@ -438,12 +438,12 @@ describe("capacity", () => {
     const spawner = FakeSpawner.fakeSpawner(() => (++spawns === 1 ? {} : { exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       const running = yield* Effect.forkChild(sessions.run(TICKET, "first", MODEL));
       for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
         yield* Effect.yieldNow;
       }
-      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.reserve(OTHER, "drive")))._tag).toBe("AtCapacity");
       yield* Fiber.interrupt(running);
       const exit = yield* Fiber.await(running);
       expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true);
@@ -480,7 +480,7 @@ describe("QEMU-first reserve", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       order.push("returned");
       expect(order).toEqual([`qemu ${TICKET}`, "returned"]);
     }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
@@ -496,7 +496,7 @@ describe("QEMU-first reserve", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      const error = yield* Effect.flip(sessions.reserve(TICKET));
+      const error = yield* Effect.flip(sessions.reserve(TICKET, "drive"));
       expect(error).toMatchObject({
         _tag: "AtCapacity",
         message: "qemu full",
@@ -522,8 +522,8 @@ describe("QEMU-first reserve", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
-      const error = yield* Effect.flip(sessions.reserve(OTHER));
+      yield* sessions.reserve(TICKET, "drive");
+      const error = yield* Effect.flip(sessions.reserve(OTHER, "drive"));
       expect(error).toMatchObject({
         _tag: "AtCapacity",
         message: "at capacity: max-jobs is 1",
@@ -534,7 +534,7 @@ describe("QEMU-first reserve", () => {
       expect((yield* Effect.flip(sessions.run(OTHER, "second", MODEL)))._tag).toBe("BadRequest");
       expect(spawner.spawned).toHaveLength(0);
       // The first ticket still holds the only slot.
-      expect((yield* Effect.flip(sessions.reserve("OLI-7")))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.reserve("OLI-7", "drive")))._tag).toBe("AtCapacity");
       expect(givenBack).toEqual([OTHER, "OLI-7"]);
     }).pipe(Effect.provide(layer(spawner, 1, reserveQemu, relinquishQemu)));
   });
@@ -548,7 +548,7 @@ describe("QEMU-first reserve", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       expect(givenBack).toBe(0);
     }).pipe(Effect.provide(layer(spawner, 1, qemuOk(), relinquishQemu)));
   });
@@ -566,8 +566,8 @@ describe("QEMU-first reserve", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
-      const error = yield* Effect.flip(sessions.reserve(OTHER));
+      yield* sessions.reserve(TICKET, "drive");
+      const error = yield* Effect.flip(sessions.reserve(OTHER, "drive"));
       expect(error).toMatchObject({
         _tag: "Internal",
         message: "internal error",
@@ -592,7 +592,7 @@ describe("QEMU-first reserve", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      const error = yield* Effect.flip(sessions.reserve(TICKET));
+      const error = yield* Effect.flip(sessions.reserve(TICKET, "drive"));
       expect(error).toMatchObject({
         _tag: "Internal",
         message: "internal error",
@@ -613,11 +613,90 @@ describe("QEMU-first reserve", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
-      expect((yield* Effect.flip(sessions.reserve(TICKET)))._tag).toBe("BadRequest");
+      yield* sessions.reserve(TICKET, "drive");
+      expect((yield* Effect.flip(sessions.reserve(TICKET, "drive")))._tag).toBe("BadRequest");
       expect(qemu).toBe(1);
     }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
   });
+});
+
+// A diagnose reads the database and boots nothing: it takes a slot on this client only. A
+// drive takes QEMU first, as above.
+describe("reserve by action", () => {
+  it.effect("a diagnose reserve takes a slot without asking QEMU, and its run spawns", () => {
+    const qemu: Array<string> = [];
+    const reserveQemu: Sessions.ReserveQemu = (agent) =>
+      Effect.sync(() => {
+        qemu.push(agent);
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET, "diagnose");
+      expect(qemu).toEqual([]);
+      expect(yield* sessions.jobs).toBe(1);
+      yield* sessions.run(TICKET, "diagnose the session", MODEL);
+      expect(spawner.spawned.map((spawned) => spawned.args[5])).toEqual(["diagnose the session"]);
+      expect(yield* sessions.jobs).toBe(0);
+    }).pipe(Effect.provide(layer(spawner, 1, reserveQemu)));
+  });
+
+  it.effect(
+    "a diagnose reserve past --max-jobs is AtCapacity and neither asks nor relinquishes QEMU",
+    () => {
+      const qemu: Array<string> = [];
+      const givenBack: Array<string> = [];
+      const reserveQemu: Sessions.ReserveQemu = (agent) =>
+        Effect.sync(() => {
+          qemu.push(agent);
+        });
+      const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
+        Effect.sync(() => {
+          givenBack.push(agent);
+        });
+      const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+      return Effect.gen(function* () {
+        const sessions = yield* Sessions.Sessions;
+        yield* sessions.reserve(TICKET, "drive");
+        const error = yield* Effect.flip(sessions.reserve(OTHER, "diagnose"));
+        expect(error).toMatchObject({
+          _tag: "AtCapacity",
+          message: "at capacity: max-jobs is 1",
+          agentId: OTHER,
+        });
+        // The drive asked once; the diagnose never did, so there was nothing to give back.
+        expect(qemu).toEqual([TICKET]);
+        expect(givenBack).toEqual([]);
+        expect((yield* Effect.flip(sessions.run(OTHER, "second", MODEL)))._tag).toBe("BadRequest");
+        expect(spawner.spawned).toHaveLength(0);
+      }).pipe(Effect.provide(layer(spawner, 1, reserveQemu, relinquishQemu)));
+    },
+  );
+
+  it.effect(
+    "a second reserve of the same ticket under the other action is already reserved",
+    () => {
+      const qemu: Array<string> = [];
+      const reserveQemu: Sessions.ReserveQemu = (agent) =>
+        Effect.sync(() => {
+          qemu.push(agent);
+        });
+      const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+      return Effect.gen(function* () {
+        const sessions = yield* Sessions.Sessions;
+        yield* sessions.reserve(TICKET, "diagnose");
+        const error = yield* Effect.flip(sessions.reserve(TICKET, "drive"));
+        expect(error).toMatchObject({
+          _tag: "BadRequest",
+          message: "already reserved",
+          agentId: TICKET,
+        });
+        // Refused before QEMU was asked: a held ticket costs the guest host nothing.
+        expect(qemu).toEqual([]);
+        expect(yield* sessions.jobs).toBe(1);
+      }).pipe(Effect.provide(layer(spawner, 2, reserveQemu)));
+    },
+  );
 });
 
 describe("jobs", () => {
@@ -626,7 +705,7 @@ describe("jobs", () => {
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
       expect(yield* sessions.jobs).toBe(0);
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       expect(yield* sessions.jobs).toBe(1);
       yield* sessions.run(TICKET, "do the work", MODEL);
       expect(yield* sessions.jobs).toBe(0);
@@ -637,9 +716,9 @@ describe("jobs", () => {
     const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
     return Effect.gen(function* () {
       const sessions = yield* Sessions.Sessions;
-      yield* sessions.reserve(TICKET);
+      yield* sessions.reserve(TICKET, "drive");
       expect(yield* sessions.jobs).toBe(1);
-      expect((yield* Effect.flip(sessions.reserve(OTHER)))._tag).toBe("AtCapacity");
+      expect((yield* Effect.flip(sessions.reserve(OTHER, "drive")))._tag).toBe("AtCapacity");
       expect(yield* sessions.jobs).toBe(1);
     }).pipe(Effect.provide(layer(spawner, 1)));
   });

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -6,6 +6,7 @@ import * as OpenCode from "../../src/automation-client/opencode.ts";
 import * as Sessions from "../../src/automation-client/sessions.ts";
 import * as Cli from "../../src/cli.ts";
 import * as Errors from "../../src/shared/errors.ts";
+import * as FakeLog from "../support/log.ts";
 import * as FakeSpawner from "../support/fake-spawner.ts";
 
 const TICKET = "OLI-42";
@@ -25,8 +26,15 @@ const layer = (
   maxJobs = MAX_JOBS,
   reserveQemu: Sessions.ReserveQemu = qemuOk(),
   relinquishQemu: Sessions.RelinquishQemu = qemuRelinquishOk(),
+  log: FakeLog.FakeLog = FakeLog.fakeLog(),
 ) =>
-  Sessions.Sessions.layer(maxJobs, reserveQemu, relinquishQemu).pipe(Layer.provide(spawner.layer));
+  Sessions.Sessions.layer(maxJobs, reserveQemu, relinquishQemu).pipe(
+    Layer.provide(Layer.mergeAll(spawner.layer, log.layer)),
+  );
+
+// A reservation nobody runs is gone after this long; the sweep that notices runs every ten
+// seconds from the start, so advancing by exactly this much lands on a sweep.
+const RESERVATION_TIMEOUT = "10 minutes";
 
 const reservedRun = (ticket: string, prompt: string, model = MODEL) =>
   Effect.gen(function* () {
@@ -755,6 +763,140 @@ describe("Sessions.run when a process opencode started still holds stderr", () =
       }).pipe(Effect.provide(layer(spawner, 1)));
     },
   );
+});
+
+// A reservation is a promise that a run follows at once; one nobody runs (the dispatcher died
+// between /reserve and /run) is given back after ten minutes, in memory only, so the slot and
+// any guest slot taken for it are free again and a restarted dispatcher can place the job anew.
+describe("reservation expiry", () => {
+  it.effect(
+    "a drive reservation unused for ten minutes expires: its slot is free, jobs drops, the guest slot is relinquished, one warning line",
+    () => {
+      const givenBack: Array<string> = [];
+      const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
+        Effect.sync(() => {
+          givenBack.push(agent);
+        });
+      const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+      const log = FakeLog.fakeLog();
+      return Effect.gen(function* () {
+        const sessions = yield* Sessions.Sessions;
+        yield* sessions.reserve(TICKET, "drive");
+        expect(yield* sessions.jobs).toBe(1);
+        yield* TestClock.adjust(RESERVATION_TIMEOUT);
+        expect(yield* sessions.jobs).toBe(0);
+        expect(givenBack).toEqual([TICKET]);
+        // Gone from the reserved set: a late run is refused, the slot goes to the next ticket.
+        expect(yield* Effect.flip(sessions.run(TICKET, "late", MODEL))).toMatchObject({
+          _tag: "BadRequest",
+          message: "no reservation",
+        });
+        yield* sessions.reserve(OTHER, "drive");
+        expect(spawner.spawned).toEqual([]);
+        expect(log.lines).toEqual([
+          {
+            level: "warning",
+            text: "reservation expired; unused for 10 minutes",
+            location: "automation-client",
+            agentId: TICKET,
+            skipSentry: false,
+            cause: undefined,
+          },
+        ]);
+      }).pipe(Effect.provide(layer(spawner, 1, qemuOk(), relinquishQemu, log)));
+    },
+  );
+
+  it.effect("a diagnose reservation unused for ten minutes expires without asking QEMU", () => {
+    const qemu: Array<string> = [];
+    const reserveQemu: Sessions.ReserveQemu = (agent) =>
+      Effect.sync(() => {
+        qemu.push(`reserve ${agent}`);
+      });
+    const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
+      Effect.sync(() => {
+        qemu.push(`relinquish ${agent}`);
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    const log = FakeLog.fakeLog();
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET, "diagnose");
+      yield* TestClock.adjust(RESERVATION_TIMEOUT);
+      expect(yield* sessions.jobs).toBe(0);
+      expect(qemu).toEqual([]);
+      expect(FakeLog.texts(log)).toEqual(["reservation expired; unused for 10 minutes"]);
+    }).pipe(Effect.provide(layer(spawner, 1, reserveQemu, relinquishQemu, log)));
+  });
+
+  it.effect("a reservation consumed by a run in time never expires", () => {
+    const givenBack: Array<string> = [];
+    const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
+      Effect.sync(() => {
+        givenBack.push(agent);
+      });
+    const spawner = FakeSpawner.fakeSpawner(() => ({}));
+    const log = FakeLog.fakeLog();
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET, "drive");
+      const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work", MODEL));
+      for (let i = 0; i < 100 && spawner.spawned[0] === undefined; i++) {
+        yield* Effect.yieldNow;
+      }
+      // Ten minutes into the run: the slot is the run's now, not a reservation's.
+      yield* TestClock.adjust(RESERVATION_TIMEOUT);
+      expect(yield* sessions.jobs).toBe(1);
+      expect(givenBack).toEqual([]);
+      expect(log.lines).toEqual([]);
+      expect((yield* Effect.flip(sessions.reserve(OTHER, "drive")))._tag).toBe("AtCapacity");
+      yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
+      yield* Fiber.join(running);
+      expect(yield* sessions.jobs).toBe(0);
+    }).pipe(Effect.provide(layer(spawner, 1, qemuOk(), relinquishQemu, log)));
+  });
+
+  it.effect(
+    "a relinquish that fails at expiry is one error line and the slot is freed all the same",
+    () => {
+      const relinquishQemu: Sessions.RelinquishQemu = (agent) =>
+        Errors.Internal.make({ cause: new Error("proxy unreachable"), agentId: agent });
+      const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+      const log = FakeLog.fakeLog();
+      return Effect.gen(function* () {
+        const sessions = yield* Sessions.Sessions;
+        yield* sessions.reserve(TICKET, "drive");
+        yield* TestClock.adjust(RESERVATION_TIMEOUT);
+        expect(yield* sessions.jobs).toBe(0);
+        yield* sessions.reserve(OTHER, "drive");
+        expect(log.lines.map((line) => [line.level, line.text, line.agentId])).toEqual([
+          ["warning", "reservation expired; unused for 10 minutes", TICKET],
+          ["error", "relinquish failed: internal error: proxy unreachable", TICKET],
+        ]);
+        expect(log.lines[1]?.cause).toBeDefined();
+      }).pipe(Effect.provide(layer(spawner, 1, qemuOk(), relinquishQemu, log)));
+    },
+  );
+
+  it.effect("expiry is per reservation: a younger one stays when an older one goes", () => {
+    const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 0 }));
+    const log = FakeLog.fakeLog();
+    return Effect.gen(function* () {
+      const sessions = yield* Sessions.Sessions;
+      yield* sessions.reserve(TICKET, "drive");
+      yield* TestClock.adjust("5 minutes");
+      yield* sessions.reserve(OTHER, "diagnose");
+      yield* TestClock.adjust("5 minutes");
+      expect(yield* sessions.jobs).toBe(1);
+      expect(log.lines.map((line) => line.agentId)).toEqual([TICKET]);
+      // The younger one still runs.
+      yield* sessions.run(OTHER, "still mine", MODEL);
+      expect(spawner.spawned.map((spawned) => spawned.args[5])).toEqual(["still mine"]);
+      // The ticket that expired may reserve again.
+      yield* sessions.reserve(TICKET, "drive");
+      expect(yield* sessions.jobs).toBe(1);
+    }).pipe(Effect.provide(layer(spawner, 2, qemuOk(), qemuRelinquishOk(), log)));
+  });
 });
 
 describe("jobs", () => {

--- a/test/automation-client/sessions.unit.test.ts
+++ b/test/automation-client/sessions.unit.test.ts
@@ -13,6 +13,8 @@ const OTHER = "OLI-99";
 const MODEL = "opencode/muse-spark-1.3-contributor-free";
 // Room for the two runs the tests above capacity start at once; the capacity tests pass 1.
 const MAX_JOBS = 2;
+// How long a run waits for stderr to end after opencode exited; then the tail so far is the tail.
+const STDERR_GRACE = "2 seconds";
 
 const qemuOk = (): Sessions.ReserveQemu => () => Effect.void;
 
@@ -695,6 +697,62 @@ describe("reserve by action", () => {
         expect(qemu).toEqual([]);
         expect(yield* sessions.jobs).toBe(1);
       }).pipe(Effect.provide(layer(spawner, 2, reserveQemu)));
+    },
+  );
+});
+
+// The stderr pipe is shared with every process opencode starts (an MCP server, a tool the agent
+// ran); one that outlives opencode keeps the pipe open. The exit is the end of the run.
+describe("Sessions.run when a process opencode started still holds stderr", () => {
+  it.effect(
+    "a run whose opencode exited 0 succeeds after the grace, not at the ceiling, and frees its slot",
+    () => {
+      const spawner = FakeSpawner.fakeSpawner(() => ({
+        exitCode: 0,
+        stderr: "noise\n",
+        stderrStaysOpen: true,
+      }));
+      return Effect.gen(function* () {
+        const sessions = yield* Sessions.Sessions;
+        yield* sessions.reserve(TICKET, "drive");
+        const running = yield* Effect.forkChild(sessions.run(TICKET, "do the work", MODEL));
+        for (let i = 0; i < 100; i++) {
+          yield* Effect.yieldNow;
+        }
+        expect(spawner.spawned[0]).toBeDefined();
+        expect(running.pollUnsafe()).toBeUndefined();
+        yield* TestClock.adjust(STDERR_GRACE);
+        yield* Fiber.join(running);
+        expect(spawner.spawned[0]?.kills).toEqual([]);
+        expect(yield* sessions.jobs).toBe(0);
+        yield* sessions.reserve(OTHER, "drive");
+      }).pipe(Effect.provide(layer(spawner, 1)));
+    },
+  );
+
+  it.effect(
+    "a run whose opencode exited 1 is RunFailed with what it wrote, after the grace",
+    () => {
+      const spawner = FakeSpawner.fakeSpawner(() => ({
+        exitCode: 1,
+        stderr: "out of token credits\n",
+        stderrStaysOpen: true,
+      }));
+      return Effect.gen(function* () {
+        const sessions = yield* Sessions.Sessions;
+        yield* sessions.reserve(TICKET, "drive");
+        const running = yield* Effect.forkChild(
+          Effect.flip(sessions.run(TICKET, "do the work", MODEL)),
+        );
+        for (let i = 0; i < 100; i++) {
+          yield* Effect.yieldNow;
+        }
+        expect(running.pollUnsafe()).toBeUndefined();
+        yield* TestClock.adjust(STDERR_GRACE);
+        const error = yield* Fiber.join(running);
+        expect(error).toMatchObject({ _tag: "RunFailed", message: "out of token credits" });
+        expect(yield* sessions.jobs).toBe(0);
+      }).pipe(Effect.provide(layer(spawner, 1)));
     },
   );
 });

--- a/test/automation-server/client.unit.test.ts
+++ b/test/automation-server/client.unit.test.ts
@@ -16,8 +16,11 @@ const token = Layer.succeed(AutomationClient.OligarchyToken)(
   AutomationClient.OligarchyToken.of(Redacted.make(TOKEN)),
 );
 
-const reserve = (http: Layer.Layer<HttpClient.HttpClient>) =>
-  AutomationClient.reserve(URL, TICKET).pipe(Effect.provide(Layer.mergeAll(token, http)));
+const reserve = (
+  http: Layer.Layer<HttpClient.HttpClient>,
+  action: "drive" | "diagnose" = "drive",
+) =>
+  AutomationClient.reserve(URL, TICKET, action).pipe(Effect.provide(Layer.mergeAll(token, http)));
 
 const run = (http: Layer.Layer<HttpClient.HttpClient>) =>
   AutomationClient.run(URL, PROMPT, TICKET, MODEL).pipe(
@@ -28,7 +31,7 @@ const abort = (http: Layer.Layer<HttpClient.HttpClient>) =>
   AutomationClient.abort(URL, TICKET).pipe(Effect.provide(Layer.mergeAll(token, http)));
 
 describe("automation client POST /reserve happy path", () => {
-  it.effect("posts the ticket with the bearer token and succeeds on 200", () =>
+  it.effect("posts the ticket and the action with the bearer token and succeeds on 200", () =>
     Effect.gen(function* () {
       const recorder = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
       yield* reserve(recorder.layer);
@@ -36,7 +39,21 @@ describe("automation client POST /reserve happy path", () => {
       expect(recorder.requests[0]?.method).toBe("POST");
       expect(recorder.requests[0]?.url).toBe(`${URL}/reserve`);
       expect(recorder.requests[0]?.headers.authorization).toBe(`Bearer ${TOKEN}`);
-      expect(JSON.parse(recorder.requests[0]?.body ?? "")).toEqual({ ticket: TICKET });
+      expect(JSON.parse(recorder.requests[0]?.body ?? "")).toEqual({
+        ticket: TICKET,
+        action: "drive",
+      });
+    }),
+  );
+
+  it.effect("a diagnose is posted as such, so the client takes no guest slot for it", () =>
+    Effect.gen(function* () {
+      const recorder = FakeHttp.recordRequests(() => FakeHttp.json({ ok: "true" }));
+      yield* reserve(recorder.layer, "diagnose");
+      expect(JSON.parse(recorder.requests[0]?.body ?? "")).toEqual({
+        ticket: TICKET,
+        action: "diagnose",
+      });
     }),
   );
 });

--- a/test/automation-server/worker.unit.test.ts
+++ b/test/automation-server/worker.unit.test.ts
@@ -224,7 +224,11 @@ describe("dispatch happy path", () => {
           reason: null,
           finishedAt: expect.any(Date),
         });
-        expect(JSON.parse(http.requests[0]?.body ?? "")).toEqual({ ticket: TICKET });
+        // A drive reserves as one: the client takes a guest slot before its own.
+        expect(JSON.parse(http.requests[0]?.body ?? "")).toEqual({
+          ticket: TICKET,
+          action: "drive",
+        });
         expect(JSON.parse(http.requests[1]?.body ?? "")).toEqual({
           prompt: DRIVE_PROMPT,
           ticket: TICKET,
@@ -261,6 +265,11 @@ describe("dispatch happy path", () => {
       yield* start(fixed, http.layer);
       yield* settle(fixed.automation.jobs, "succeeded");
       expect(fixed.automation.jobs[0]?.status).toBe("succeeded");
+      // A diagnose reserves as one: the client takes a slot of its own and no guest.
+      expect(JSON.parse(http.requests[0]?.body ?? "")).toEqual({
+        ticket: TICKET,
+        action: "diagnose",
+      });
       expect(JSON.parse(http.requests[1]?.body ?? "")).toEqual({
         prompt: DIAGNOSE_PROMPT,
         ticket: TICKET,

--- a/test/cli.unit.test.ts
+++ b/test/cli.unit.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect } from "vitest";
 import { it } from "@effect/vitest";
 import { Effect, Fiber, Layer, PlatformError, Sink, Stream } from "effect";
+import { TestClock } from "effect/testing";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as Cli from "../src/cli.ts";
 import * as FakeSpawner from "./support/fake-spawner.ts";
+
+// How long a run waits for stderr to end after the command exited; then the tail so far is the tail.
+const STDERR_GRACE = "2 seconds";
+
+// Enough turns for a forked run to spawn, see the exit and register its grace timer.
+const settle = Effect.gen(function* () {
+  for (let i = 0; i < 100; i++) {
+    yield* Effect.yieldNow;
+  }
+});
 
 describe("Cli.run happy path", () => {
   it.effect(
@@ -50,6 +61,44 @@ describe("Cli.run happy path", () => {
       yield* Effect.yieldNow;
       expect(running.pollUnsafe()).toBeUndefined();
       yield* spawner.spawned[0]?.exit(0) ?? Effect.void;
+      yield* Fiber.join(running);
+    }),
+  );
+
+  // The stderr pipe is shared with every process the command started; one that outlives it
+  // keeps the pipe open, and Node's `exit` fires long before its `close`. The exit is the end
+  // of the run: the wait for stderr is bounded after it.
+  it.effect(
+    "succeeds once the command exits 0 while a process it started still holds stderr, after the grace",
+    () =>
+      Effect.gen(function* () {
+        const spawner = FakeSpawner.fakeSpawner(() => ({
+          exitCode: 0,
+          stderr: "noise\n",
+          stderrStaysOpen: true,
+        }));
+        const running = yield* Effect.forkChild(
+          Cli.run("tool", ["run"]).pipe(Effect.provide(spawner.layer)),
+        );
+        yield* settle;
+        expect(running.pollUnsafe()).toBeUndefined();
+        yield* TestClock.adjust(STDERR_GRACE);
+        yield* Fiber.join(running);
+        // Leaving the scope released the process; nothing was killed, it had already exited.
+        expect(spawner.spawned[0]?.isReleased()).toBe(true);
+        expect(spawner.spawned[0]?.kills).toEqual([]);
+      }),
+  );
+
+  it.effect("does not wait out the grace when stderr ends with the exit", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({}));
+      const running = yield* Effect.forkChild(
+        Cli.run("tool", ["run"]).pipe(Effect.provide(spawner.layer)),
+      );
+      yield* Effect.yieldNow;
+      yield* spawner.spawned[0]?.exit(0, "last words\n") ?? Effect.void;
+      // No clock adjustment: the exit and the pipe's end are all the run waits for.
       yield* Fiber.join(running);
     }),
   );
@@ -106,12 +155,48 @@ describe("Cli.run unhappy path", () => {
       }),
   );
 
+  // The drain keeps a bounded buffer; NUL bytes are dropped as they arrive, so a binary blob after
+  // the message cannot push it out of the buffer.
+  it.effect("keeps the message when a NUL blob larger than the buffer follows it", () =>
+    Effect.gen(function* () {
+      const spawner = FakeSpawner.fakeSpawner(() => ({
+        exitCode: 1,
+        stderr: `Error: Invalid upload request.\n${"\u0000".repeat(20_000)}`,
+      }));
+      const error = yield* Effect.flip(
+        Cli.run("tool", ["run"]).pipe(Effect.provide(spawner.layer)),
+      );
+      expect(error.message).toBe("Error: Invalid upload request.");
+    }),
+  );
+
   it.effect("names the exit when the command exits non-zero with empty stderr", () =>
     Effect.gen(function* () {
       const spawner = FakeSpawner.fakeSpawner(() => ({ exitCode: 2 }));
       const error = yield* Effect.flip(Cli.run("tool", []).pipe(Effect.provide(spawner.layer)));
       expect(error.message).toBe("tool exited 2");
     }),
+  );
+
+  it.effect(
+    "fails with what the command wrote when it exits non-zero while a process it started still holds stderr",
+    () =>
+      Effect.gen(function* () {
+        const spawner = FakeSpawner.fakeSpawner(() => ({
+          exitCode: 1,
+          stderr: "out of token credits\n",
+          stderrStaysOpen: true,
+        }));
+        const running = yield* Effect.forkChild(
+          Effect.flip(Cli.run("tool", ["run"]).pipe(Effect.provide(spawner.layer))),
+        );
+        yield* settle;
+        expect(running.pollUnsafe()).toBeUndefined();
+        yield* TestClock.adjust(STDERR_GRACE);
+        const error = yield* Fiber.join(running);
+        expect(error._tag).toBe("CliFailed");
+        expect(error.message).toBe("out of token credits");
+      }),
   );
 
   it.effect("fails with the signal when the command dies before exiting", () =>

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -161,13 +161,20 @@ const request = (port: number, path: string, headers: Record<string, string>, bo
 
 const AUTH_JSON = { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" };
 
-// The client reserves QEMU first; these process tests stub that host so /reserve can succeed.
+const DRIVE_RESERVE = JSON.stringify({ ticket: "OLI-42", action: "drive" });
+const DIAGNOSE_RESERVE = JSON.stringify({ ticket: "OLI-42", action: "diagnose" });
+
+// A drive reserves QEMU first; these process tests stub that host so /reserve can succeed, and
+// count what reached it so a diagnose can be shown to ask nothing.
 const stubQemuReserve = async (): Promise<{
   readonly url: string;
+  readonly hits: () => ReadonlyArray<string>;
   readonly close: () => Promise<void>;
 }> => {
+  const hits: Array<string> = [];
   const server = createHttpServer((req, res) => {
     if (req.method === "POST" && (req.url === "/reserve" || req.url === "/relinquish")) {
+      hits.push(req.url);
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: "true" }));
       return;
@@ -181,6 +188,7 @@ const stubQemuReserve = async (): Promise<{
   });
   return {
     url: `http://127.0.0.1:${String(portOf(server.address()))}`,
+    hits: () => hits,
     close: () => new Promise((done) => server.close(() => done())),
   };
 };
@@ -345,10 +353,7 @@ describeWithDatabase("automation client POST /run", () => {
           await process.waitFor(
             new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
           );
-          expect(
-            (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" })))
-              .status,
-          ).toBe(200);
+          expect((await request(port, "/reserve", AUTH_JSON, DRIVE_RESERVE)).status).toBe(200);
           const response = await request(
             port,
             "/run",
@@ -367,6 +372,7 @@ describeWithDatabase("automation client POST /run", () => {
               openrouter: { options: { headerTimeout: 180_000, chunkTimeout: 180_000 } },
             },
           });
+          expect(qemu.hits()).toEqual(["/reserve"]);
         } finally {
           process.child.kill("SIGTERM");
           await process.exited;
@@ -374,6 +380,38 @@ describeWithDatabase("automation client POST /run", () => {
           await qemu.close();
         }
       }),
+  );
+
+  it.live("a diagnose reserve asks the qemu host nothing, and its run still answers 200", () =>
+    Effect.promise(async () => {
+      const qemu = await stubQemuReserve();
+      const bin = installOpencode("exit 0");
+      const port = await freePort();
+      const process = spawnAutomationClient(
+        [...REQUIRED, "--port", String(port)],
+        { SERVER_URL: qemu.url },
+        `${bin}:${processEnv.PATH ?? ""}`,
+      );
+      try {
+        await process.waitFor(
+          new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
+        );
+        expect((await request(port, "/reserve", AUTH_JSON, DIAGNOSE_RESERVE)).status).toBe(200);
+        const response = await request(
+          port,
+          "/run",
+          AUTH_JSON,
+          JSON.stringify({ prompt: "diagnose the session", ticket: "OLI-42", model: MODEL }),
+        );
+        expect(response.status).toBe(200);
+        expect(qemu.hits()).toEqual([]);
+      } finally {
+        process.child.kill("SIGTERM");
+        await process.exited;
+        rmSync(bin, { recursive: true, force: true });
+        await qemu.close();
+      }
+    }),
   );
 
   it.live("answers 500 with opencode's error when it exits non-zero", () =>
@@ -390,9 +428,7 @@ describeWithDatabase("automation client POST /run", () => {
         await process.waitFor(
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
         );
-        expect(
-          (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" }))).status,
-        ).toBe(200);
+        expect((await request(port, "/reserve", AUTH_JSON, DRIVE_RESERVE)).status).toBe(200);
         const response = await request(
           port,
           "/run",
@@ -459,9 +495,7 @@ describeWithDatabase("automation client POST /run", () => {
             `automation client listening on 127.0.0.1:${String(port)}; name garage; max jobs 1`,
           ),
         );
-        expect(
-          (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" }))).status,
-        ).toBe(200);
+        expect((await request(port, "/reserve", AUTH_JSON, DRIVE_RESERVE)).status).toBe(200);
         const running = request(
           port,
           "/run",
@@ -479,7 +513,7 @@ describeWithDatabase("automation client POST /run", () => {
           port,
           "/reserve",
           AUTH_JSON,
-          JSON.stringify({ ticket: "OLI-99" }),
+          JSON.stringify({ ticket: "OLI-99", action: "drive" }),
         );
         expect(refused.status).toBe(503);
         expect(await refused.json()).toEqual({ error: "at capacity: max-jobs is 1" });
@@ -524,9 +558,7 @@ describeWithDatabase("automation client POST /abort", () => {
         await process.waitFor(
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
         );
-        expect(
-          (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" }))).status,
-        ).toBe(200);
+        expect((await request(port, "/reserve", AUTH_JSON, DRIVE_RESERVE)).status).toBe(200);
         const running = request(
           port,
           "/run",
@@ -576,9 +608,7 @@ describeWithDatabase("automation client POST /abort", () => {
         await process.waitFor(
           new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
         );
-        expect(
-          (await request(port, "/reserve", AUTH_JSON, JSON.stringify({ ticket: "OLI-42" }))).status,
-        ).toBe(200);
+        expect((await request(port, "/reserve", AUTH_JSON, DRIVE_RESERVE)).status).toBe(200);
         const running = request(
           port,
           "/run",

--- a/test/integration/automation-client.integration.test.ts
+++ b/test/integration/automation-client.integration.test.ts
@@ -414,6 +414,55 @@ describeWithDatabase("automation client POST /run", () => {
     }),
   );
 
+  // opencode's stderr is shared with everything it starts; a straggler holding it must not hold
+  // the answer. The exit ends the run.
+  it.live(
+    "answers 200 once opencode exits 0 even while a process it started still holds stderr",
+    () =>
+      Effect.promise(async () => {
+        const qemu = await stubQemuReserve();
+        // The straggler keeps opencode's stderr and outlives it by a minute; it gives up stdout,
+        // which is this test's pipe to the client, so the client's own close is not held too.
+        const bin = installOpencode(
+          '(exec sleep 60 >/dev/null) & echo $! > "$(dirname "$0")/straggler"; echo agent-said-done >&2; exit 0',
+        );
+        const port = await freePort();
+        const process = spawnAutomationClient(
+          [...REQUIRED, "--port", String(port)],
+          { SERVER_URL: qemu.url },
+          `${bin}:${processEnv.PATH ?? ""}`,
+        );
+        try {
+          await process.waitFor(
+            new RegExp(`automation client listening on 127.0.0.1:${String(port)}`),
+          );
+          expect((await request(port, "/reserve", AUTH_JSON, DRIVE_RESERVE)).status).toBe(200);
+          const began = Date.now();
+          const response = await request(
+            port,
+            "/run",
+            AUTH_JSON,
+            JSON.stringify({ prompt: "do the work", ticket: "OLI-42", model: MODEL }),
+          );
+          expect(response.status).toBe(200);
+          // Well under the straggler's minute: the grace, not the pipe, bounded the wait.
+          expect(Date.now() - began).toBeLessThan(30_000);
+        } finally {
+          process.child.kill("SIGTERM");
+          await process.exited;
+          const straggler = Number(readFileSync(join(bin, "straggler"), "utf8").trim());
+          // Best effort: a straggler already gone cannot be killed.
+          try {
+            globalThis.process.kill(straggler, "SIGKILL");
+          } catch {
+            // ESRCH: it exited on its own.
+          }
+          rmSync(bin, { recursive: true, force: true });
+          await qemu.close();
+        }
+      }),
+  );
+
   it.live("answers 500 with opencode's error when it exits non-zero", () =>
     Effect.promise(async () => {
       const qemu = await stubQemuReserve();

--- a/test/qemu-reverse-proxy/http.unit.test.ts
+++ b/test/qemu-reverse-proxy/http.unit.test.ts
@@ -871,6 +871,73 @@ describe("placement", () => {
     }),
   );
 
+  // The server let the reservation go on its own (ten minutes unused) or restarted: it holds
+  // nothing for the agent, so the route is stale too, and a fresh reserve must be able to place.
+  it.effect(
+    "POST /relinquish answered 400 no reservation by the server forgets the agent and passes the 400 through",
+    () =>
+      Effect.gen(function* () {
+        const fixed = fixture((request, url) =>
+          url.pathname === "/relinquish"
+            ? FakeHttp.json({ error: "no reservation" }, 400)
+            : url.pathname === "/reserve"
+              ? FakeHttp.json({ ok: "true" })
+              : fleet(request, url),
+        );
+        fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+        yield* Effect.gen(function* () {
+          const api = yield* qemuServerClient;
+          yield* api.Sessions.reserve({ payload: reserveBody });
+          expect(fixed.store.agents.has(AGENT_ID)).toBe(true);
+          const error = yield* Effect.flip(api.Sessions.relinquish({ payload: reserveBody }));
+          expect(error).toMatchObject({ _tag: "BadRequest", message: "no reservation" });
+          // Forgotten: the agent can reserve again, and the placement runs afresh.
+          yield* api.Sessions.reserve({ payload: reserveBody });
+        }).pipe(Effect.provide(serve(fixed)));
+        expect(fixed.store.agents.has(AGENT_ID)).toBe(true);
+        expect(
+          fixed.upstream.requests
+            .filter((request) => request.url.endsWith("/reserve"))
+            .map((request) => request.url),
+        ).toEqual([`${SERVER_B}/reserve`, `${SERVER_B}/reserve`]);
+        expect(fixed.log.lines.filter((line) => line.text.startsWith("reservation gone"))).toEqual([
+          {
+            level: "info",
+            text: `reservation gone; ${SERVER_B}`,
+            location: "server",
+            agentId: AGENT_ID,
+            skipSentry: false,
+            cause: undefined,
+          },
+        ]);
+      }),
+  );
+
+  it.effect("POST /relinquish answered 500 by the server keeps the agent routed", () =>
+    Effect.gen(function* () {
+      const fixed = fixture((request, url) =>
+        url.pathname === "/relinquish"
+          ? FakeHttp.json({ error: "internal error" }, 500)
+          : url.pathname === "/reserve"
+            ? FakeHttp.json({ ok: "true" })
+            : fleet(request, url),
+      );
+      fixed.store.servers.push(qemu(SERVER_A), qemu(SERVER_B));
+      yield* Effect.gen(function* () {
+        const api = yield* qemuServerClient;
+        yield* api.Sessions.reserve({ payload: reserveBody });
+        const error = yield* Effect.flip(api.Sessions.relinquish({ payload: reserveBody }));
+        expect(error).toMatchObject({ _tag: "Internal" });
+        // Still routed: the server may well hold the slot, so a second reserve is refused.
+        const again = yield* Effect.flip(api.Sessions.reserve({ payload: reserveBody }));
+        expect(again).toMatchObject({ _tag: "BadRequest", message: "already reserved" });
+      }).pipe(Effect.provide(serve(fixed)));
+      expect(fixed.store.agents.has(AGENT_ID)).toBe(true);
+      expect(fixed.log.lines.some((line) => line.text.startsWith("reservation gone"))).toBe(false);
+      expect(fixed.log.lines.some((line) => line.text.startsWith("relinquished"))).toBe(false);
+    }),
+  );
+
   it.effect("POST /relinquish without a reservation is 400 no reservation", () =>
     Effect.gen(function* () {
       const fixed = fixture();

--- a/test/qemu-server/sessions.unit.test.ts
+++ b/test/qemu-server/sessions.unit.test.ts
@@ -2304,3 +2304,113 @@ describe("capacity", () => {
     }),
   );
 });
+
+// ---------------------------------------------------------------------------
+// reservation expiry
+// ---------------------------------------------------------------------------
+
+// A reservation is a promise that a start follows soon; one nobody starts (the client that took
+// it died, or its dispatcher did) is given back after ten minutes, in memory only: no row records
+// a reservation, so a restart starts clean.
+describe("reservation expiry", () => {
+  it.effect(
+    "a reservation unused for ten minutes expires: the slot is free, jobs drops, a late start is refused, one warning line",
+    () =>
+      Effect.gen(function* () {
+        const h = harness({ maxJobs: 1 });
+        yield* h.run(
+          Effect.gen(function* () {
+            const sessions = yield* Sessions.Sessions;
+            yield* sessions.reserve(AGENT);
+            expect(yield* sessions.jobs).toBe(1);
+            yield* TestClock.adjust("10 minutes");
+            expect(yield* sessions.jobs).toBe(0);
+            expect(yield* Effect.flip(sessions.start(startBody(), "none", false))).toMatchObject({
+              _tag: "BadRequest",
+              message: "no reservation",
+              agentId: AGENT,
+            });
+            yield* sessions.reserve(OTHER_AGENT);
+            expect(yield* qemus(sessions)).toBe(0);
+            // Nothing durable: no row, no registration, no span.
+            expect(h.sessions.sessions).toEqual([]);
+            expect(h.sessions.agentRuns).toEqual([]);
+            expect(spanNamed(h, AGENT)).toBeUndefined();
+            expect(h.log.lines).toEqual([
+              {
+                level: "warning",
+                text: "reservation expired; unused for 10 minutes",
+                location: "server",
+                agentId: AGENT,
+                skipSentry: false,
+                cause: undefined,
+              },
+            ]);
+          }),
+        );
+      }),
+  );
+
+  it.effect("a reservation consumed by a start in time never expires", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          yield* sessions.reserve(AGENT);
+          yield* TestClock.adjust("5 minutes");
+          const id = yield* sessions.start(startBody(), "none", false);
+          // Eleven minutes after the reserve, six into the session: the slot is the session's.
+          yield* TestClock.adjust("6 minutes");
+          expect(yield* sessions.jobs).toBe(1);
+          expect(yield* qemus(sessions)).toBe(1);
+          expect(h.sessions.sessions.map((row) => [row.id, row.status])).toEqual([[id, "running"]]);
+          expect((yield* Effect.flip(sessions.reserve(OTHER_AGENT)))._tag).toBe("AtCapacity");
+        }),
+      );
+      expect(line(h, "reservation expired")).toBeUndefined();
+    }),
+  );
+
+  it.effect("an expired reservation cannot be relinquished, and its agent may reserve again", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 1 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          yield* sessions.reserve(AGENT);
+          yield* TestClock.adjust("10 minutes");
+          expect(yield* Effect.flip(sessions.relinquish(AGENT))).toMatchObject({
+            _tag: "BadRequest",
+            message: "no reservation",
+            agentId: AGENT,
+          });
+          yield* sessions.reserve(AGENT);
+          expect(yield* sessions.jobs).toBe(1);
+          expect(texts(h)).toEqual(["reservation expired; unused for 10 minutes"]);
+        }),
+      );
+    }),
+  );
+
+  it.effect("a younger reservation stays when an older one expires", () =>
+    Effect.gen(function* () {
+      const h = harness({ maxJobs: 2 });
+      yield* h.run(
+        Effect.gen(function* () {
+          const sessions = yield* Sessions.Sessions;
+          yield* sessions.reserve(AGENT);
+          yield* TestClock.adjust("5 minutes");
+          yield* sessions.reserve(OTHER_AGENT);
+          yield* TestClock.adjust("5 minutes");
+          expect(yield* sessions.jobs).toBe(1);
+          expect(h.log.lines.map((entry) => entry.agentId)).toEqual([AGENT]);
+          // The younger one still starts.
+          const id = yield* sessions.start(startBody(ISO, OTHER_AGENT), "none", false);
+          expect(h.sessions.sessions.map((row) => row.id)).toEqual([id]);
+          expect(yield* sessions.jobs).toBe(1);
+        }),
+      );
+    }),
+  );
+});

--- a/test/support/fake-spawner.ts
+++ b/test/support/fake-spawner.ts
@@ -13,6 +13,9 @@ export type Scripted = {
   // kill() fails with this description; the process stays running unless alreadyDeadOnKill.
   readonly killError?: string;
   readonly alreadyDeadOnKill?: boolean;
+  // A process the command started outlives it holding the stderr pipe: the exit delivers its
+  // code and the last bytes, but stderr never ends, as Node's `exit` fires before `close`.
+  readonly stderrStaysOpen?: boolean;
 };
 
 export type Script = (command: string, args: ReadonlyArray<string>) => Scripted;
@@ -79,7 +82,9 @@ export const fakeSpawner = (script: Script = () => ({ exitCode: 0 })): FakeSpawn
       };
       const end = () => {
         Queue.endUnsafe(stdout);
-        Queue.endUnsafe(stderr);
+        if (scripted.stderrStaysOpen !== true) {
+          Queue.endUnsafe(stderr);
+        }
       };
       emit(stdout, scripted.stdout);
       emit(stderr, scripted.stderr);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

A diagnosing agent reported it was done, but its job never finished. Reviewing how the automation client decides a run is over found two defects in the start/stop path, and a third was then requested.

### 1. A run ended only when opencode's stderr pipe closed, not when opencode exited

`Cli.awaitExit` waited for the exit code **and** for the stderr stream to end. The stderr pipe is shared with every process opencode starts (an MCP server, a tool the agent ran) and ends only when the last of them closes it; Node's `exit` fires long before that `close`. A straggler therefore held `POST /run` until the 30-minute ceiling after opencode had exited, and the job was then closed as `failed: opencode run exceeded 30 minutes` although the agent had finished (and `/abort` during that window answered 200 while freeing nothing).

Fix: stderr is drained while the command runs into a bounded tail (NUL bytes dropped as they arrive), the exit is awaited on its own, and the drain is joined for a two-second grace after it. Verdict and stderr text are unchanged; only the wait is bounded.

Reproduced against the real `NodeChildProcessSpawner` with a command that exits at once but leaves a subshell holding stderr for 8 s:

```
## master (old Cli.awaitExit waits for stderr EOF)
[old] exit 0: Cli.run succeeded after 8007 ms (straggler holds stderr for 8000 ms)
[old] exit 1: Cli.run failed: CliFailed: agent said done (exit 1) after 8006 ms

## this branch (exit ends the run; 2 s grace for the drain)
[new] exit 0: Cli.run succeeded after 2011 ms (straggler holds stderr for 8000 ms)
[new] exit 1: Cli.run failed: CliFailed: agent said done (exit 1) after 2008 ms
```

### 2. A diagnose reserved a QEMU slot it could never use

Every job reserved a guest slot through the proxy. A drive consumes it with `./client start` and the qemu server gives it back when the session ends; a diagnose boots nothing, so its guest slot was never consumed nor relinquished and was gone for as long as that qemu server lived. Enough diagnoses and every drive is `deferred; at capacity`.

Fix (as requested): `POST /reserve` carries `action: "drive" | "diagnose"`. A drive reserves QEMU first, then a `--max-jobs` slot, as before; a diagnose takes a client slot only. `Domain.AutomationAction` is the `Schema.Literals` twin of the `automation_action` pgEnum, `Contract.ReserveBody` gains `action`, and the automation server passes `job.action`.

### 3. A reservation nobody used held its slot until a restart

A reservation is a promise that a run (client) or a start (qemu server) follows soon. A dispatcher dying between `/reserve` and `/run` left both slots taken forever. Both processes now sweep every ten seconds and give back any reservation unused for ten minutes: it leaves the reserved set and `jobs` drops by one, in memory only (no row records a reservation, so a restart starts clean). One warning line per expiry. The client gives an expired drive's guest slot back through the proxy (a failure is one error line, the slot freed regardless; no answer within ten seconds gives up so the sweep goes on).

Because both sides expire at ten minutes with unsynchronised sweeps, the guest host often lets go first: the client takes the proxy's 400 `no reservation` as nothing to give back, and the proxy forgets its `agent_servers` route on that answer as it already did on a 200, so a fresh reserve for the ticket places again. That route delete is the proxy's existing bookkeeping, not a record of the expiry. The proxy-facing `reserve`/`relinquish` moved from the client's `main.ts` into `qemu.ts` to be testable.

Live run of the real client (max-jobs 2, a drive and a diagnose reserved at 20:32:20, nothing run): both expired on the first sweep after 20:42:20, `/relinquish OLI-D` reached the QEMU stub and nothing for the diagnose, `process_stats.jobs` went 2 → 0, two new tickets then reserved fine, and `automation_jobs`/`agent_servers` stayed empty.

## Tests (written first)

- `test/cli.unit.test.ts`: exit 0 / exit non-zero with stderr held open succeed/fail after the grace; stderr ending with the exit does not wait out the grace; a NUL blob larger than the buffer cannot push the message out.
- `test/automation-client/sessions.unit.test.ts`: diagnose reserve takes a slot without asking QEMU; diagnose past `--max-jobs` neither asks nor relinquishes QEMU; second reserve under the other action is `already reserved`; a run with stderr held open finishes after the grace and frees its slot; expiry: drive (relinquishes) and diagnose (does not), a run in time never expires, a failed relinquish is one line and the slot still frees, per-reservation deadlines.
- `test/automation-client/qemu.unit.test.ts` (new): reserve 200/503/other/unreachable; relinquish 200/400-as-gone/500/unreachable/never-answers.
- `test/automation-client/http.unit.test.ts`: `/reserve` drive asks QEMU, diagnose does not; missing or unknown `action` is 400.
- `test/automation-server/client.unit.test.ts`, `worker.unit.test.ts`: the job's action reaches the reserve body.
- `test/qemu-server/sessions.unit.test.ts`: expiry frees the slot and refuses a late start; a start in time never expires; an expired reservation cannot be relinquished but its agent may reserve again; per-reservation deadlines.
- `test/qemu-reverse-proxy/http.unit.test.ts`: a server 400 on relinquish forgets the route and passes the 400 through; a 500 keeps the route.
- `test/integration/automation-client.integration.test.ts`: diagnose reserve never hits the qemu stub; a straggler on stderr does not hold `/run`.

`npm run check:fast` green (1142 unit tests, 1109 on master). All 20 automation-client and all automation-server integration tests pass against a real Postgres (Docker was unavailable, so a local PostgreSQL 16 stood in for the container).

## Reviewed but left as is (for the maintainer to decide)

- A drive whose driver never calls `./client start` (quit early, spawn failure, killed at the ceiling): the qemu server now frees its slot after ten minutes, but the proxy's `agent_servers` route lingers, so a later reserve for that ticket is `already reserved`. Relinquishing at the end of every drive run would close it: the proxy now answers 400 when nothing is held and forgets the route.
- Kill does not reach grandchildren: with `detached: false` the spawner's group kill fails (the child is not a group leader) and only opencode's pid gets SIGTERM; its MCP servers and in-flight tools survive an abort or ceiling kill. `detached: true` would kill the tree but a terminal Ctrl-C would then no longer reach opencode directly.
- A SIGTERM to the client while a run is in flight waits for opencode to finish (the `/run` handler is uninterruptible); measured 19 s for a 20 s run, up to the ceiling in production.
- A client's `/reserve` maps every non-503 proxy failure to `Internal`, so the automation server records the job as `failed: ... internal error` and the actual reason is only in the client's log.
- Pre-existing, unrelated: two `test/integration/qemu-reverse-proxy.integration.test.ts` cases expect `/start` without a reservation to be 503 `no server registered`; the router has answered 400 `no reservation` since reserve-first landed, and this DB-gated lane is not in CI.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09715-2a16-777f-bab6-9e1883104d8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09715-2a16-777f-bab6-9e1883104d8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

