### PR TITLE
Count child-process VmRSS in process memory reports

### DIFF
--- a/src/automation-client/heartbeat.ts
+++ b/src/automation-client/heartbeat.ts
@@ -24,13 +24,13 @@ const detail = (error: unknown): string =>
 // Announces this process under `url`: its `servers` row is written now and every thirty seconds
 // as an automation-client, with the host's stats and qemus 0 — this process boots no guests —
 // and the row's generation counts the writes, so a number that stops moving is a client that
-// stopped without a chance to leave. The same tick inserts a `process_stats` row: current
-// jobs, current VmRSS, and the cpu busy over the last thirty seconds. A write that fails
-// is one error line; the other write and the next tick still run. A shutdown deletes the
-// servers row only: the readings stay so they can be graphed later. Registered before the
-// loop so the fiber is interrupted first; a write in flight finishes (the write is
-// uninterruptible). A delete that fails is one `unannounce failed` line; the process still
-// exits.
+// stopped without a chance to leave. The same tick inserts a `process_stats` row: current jobs,
+// VmRSS of this process and every child that still answers, and the cpu busy over the last
+// thirty seconds. A write that fails is one error line; the other write and the next tick still
+// run. A shutdown deletes the servers row only: the readings stay so they can be graphed later.
+// Registered before the loop so the fiber is interrupted first; a write in flight finishes
+// (the write is uninterruptible). A delete that fails is one `unannounce failed` line; the
+// process still exits.
 export const announce = (
   url: string,
   name: string,

--- a/src/dashboard/query.ts
+++ b/src/dashboard/query.ts
@@ -59,9 +59,9 @@ export type AutomationQueue = {
   readonly completed: ReadonlyArray<AutomationJob>;
 };
 
-// One process's word on itself: current jobs, current VmRSS, cpu over the last thirty seconds,
-// and the database's clock at the read so the page measures the report's age against the clock
-// that stamped it.
+// One process's word on itself: current jobs, VmRSS of this process and every child that
+// still answers, cpu over the last thirty seconds, and the database's clock at the read so
+// the page measures the report's age against the clock that stamped it.
 export type ProcessStat = {
   readonly name: string;
   readonly type: (typeof processStats.$inferSelect)["type"];

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -226,9 +226,10 @@ export const servers = pgTable(
 );
 
 // What a qemu server or automation-client said of this process at one heartbeat: current
-// jobs, current VmRSS, and the cpu busy over the last thirty seconds. One insert per tick,
-// so a later graph can read the series. name is the machine (--name), not a relation: the
-// row outlives the servers row, and a shutdown or an operator's delete must not erase it.
+// jobs, VmRSS of this process and every child that still answers, and the cpu busy over
+// the last thirty seconds. One insert per tick, so a later graph can read the series.
+// name is the machine (--name), not a relation: the row outlives the servers row, and a
+// shutdown or an operator's delete must not erase it.
 export type ProcessStats = {
   readonly jobs: number;
   readonly memoryBytes: number;

--- a/src/qemu-server/heartbeat.ts
+++ b/src/qemu-server/heartbeat.ts
@@ -23,12 +23,12 @@ const detail = (error: unknown): string =>
 // Announces this server under `url`: its `servers` row is written now and every thirty seconds
 // with what it knows of itself — a qemu server, this process boots nothing else — and the row's
 // generation counts the writes, so a number that stops moving is a server that stopped without a
-// chance to leave. The same tick inserts a `process_stats` row: current jobs, current
-// VmRSS, and the cpu busy over the last thirty seconds. A write that fails is one error
-// line; the other write and the next tick still run. A shutdown deletes the servers row
-// only: the readings stay so they can be graphed later. Registered before the loop so the
-// fiber is interrupted first; a write in flight finishes (the write is uninterruptible).
-// A delete that fails is one `unannounce failed` line; the process still exits.
+// chance to leave. The same tick inserts a `process_stats` row: current jobs, VmRSS of this
+// process and every child that still answers, and the cpu busy over the last thirty seconds. A
+// write that fails is one error line; the other write and the next tick still run. A shutdown
+// deletes the servers row only: the readings stay so they can be graphed later. Registered
+// before the loop so the fiber is interrupted first; a write in flight finishes (the write is
+// uninterruptible). A delete that fails is one `unannounce failed` line; the process still exits.
 export const announce = (
   url: string,
   name: string,

--- a/src/shared/process-usage.ts
+++ b/src/shared/process-usage.ts
@@ -66,29 +66,10 @@ type Sample = {
 
 const missing = (path: string): Error => new Error(`unreadable process usage: ${path}`);
 
-const readChild = (
-  fs: FileSystem.FileSystem,
-  pid: string,
-): Effect.Effect<Option.Option<Reading>> =>
-  Effect.gen(function* () {
-    const stat = yield* Effect.option(fs.readFileString(`/proc/${pid}/stat`));
-    const status = yield* Effect.option(fs.readFileString(`/proc/${pid}/status`));
-    if (Option.isNone(stat) || Option.isNone(status)) {
-      return Option.none();
-    }
-    const cpuTicks = parseCpuTicks(stat.value);
-    const memoryBytes = parseVmRssBytes(status.value);
-    return Option.isNone(cpuTicks) || Option.isNone(memoryBytes)
-      ? Option.none()
-      : Option.some({ cpuTicks: cpuTicks.value, memoryBytes: memoryBytes.value });
-  });
-
 // QEMU and OpenCode hold the RAM this Node process does not. Walk every task's children
-// file; a pid that is gone or whose /proc cannot be read is skipped, not a defect of us.
-const descendantsMemory = (
-  fs: FileSystem.FileSystem,
-  root: string,
-): Effect.Effect<number> =>
+// file; a pid with no VmRSS is skipped for the sum, but we still walk its children so a
+// grandchild that answers is counted. A missing /proc is not a defect of us.
+const descendantsMemory = (fs: FileSystem.FileSystem, root: string): Effect.Effect<number> =>
   Effect.gen(function* () {
     const seen = new Set<string>([root]);
     let total = 0;
@@ -107,11 +88,13 @@ const descendantsMemory = (
               continue;
             }
             seen.add(child);
-            const reading = yield* readChild(fs, child);
-            if (Option.isNone(reading)) {
-              continue;
+            const status = yield* Effect.option(fs.readFileString(`/proc/${child}/status`));
+            if (Option.isSome(status)) {
+              const bytes = Option.getOrUndefined(parseVmRssBytes(status.value));
+              if (bytes !== undefined) {
+                total += bytes;
+              }
             }
-            total += reading.value.memoryBytes;
             yield* visit(child);
           }
         }

--- a/src/shared/process-usage.ts
+++ b/src/shared/process-usage.ts
@@ -2,8 +2,6 @@ import { Clock, Context, Effect, FileSystem, Layer, Option, Ref } from "effect";
 
 // USER_HZ on Linux, and this process only runs there. /proc/self/stat counts in these ticks.
 const CLK_TCK = 100;
-const STAT_PATH = "/proc/self/stat";
-const STATUS_PATH = "/proc/self/status";
 
 export type Reading = {
   readonly cpuTicks: number;
@@ -49,6 +47,16 @@ const parseVmRssBytes = (status: string): Option.Option<number> => {
   return Number.isFinite(kb) ? Option.some(kb * 1024) : Option.none();
 };
 
+const parseChildren = (text: string): ReadonlyArray<string> => {
+  const pids: Array<string> = [];
+  for (const token of text.trim().split(/\s+/)) {
+    if (/^\d+$/.test(token)) {
+      pids.push(token);
+    }
+  }
+  return pids;
+};
+
 const round1 = (value: number): number => Math.round(value * 10) / 10;
 
 type Sample = {
@@ -58,21 +66,80 @@ type Sample = {
 
 const missing = (path: string): Error => new Error(`unreadable process usage: ${path}`);
 
+const readChild = (
+  fs: FileSystem.FileSystem,
+  pid: string,
+): Effect.Effect<Option.Option<Reading>> =>
+  Effect.gen(function* () {
+    const stat = yield* Effect.option(fs.readFileString(`/proc/${pid}/stat`));
+    const status = yield* Effect.option(fs.readFileString(`/proc/${pid}/status`));
+    if (Option.isNone(stat) || Option.isNone(status)) {
+      return Option.none();
+    }
+    const cpuTicks = parseCpuTicks(stat.value);
+    const memoryBytes = parseVmRssBytes(status.value);
+    return Option.isNone(cpuTicks) || Option.isNone(memoryBytes)
+      ? Option.none()
+      : Option.some({ cpuTicks: cpuTicks.value, memoryBytes: memoryBytes.value });
+  });
+
+// QEMU and OpenCode hold the RAM this Node process does not. Walk every task's children
+// file; a pid that is gone or whose /proc cannot be read is skipped, not a defect of us.
+const descendantsMemory = (
+  fs: FileSystem.FileSystem,
+  root: string,
+): Effect.Effect<number> =>
+  Effect.gen(function* () {
+    const seen = new Set<string>([root]);
+    let total = 0;
+    const visit = (pid: string): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const tasks = yield* Effect.option(fs.readDirectory(`/proc/${pid}/task`));
+        if (Option.isNone(tasks)) {
+          return;
+        }
+        for (const tid of tasks.value) {
+          const text = yield* fs
+            .readFileString(`/proc/${pid}/task/${tid}/children`)
+            .pipe(Effect.orElseSucceed(() => ""));
+          for (const child of parseChildren(text)) {
+            if (seen.has(child)) {
+              continue;
+            }
+            seen.add(child);
+            const reading = yield* readChild(fs, child);
+            if (Option.isNone(reading)) {
+              continue;
+            }
+            total += reading.value.memoryBytes;
+            yield* visit(child);
+          }
+        }
+      });
+    yield* visit(root);
+    return total;
+  });
+
 const procSource =
   (fs: FileSystem.FileSystem): Source =>
   () =>
     Effect.gen(function* () {
-      const stat = yield* fs.readFileString(STAT_PATH).pipe(Effect.orDie);
-      const status = yield* fs.readFileString(STATUS_PATH).pipe(Effect.orDie);
+      const statPath = "/proc/self/stat";
+      const statusPath = "/proc/self/status";
+      const stat = yield* fs.readFileString(statPath).pipe(Effect.orDie);
+      const status = yield* fs.readFileString(statusPath).pipe(Effect.orDie);
       const cpuTicks = Option.getOrUndefined(parseCpuTicks(stat));
       const memoryBytes = Option.getOrUndefined(parseVmRssBytes(status));
       if (cpuTicks === undefined) {
-        return yield* Effect.die(missing(STAT_PATH));
+        return yield* Effect.die(missing(statPath));
       }
       if (memoryBytes === undefined) {
-        return yield* Effect.die(missing(STATUS_PATH));
+        return yield* Effect.die(missing(statusPath));
       }
-      return { cpuTicks, memoryBytes };
+      // cpu stays this pid: children appear and vanish with each job, and lost ticks would
+      // report 0. Memory is the tree, so a qemu or opencode the dashboard cannot see is counted.
+      const childrenBytes = yield* descendantsMemory(fs, "self");
+      return { cpuTicks, memoryBytes: memoryBytes + childrenBytes };
     });
 
 const make = (source: Source): Effect.Effect<ProcessUsageService> =>

--- a/test/shared/process-usage.unit.test.ts
+++ b/test/shared/process-usage.unit.test.ts
@@ -142,13 +142,40 @@ const collectThrough = (statText: string | undefined, statusText: string | undef
     ),
   );
 
+const treeFs = (spec: {
+  readonly files: Readonly<Record<string, string>>;
+  readonly directories?: ReadonlyArray<string>;
+}) => {
+  const entries: Record<string, "File" | "Directory"> = {};
+  const contents: Record<string, Uint8Array> = {};
+  for (const dir of spec.directories ?? []) {
+    entries[dir] = "Directory";
+  }
+  for (const [path, text] of Object.entries(spec.files)) {
+    entries[path] = "File";
+    contents[path] = new TextEncoder().encode(text);
+  }
+  return FakeFs.recordingFs(entries, { contents });
+};
+
+const collectTree = (spec: {
+  readonly files: Readonly<Record<string, string>>;
+  readonly directories?: ReadonlyArray<string>;
+}) =>
+  Effect.gen(function* () {
+    const usage = yield* ProcessUsage.ProcessUsage;
+    return yield* usage.collect;
+  }).pipe(
+    Effect.provide(ProcessUsage.ProcessUsage.layer.pipe(Layer.provide(treeFs(spec).layer))),
+  );
+
 describe("ProcessUsage.layer happy path", () => {
   it.effect("reads /proc/self/stat and /proc/self/status without sudo", () => {
     const fs = procFs(stat("node", 0, 0), status(4));
     return Effect.gen(function* () {
       const usage = yield* ProcessUsage.ProcessUsage;
       expect(yield* usage.collect).toEqual({ memoryBytes: 4 * 1024, cpuPercent: 0 });
-      expect(FakeFs.methods(fs)).toEqual(["readFileString", "readFileString"]);
+      expect(FakeFs.methods(fs)).toEqual(["readFileString", "readFileString", "readDirectory"]);
     }).pipe(Effect.provide(ProcessUsage.ProcessUsage.layer.pipe(Layer.provide(fs.layer))));
   });
 
@@ -167,6 +194,59 @@ describe("ProcessUsage.layer happy path", () => {
         memoryBytes: 12_345 * 1024,
         cpuPercent: 0,
       });
+    }),
+  );
+
+  it.effect("sums VmRSS of every child that still answers, not only this pid", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* collectTree({
+          directories: ["/proc/self/task", "/proc/self/task/1", "/proc/10/task", "/proc/10/task/10"],
+          files: {
+            "/proc/self/stat": stat("node", 10, 5),
+            "/proc/self/status": status(4),
+            "/proc/self/task/1/children": "10\n",
+            "/proc/10/stat": stat("qemu-system x86_64", 900, 100),
+            "/proc/10/status": status(8),
+            "/proc/10/task/10/children": "",
+          },
+        }),
+      ).toEqual({ memoryBytes: 12 * 1024, cpuPercent: 0 });
+    }),
+  );
+
+  it.effect("adds children listed by every thread and walks grandchildren", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* collectTree({
+          directories: [
+            "/proc/self/task",
+            "/proc/self/task/1",
+            "/proc/self/task/2",
+            "/proc/10/task",
+            "/proc/10/task/10",
+            "/proc/11/task",
+            "/proc/11/task/11",
+            "/proc/20/task",
+            "/proc/20/task/20",
+          ],
+          files: {
+            "/proc/self/stat": stat("node", 0, 0),
+            "/proc/self/status": status(1),
+            "/proc/self/task/1/children": "10",
+            "/proc/self/task/2/children": "11",
+            "/proc/10/stat": stat("qemu", 0, 0),
+            "/proc/10/status": status(2),
+            "/proc/10/task/10/children": "20",
+            "/proc/11/stat": stat("opencode", 0, 0),
+            "/proc/11/status": status(3),
+            "/proc/11/task/11/children": "",
+            "/proc/20/stat": stat("vhost", 0, 0),
+            "/proc/20/status": status(4),
+            "/proc/20/task/20/children": "",
+          },
+        }),
+      ).toEqual({ memoryBytes: 10 * 1024, cpuPercent: 0 });
     }),
   );
 });
@@ -199,6 +279,68 @@ describe("ProcessUsage.layer unhappy path", () => {
         const exit = yield* Effect.exit(collectThrough(stat("node", 0, 0), text));
         expect(Exit.isFailure(exit) && Cause.hasDies(exit.cause), text).toBe(true);
       }
+    }),
+  );
+
+  it.effect("skips a child whose /proc files are gone", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* collectTree({
+          directories: ["/proc/self/task", "/proc/self/task/1"],
+          files: {
+            "/proc/self/stat": stat("node", 0, 0),
+            "/proc/self/status": status(4),
+            "/proc/self/task/1/children": "10 11\n",
+          },
+        }),
+      ).toEqual({ memoryBytes: 4 * 1024, cpuPercent: 0 });
+    }),
+  );
+
+  it.effect("skips a child whose stat or status cannot be read as a reading", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* collectTree({
+          directories: [
+            "/proc/self/task",
+            "/proc/self/task/1",
+            "/proc/10/task",
+            "/proc/10/task/10",
+            "/proc/11/task",
+            "/proc/11/task/11",
+            "/proc/12/task",
+            "/proc/12/task/12",
+          ],
+          files: {
+            "/proc/self/stat": stat("node", 0, 0),
+            "/proc/self/status": status(4),
+            "/proc/self/task/1/children": "10 11 12",
+            "/proc/10/stat": "1 (qemu R 0 0",
+            "/proc/10/status": status(8),
+            "/proc/10/task/10/children": "",
+            "/proc/11/stat": stat("qemu", 0, 0),
+            "/proc/11/status": "Name:\tqemu\n",
+            "/proc/11/task/11/children": "",
+            "/proc/12/stat": stat("qemu", 0, 0),
+            "/proc/12/status": status(16),
+            "/proc/12/task/12/children": "",
+          },
+        }),
+      ).toEqual({ memoryBytes: 20 * 1024, cpuPercent: 0 });
+    }),
+  );
+
+  it.effect("a missing children file on a thread still reports this pid", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* collectTree({
+          directories: ["/proc/self/task", "/proc/self/task/1"],
+          files: {
+            "/proc/self/stat": stat("node", 0, 0),
+            "/proc/self/status": status(4),
+          },
+        }),
+      ).toEqual({ memoryBytes: 4 * 1024, cpuPercent: 0 });
     }),
   );
 });

--- a/test/shared/process-usage.unit.test.ts
+++ b/test/shared/process-usage.unit.test.ts
@@ -165,9 +165,7 @@ const collectTree = (spec: {
   Effect.gen(function* () {
     const usage = yield* ProcessUsage.ProcessUsage;
     return yield* usage.collect;
-  }).pipe(
-    Effect.provide(ProcessUsage.ProcessUsage.layer.pipe(Layer.provide(treeFs(spec).layer))),
-  );
+  }).pipe(Effect.provide(ProcessUsage.ProcessUsage.layer.pipe(Layer.provide(treeFs(spec).layer))));
 
 describe("ProcessUsage.layer happy path", () => {
   it.effect("reads /proc/self/stat and /proc/self/status without sudo", () => {
@@ -201,7 +199,12 @@ describe("ProcessUsage.layer happy path", () => {
     Effect.gen(function* () {
       expect(
         yield* collectTree({
-          directories: ["/proc/self/task", "/proc/self/task/1", "/proc/10/task", "/proc/10/task/10"],
+          directories: [
+            "/proc/self/task",
+            "/proc/self/task/1",
+            "/proc/10/task",
+            "/proc/10/task/10",
+          ],
           files: {
             "/proc/self/stat": stat("node", 10, 5),
             "/proc/self/status": status(4),
@@ -297,7 +300,7 @@ describe("ProcessUsage.layer unhappy path", () => {
     }),
   );
 
-  it.effect("skips a child whose stat or status cannot be read as a reading", () =>
+  it.effect("skips a child whose status cannot be read as VmRSS", () =>
     Effect.gen(function* () {
       expect(
         yield* collectTree({
@@ -308,25 +311,44 @@ describe("ProcessUsage.layer unhappy path", () => {
             "/proc/10/task/10",
             "/proc/11/task",
             "/proc/11/task/11",
-            "/proc/12/task",
-            "/proc/12/task/12",
           ],
           files: {
             "/proc/self/stat": stat("node", 0, 0),
             "/proc/self/status": status(4),
-            "/proc/self/task/1/children": "10 11 12",
-            "/proc/10/stat": "1 (qemu R 0 0",
-            "/proc/10/status": status(8),
+            "/proc/self/task/1/children": "10 11",
+            "/proc/10/status": "Name:\tqemu\n",
             "/proc/10/task/10/children": "",
-            "/proc/11/stat": stat("qemu", 0, 0),
-            "/proc/11/status": "Name:\tqemu\n",
+            "/proc/11/status": status(16),
             "/proc/11/task/11/children": "",
-            "/proc/12/stat": stat("qemu", 0, 0),
-            "/proc/12/status": status(16),
-            "/proc/12/task/12/children": "",
           },
         }),
       ).toEqual({ memoryBytes: 20 * 1024, cpuPercent: 0 });
+    }),
+  );
+
+  it.effect("still counts a grandchild when the child in between has no VmRSS", () =>
+    Effect.gen(function* () {
+      expect(
+        yield* collectTree({
+          directories: [
+            "/proc/self/task",
+            "/proc/self/task/1",
+            "/proc/10/task",
+            "/proc/10/task/10",
+            "/proc/20/task",
+            "/proc/20/task/20",
+          ],
+          files: {
+            "/proc/self/stat": stat("node", 0, 0),
+            "/proc/self/status": status(1),
+            "/proc/self/task/1/children": "10",
+            "/proc/10/status": "Name:\tqemu\n",
+            "/proc/10/task/10/children": "20",
+            "/proc/20/status": status(4),
+            "/proc/20/task/20/children": "",
+          },
+        }),
+      ).toEqual({ memoryBytes: 5 * 1024, cpuPercent: 0 });
     }),
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Process memory graphs for qemu-server and automation-client only counted `/proc/self`, so they missed the RAM held by QEMU guests and OpenCode children.

`ProcessUsage` now walks each task's `children` file and adds VmRSS from every descendant that still answers. A pid with no readable RSS is omitted from the sum but still walked, so a grandchild that answers is not dropped with it. CPU stays on this pid so children appearing and vanishing with each job do not zero the window.

Dashboard process cards keep the same shape; the memory number is now the process tree.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a097a3-04aa-71a5-9a42-805c02eb7be0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a097a3-04aa-71a5-9a42-805c02eb7be0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

